### PR TITLE
Fixing qt and ab popups

### DIFF
--- a/lca_activity_browser/app/controller.py
+++ b/lca_activity_browser/app/controller.py
@@ -30,11 +30,13 @@ class Controller(object):
         self.connect_signals()
         self.db_wizard = None
         # switch directly to custom bw2 directory and project, if specified in settings
+        print('Brightway2 data directory: {}'.format(bw.projects._base_data_dir))
+        print('Brightway2 active project: {}'.format(bw.projects.current))
+
         if settings:
             if hasattr(settings, "BW2_DIR"):
-                print('Brightway2 data directory: {}'.format(bw.projects._base_data_dir))
                 self.switch_brightway2_dir_path(dirpath=settings.BW2_DIR)
-                print('Switched to {} as Brightway2 data directory.'.format(
+                print('Switched to Brightway2 data directory: {}'.format(
                     bw.projects._base_data_dir))
             if hasattr(settings, "PROJECT_NAME"):
                 if settings.PROJECT_NAME in [x.name for x in bw.projects]:

--- a/lca_activity_browser/app/ui/menu_bar.py
+++ b/lca_activity_browser/app/ui/menu_bar.py
@@ -50,24 +50,22 @@ class MenuBar(object):
         return help_menu
 
     def about(self):
-        text = """
-Activity Browser - a graphical interface for Brightway2.
-
-Main developers:
-- Bernhard Steubing (CML Leiden University, b.steubing@cml.leidenuniv.nl)
-- Chris Mutel (Paul Scherer Institut, cmutel@gmail.com)
-- Adrian Haas (ETH Zurich, haasad@ethz.ch)
-
-Copyright (c) 2015, Bernhard Steubing and ETH Zurich
-Copyright (c) 2016, Chris Mutel and Paul Scherrer Institut
-Copyright (c) 2017, Adrian Haas (ETH Zurich) and Bernhard Steubing (Leiden University) 
-
-LICENSE:
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>."""
+        text = '''
+Activity Browser - a graphical interface for Brightway2.<br><br>
+All development happens on <a href="https://github.com/LCA-ActivityBrowser/activity-browser">github</a>.<br><br>
+Main developers:<br>
+- Bernhard Steubing (CML Leiden University, b.steubing@cml.leidenuniv.nl)<br>
+- Chris Mutel (Paul Scherer Institut, cmutel@gmail.com)<br>
+- Adrian Haas (ETH Zurich, haasad@ethz.ch)<br><br>
+Copyright (c) 2015, Bernhard Steubing and ETH Zurich<br>
+Copyright (c) 2016, Chris Mutel and Paul Scherrer Institut<br>
+Copyright (c) 2017, Adrian Haas (ETH Zurich) and Bernhard Steubing (Leiden University)<br>
+<br>
+LICENSE:<br>
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.<br><br>
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.<br><br>
+You should have received a copy of the GNU General Public License along with this program.  If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</a>.
+'''
         msgBox = QtWidgets.QMessageBox()
         msgBox.setWindowTitle('About the Activity Browser')
         pixmap = self.window.icon.pixmap(QtCore.QSize(150, 150))

--- a/lca_activity_browser/app/ui/menu_bar.py
+++ b/lca_activity_browser/app/ui/menu_bar.py
@@ -45,7 +45,7 @@ class MenuBar(object):
 
         help_menu.addAction(
             '&About Qt',
-            lambda x: QtWidgets.QMessageBox.aboutQt(self.window)
+            lambda: QtWidgets.QMessageBox.aboutQt(self.window)
         )
         return help_menu
 
@@ -53,9 +53,14 @@ class MenuBar(object):
         text = """
 Activity Browser - a graphical interface for Brightway2.
 
+Main developers:
+- Bernhard Steubing (CML Leiden University, b.steubing@cml.leidenuniv.nl)
+- Chris Mutel (Paul Scherer Institut, cmutel@gmail.com)
+- Adrian Haas (ETH Zurich, haasad@ethz.ch)
+
 Copyright (c) 2015, Bernhard Steubing and ETH Zurich
 Copyright (c) 2016, Chris Mutel and Paul Scherrer Institut
-Contact: cmutel@gmail.com
+Copyright (c) 2017, Adrian Haas (ETH Zurich) and Bernhard Steubing (Leiden University) 
 
 LICENSE:
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -64,11 +69,9 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>."""
         msgBox = QtWidgets.QMessageBox()
-        # msgBox.setMinimumSize(QtCore.QSize(400, 400))
         msgBox.setWindowTitle('About the Activity Browser')
         pixmap = self.window.icon.pixmap(QtCore.QSize(150, 150))
         msgBox.setIconPixmap(pixmap)
         msgBox.setWindowIcon(self.window.icon)
         msgBox.setText(text)
-        msgBox.setFixedSize(QtCore.QSize(400, 400))
         msgBox.exec_()


### PR DESCRIPTION
Fixed the popup windows that you get in the Help menu. Please check the content of the AB popup. Copyright is a bit complicated now... one day we might simplify this a bit.