### PR TITLE
Pep8imports

### DIFF
--- a/lca_activity_browser/app/__init__.py
+++ b/lca_activity_browser/app/__init__.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-from PyQt5 import QtWidgets
-from .application import Application
 import sys
 import traceback
+
+from PyQt5 import QtWidgets
+
+from .application import Application
 
 
 def run_activity_browser():

--- a/lca_activity_browser/app/bw2extensions/multilca.py
+++ b/lca_activity_browser/app/bw2extensions/multilca.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 import brightway2 as bw
-
 from bw2analyzer import ContributionAnalysis
-ca = ContributionAnalysis()
-
 try:
     from bw2data import calculation_setups
 except ImportError:
     calculation_setups = None
+
+
+ca = ContributionAnalysis()
 
 
 class MLCA(object):

--- a/lca_activity_browser/app/bw2extensions/multilca.py
+++ b/lca_activity_browser/app/bw2extensions/multilca.py
@@ -2,11 +2,6 @@
 import numpy as np
 import brightway2 as bw
 from bw2analyzer import ContributionAnalysis
-try:
-    from bw2data import calculation_setups
-except ImportError:
-    calculation_setups = None
-
 
 ca = ContributionAnalysis()
 
@@ -24,11 +19,8 @@ class MLCA(object):
 
     """
     def __init__(self, cs_name):
-        if not calculation_setups:
-            raise ImportError
-        assert cs_name in calculation_setups
         try:
-            cs = calculation_setups[cs_name]
+            cs = bw.calculation_setups[cs_name]
         except KeyError:
             raise ValueError(
                 "{} is not a known `calculation_setup`.".format(cs_name)

--- a/lca_activity_browser/app/controller.py
+++ b/lca_activity_browser/app/controller.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
+import os
+import copy
+import uuid
+
+import brightway2 as bw
+from bw2data.backends.peewee import Exchange
+from bw2data.project import ProjectDataset, create_database
+from PyQt5 import QtWidgets
+
 from .signals import signals
 from .ui.db_import_wizard import DatabaseImportWizard, DefaultBiosphereDialog
 try:
     from . import settings
 except ImportError:
     settings = None
-import brightway2 as bw
-from bw2data.backends.peewee import Exchange
-from PyQt5 import QtWidgets
-import copy
-import uuid
-from bw2data.project import ProjectDataset, create_database
-import os
 
 
 class Controller(object):

--- a/lca_activity_browser/app/ui/db_import_wizard.py
+++ b/lca_activity_browser/app/ui/db_import_wizard.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import tempfile
+
 import bs4
 import requests
 import patoolib
@@ -18,6 +19,7 @@ from bw2data.backends.peewee.utils import (
 )
 from bw2data.errors import InvalidExchange, UntypedExchange
 from PyQt5 import QtWidgets, QtCore
+
 from ..signals import signals
 
 

--- a/lca_activity_browser/app/ui/graphics.py
+++ b/lca_activity_browser/app/ui/graphics.py
@@ -5,8 +5,8 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
-from matplotlib import cm
 from PyQt5 import QtWidgets
+
 from ..bw2extensions.commontasks import format_activity_label
 
 
@@ -136,7 +136,7 @@ class LCAProcessContributionPlot(FigureCanvasQTAgg):
         plot = df_tc.T.plot.barh(
             stacked=True,
             figsize=(6, 6),
-            cmap=cm.nipy_spectral_r,
+            cmap=plt.cm.nipy_spectral_r,
             ax=axes
         )
         plot.tick_params(labelsize=8)
@@ -161,7 +161,7 @@ class LCAElementaryFlowContributionPlot(FigureCanvasQTAgg):
         plot = df_tc.T.plot.barh(
             stacked=True,
             figsize=(6, 6),
-            cmap=cm.nipy_spectral_r,
+            cmap=plt.cm.nipy_spectral_r,
             ax=axes
         )
         plot.tick_params(labelsize=8)

--- a/lca_activity_browser/app/ui/main.py
+++ b/lca_activity_browser/app/ui/main.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import sys
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
 from . import header
 from .icons import icons
 from .menu_bar import MenuBar
@@ -7,8 +11,6 @@ from .statusbar import Statusbar
 from .toolbar import Toolbar
 from .utils import StdRedirector
 from ..signals import signals
-from PyQt5 import QtCore, QtGui, QtWidgets
-import sys
 
 
 class MainWindow(QtWidgets.QMainWindow):

--- a/lca_activity_browser/app/ui/menu_bar.py
+++ b/lca_activity_browser/app/ui/menu_bar.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtCore, QtWidgets
+
 from ..signals import signals
+
 
 class MenuBar(object):
     def __init__(self, window):

--- a/lca_activity_browser/app/ui/network/sankey.py
+++ b/lca_activity_browser/app/ui/network/sankey.py
@@ -2,10 +2,12 @@
 import os
 import json
 import collections
-from PyQt5 import QtWidgets, QtCore, QtWebEngineWidgets, QtWebChannel
+
 import numpy as np
 import brightway2 as bw
 import matplotlib.pyplot as plt
+from PyQt5 import QtWidgets, QtCore, QtWebEngineWidgets, QtWebChannel
+
 from .signals import sankeysignals
 from .worker_threads import gt_worker_thread
 

--- a/lca_activity_browser/app/ui/network/worker_threads.py
+++ b/lca_activity_browser/app/ui/network/worker_threads.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 import brightway2 as bw
 from PyQt5 import QtCore
+
 from .signals import sankeysignals
 
 

--- a/lca_activity_browser/app/ui/panels/__init__.py
+++ b/lca_activity_browser/app/ui/panels/__init__.py
@@ -1,2 +1,3 @@
+# -*- coding: utf-8 -*-
 from .left import LeftPanel
 from .right import RightPanel

--- a/lca_activity_browser/app/ui/panels/left.py
+++ b/lca_activity_browser/app/ui/panels/left.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-from ..graphics import DefaultGraph
-from ..tabs import (
-    CalculationSetupTab,
-    CFsTab,
-)
-from ...signals import signals
 from .panel import Panel, ActivitiesPanel
 from .. import activity_cache
+from ..graphics import DefaultGraph
+from ..tabs import CalculationSetupTab, CFsTab
+from ...signals import signals
 
 
 class LeftPanel(Panel):

--- a/lca_activity_browser/app/ui/panels/panel.py
+++ b/lca_activity_browser/app/ui/panels/panel.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from .. import activity_cache
-from ...signals import signals
-from ..tabs import ActivityDetailsTab
-from ..utils import get_name
 import brightway2 as bw
 from PyQt5 import QtWidgets
+
+from .. import activity_cache
+from ..tabs import ActivityDetailsTab
+from ..utils import get_name
+from ...signals import signals
 
 
 class Panel(QtWidgets.QTabWidget):

--- a/lca_activity_browser/app/ui/statusbar.py
+++ b/lca_activity_browser/app/ui/statusbar.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtWidgets
+
 from ..signals import signals
 
 

--- a/lca_activity_browser/app/ui/tables/__init__.py
+++ b/lca_activity_browser/app/ui/tables/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .activity import ActivitiesTable
 from .biosphere import BiosphereFlowsTable
 from .calculation_setups import (

--- a/lca_activity_browser/app/ui/tables/activity.py
+++ b/lca_activity_browser/app/ui/tables/activity.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
-from ..icons import icons
-from . table import ABTableWidget
+import itertools
+
 from brightway2 import Database
 from PyQt5 import QtCore, QtGui, QtWidgets
-import itertools
+
+from . table import ABTableWidget
+from ..icons import icons
+from ...signals import signals
 
 
 class ActivityItem(QtWidgets.QTableWidgetItem):

--- a/lca_activity_browser/app/ui/tables/biosphere.py
+++ b/lca_activity_browser/app/ui/tables/biosphere.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-import brightway2 as bw
-from PyQt5 import QtWidgets
 import itertools
-from ...signals import signals
-from .activity import ActivityItem
-from . table import ABTableWidget
 
+import brightway2 as bw
+
+from . table import ABTableWidget
+from .activity import ActivityItem
+from ...signals import signals
 
 
 class BiosphereFlowsTable(ABTableWidget):

--- a/lca_activity_browser/app/ui/tables/calculation_setups.py
+++ b/lca_activity_browser/app/ui/tables/calculation_setups.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
-from ..icons import icons
+import brightway2 as bw
+from PyQt5 import QtCore, QtGui, QtWidgets
+
 from .activity import ActivitiesTable
 from .table import ABTableWidget
 from .ia import MethodsTable
-import brightway2 as bw
-from PyQt5 import QtCore, QtGui, QtWidgets
+from ..icons import icons
+from ...signals import signals
 
 
 class CSList(QtWidgets.QComboBox):

--- a/lca_activity_browser/app/ui/tables/database.py
+++ b/lca_activity_browser/app/ui/tables/database.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
-from . table import ABTableWidget
+import arrow
 from bw2data import databases
 from bw2data.utils import natural_sort
 from PyQt5 import QtCore, QtWidgets
-import arrow
+
+from .table import ABTableWidget
+from ...signals import signals
 
 
 class DatabaseItem(QtWidgets.QTableWidgetItem):

--- a/lca_activity_browser/app/ui/tables/exchange.py
+++ b/lca_activity_browser/app/ui/tables/exchange.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
-from ..icons import icons
+from PyQt5 import QtCore, QtGui, QtWidgets
+
 from .activity import ActivityItem, ActivitiesTable
 from .biosphere import BiosphereFlowsTable
 from .table import ABTableWidget, ABTableItem
-from PyQt5 import QtCore, QtGui, QtWidgets
+from ..icons import icons
+from ...signals import signals
 
 
 class ExchangeTable(ABTableWidget):

--- a/lca_activity_browser/app/ui/tables/history.py
+++ b/lca_activity_browser/app/ui/tables/history.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
-from ..icons import icons
-from . table import ABTableWidget
 import brightway2 as bw
 from PyQt5 import QtCore, QtGui, QtWidgets
+
+from . table import ABTableWidget
+from ..icons import icons
+from ...signals import signals
 
 
 class ActivityHistoryItem(QtWidgets.QTableWidgetItem):

--- a/lca_activity_browser/app/ui/tables/ia.py
+++ b/lca_activity_browser/app/ui/tables/ia.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
-from . table import ABTableWidget
+import numbers
+
 import brightway2 as bw
 from PyQt5 import QtCore, QtWidgets
-import numbers
+
+from . table import ABTableWidget
+from ...signals import signals
 
 
 class MethodItem(QtWidgets.QTableWidgetItem):

--- a/lca_activity_browser/app/ui/tables/lca_results.py
+++ b/lca_activity_browser/app/ui/tables/lca_results.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-from . table import ABTableWidget
 from brightway2 import get_activity
 from PyQt5 import QtCore, QtWidgets
+
+from . table import ABTableWidget
 
 
 class ReadOnlyItem(QtWidgets.QTableWidgetItem):

--- a/lca_activity_browser/app/ui/tables/projects.py
+++ b/lca_activity_browser/app/ui/tables/projects.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PyQt5 import QtCore, QtWidgets
 from bw2data import projects
+from PyQt5 import QtCore, QtWidgets
 
 
 class ProjectListModel(QtCore.QAbstractListModel):

--- a/lca_activity_browser/app/ui/tables/table.py
+++ b/lca_activity_browser/app/ui/tables/table.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
 from PyQt5 import QtCore, QtWidgets
+from ...signals import signals
 
 
 class ABTableItem(QtWidgets.QTableWidgetItem):
@@ -43,6 +43,5 @@ class ABTableWidget(QtWidgets.QTableWidget):
                     s = s[:-1] + "\n"  # eliminate last '\t'
                 signals.copy_selection_to_clipboard.emit(s)
 
-            elif e.key() == QtCore.Qt.Key_V: # paste
+            elif e.key() == QtCore.Qt.Key_V:  # paste
                 pass
-

--- a/lca_activity_browser/app/ui/tabs/__init__.py
+++ b/lca_activity_browser/app/ui/tabs/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .activity import ActivityDetailsTab
 from .calculation_setups import CalculationSetupTab
 from .history import HistoryTab

--- a/lca_activity_browser/app/ui/tabs/activity.py
+++ b/lca_activity_browser/app/ui/tabs/activity.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+import functools
+
+import brightway2 as bw
+from PyQt5 import QtCore, QtWidgets
+
 from .. import header
 from ..tables import ExchangeTable
 from ..widgets import ActivityDataGrid
-import brightway2 as bw
-from PyQt5 import QtCore, QtWidgets
-import functools
 
 
 class ActivityDetailsTab(QtWidgets.QWidget):

--- a/lca_activity_browser/app/ui/tabs/calculation_setups.py
+++ b/lca_activity_browser/app/ui/tabs/calculation_setups.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from brightway2 import calculation_setups
+from PyQt5 import QtWidgets
+
+from .. import horizontal_line, header
+from ..network import SankeyWindow
 from ..tables import (
     CSActivityTable,
     CSList,
     CSMethodsTable,
 )
-from .. import horizontal_line, header
 from ...signals import signals
-from ..network import SankeyWindow
-from PyQt5 import QtWidgets
 
 """
 Lifecycle of a calculation setup

