### PR TITLE
display plots for single functional unit, fix for #34

### DIFF
--- a/lca_activity_browser/app/bw2extensions/commontasks.py
+++ b/lca_activity_browser/app/bw2extensions/commontasks.py
@@ -28,5 +28,8 @@ def format_activity_label(act, style='pnl'):
                                a['location'],
                                ])
     except:
-        return str(act)
+        if isinstance(act, tuple):
+            return str(''.join(act))
+        else:
+            return str(act)
     return label

--- a/lca_activity_browser/app/bw2extensions/multilca.py
+++ b/lca_activity_browser/app/bw2extensions/multilca.py
@@ -78,7 +78,7 @@ class MLCA(object):
             top_contribution = ca.sort_array(contribution_array[col, :], limit=limit)
             cont_per_fu = {}
             cont_per_fu.update(
-                {'Rest': contribution_array[col, :].sum() - top_contribution[:, 0].sum()})
+                {('Rest', ''): contribution_array[col, :].sum() - top_contribution[:, 0].sum()})
             for value, index in top_contribution:
                 cont_per_fu.update({self.rev_activity_dict[index]: value})
             topcontribution_dict.update({next(iter(fu.keys())): cont_per_fu})
@@ -94,7 +94,7 @@ class MLCA(object):
             top_contribution = ca.sort_array(contribution_array[col, :], limit=limit)
             cont_per_fu = {}
             cont_per_fu.update(
-                {'Rest': contribution_array[col, :].sum() - top_contribution[:, 0].sum()})
+                {('Rest', ''): contribution_array[col, :].sum() - top_contribution[:, 0].sum()})
             for value, index in top_contribution:
                 cont_per_fu.update({self.rev_biosphere_dict[index]: value})
             topcontribution_dict.update({next(iter(fu.keys())): cont_per_fu})

--- a/lca_activity_browser/app/ui/tabs/lca_results.py
+++ b/lca_activity_browser/app/ui/tabs/lca_results.py
@@ -71,13 +71,15 @@ class LCAResultsTab(QtWidgets.QWidget):
 
         # Multi-LCA calculation
         self.mlca = MLCA(name)
+        single_lca = len(self.mlca.func_units) == 1
         normalized_results = self.mlca.results / self.mlca.results.max(axis=0)
         # plots
         lca_results_plot = LCAResultsPlot(self, self.mlca)
         process_contribution_plot = LCAProcessContributionPlot(self, self.mlca)
         elementary_flow_contribution_plot = LCAElementaryFlowContributionPlot(self, self.mlca)
         labels = [str(x + 1) for x in range(len(self.mlca.func_units))]
-        corr_chart = CorrelationPlot(self, normalized_results.T, labels)
+        if not single_lca:
+            corr_chart = CorrelationPlot(self, normalized_results.T, labels)
         # LCA results table
         results_table = LCAResultsTable()
         results_table.sync(self.mlca)
@@ -95,9 +97,10 @@ class LCAResultsTab(QtWidgets.QWidget):
         self.scroll_widget_layout.addWidget(horizontal_line())
         self.scroll_widget_layout.addWidget(elementary_flow_contribution_plot)
 
-        self.scroll_widget_layout.addWidget(header("LCA Scores Correlation:"))
-        self.scroll_widget_layout.addWidget(horizontal_line())
-        self.scroll_widget_layout.addWidget(corr_chart)
+        if not single_lca:
+            self.scroll_widget_layout.addWidget(header("LCA Scores Correlation:"))
+            self.scroll_widget_layout.addWidget(horizontal_line())
+            self.scroll_widget_layout.addWidget(corr_chart)
 
         self.scroll_widget_layout.addWidget(header("LCA Scores:"))
         self.scroll_widget_layout.addWidget(horizontal_line())


### PR DESCRIPTION
This fixes the plots for single functional units:
- Contributions plot was a mess-up with pandas indices, if 'Rest' is changed to a tuple ('Rest', '') it works as expected
- A correlation plot only makes sense for several FUs, right? I disabled it for MultiLCAs with a single FU