--- a/lca_activity_browser/app/ui/tabs/history.py
+++ b/lca_activity_browser/app/ui/tabs/history.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+from PyQt5 import QtCore, QtWidgets
+
 from .. import horizontal_line, header
 from ..tables import ActivitiesHistoryTable
-from PyQt5 import QtCore, QtWidgets
 
 
 class HistoryTab(QtWidgets.QWidget):

--- a/lca_activity_browser/app/ui/tabs/ia.py
+++ b/lca_activity_browser/app/ui/tabs/ia.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+from PyQt5 import QtCore, QtWidgets
+
 from .. import horizontal_line, header
 from ..tables import CFTable, MethodsTable
 from ...signals import signals
-from PyQt5 import QtCore, QtWidgets
 
 
 class CFsTab(QtWidgets.QWidget):

--- a/lca_activity_browser/app/ui/tabs/inventory.py
+++ b/lca_activity_browser/app/ui/tabs/inventory.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+from .. import header
+from ..icons import icons
 from ..tables import (
     ActivitiesTable,
     DatabasesTable,
     BiosphereFlowsTable,
 )
-from .. import header
 from ...signals import signals
-from ..icons import icons
-from PyQt5 import QtCore, QtGui, QtWidgets
 
 
 class MaybeTable(QtWidgets.QWidget):

--- a/lca_activity_browser/app/ui/tabs/lca_results.py
+++ b/lca_activity_browser/app/ui/tabs/lca_results.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
-from .. import horizontal_line, header
 from PyQt5 import QtWidgets
+
+from .. import horizontal_line, header
+from ..tables import LCAResultsTable
+from ..graphics import (
+    CorrelationPlot,
+    LCAResultsPlot,
+    LCAProcessContributionPlot,
+    LCAElementaryFlowContributionPlot
+)
 from ...bw2extensions.multilca import MLCA
 from ...signals import signals
-from ..graphics import \
-    CorrelationPlot, \
-    LCAResultsPlot, \
-    LCAProcessContributionPlot, \
-    LCAElementaryFlowContributionPlot
-from ..tables import LCAResultsTable
 
 
 class LCAResultsTab(QtWidgets.QWidget):

--- a/lca_activity_browser/app/ui/toolbar.py
+++ b/lca_activity_browser/app/ui/toolbar.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from ..signals import signals
-from .icons import icons
 from brightway2 import projects
 from PyQt5 import QtGui, QtWidgets
 from requests_oauthlib import OAuth1Session
+
+from .icons import icons
+from ..signals import signals
 
 
 def create_issue(content):

--- a/lca_activity_browser/app/ui/utils.py
+++ b/lca_activity_browser/app/ui/utils.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-from io import StringIO
-from PyQt5 import QtGui
 import uuid
+from io import StringIO
+
+from PyQt5 import QtGui
 
 
 class StdRedirector(StringIO):

--- a/lca_activity_browser/app/ui/widgets/__init__.py
+++ b/lca_activity_browser/app/ui/widgets/__init__.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 from .activity import ActivityDataGrid

--- a/lca_activity_browser/app/ui/widgets/activity.py
+++ b/lca_activity_browser/app/ui/widgets/activity.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from .line_edit import SignalledLineEdit, SignalledPlainTextEdit
 from PyQt5 import QtCore, QtWidgets
+
+from .line_edit import SignalledLineEdit, SignalledPlainTextEdit
 
 
 class ActivityDataGrid(QtWidgets.QWidget):

--- a/lca_activity_browser/app/ui/widgets/line_edit.py
+++ b/lca_activity_browser/app/ui/widgets/line_edit.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from ...signals import signals
 from PyQt5 import QtGui, QtWidgets
+
+from ...signals import signals
 
 
 class SignalledLineEdit(QtWidgets.QLineEdit):

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 from setuptools import setup
 


### PR DESCRIPTION
I tidied up the import statements, code was really inconsistent here, see #59.

@bsteubing, please have a look at the second commit. I removed some code that you recently added, because I think it doesn't work as you intended.

`from bw2data import calculation_setups` will never raise an `ImportError`. `calculation_setups` will just be an empty dict if no cs are defined. But in the empty case this would reraise an `ImportError`, because an empty dict evaluates to `False` in this statement:
```
if not calculation_setups:
    raise ImportError
```
I'm not 100% sure that I understood everything correctly, so please check this. Otherwise I think it would be good to merge this fast to reduce the time we spend on resolving merge-conflicts. This PR affects almost the full codebase.