### PR TITLE
Report issues to github directly from activity browser

### DIFF
--- a/lca_activity_browser/app/ui/menu_bar.py
+++ b/lca_activity_browser/app/ui/menu_bar.py
@@ -113,12 +113,13 @@ You should have received a copy of the GNU General Public License along with thi
             print(response.text)
 
     def raise_issue_from_app(self):
-        text = self.window.dialog(
+        text, _ = QtWidgets.QInputDialog.getMultiLineText(
+            None,
             'Report new bug',
             ('Please describe the buggy behaviour. View existing issues on ' +
              '<a href="https://github.com/LCA-ActivityBrowser/activity-browser/issues">github</a>.'+
              '<br>If you have a github account, please consider raising the issue directly on github.'
-             )
+             ),
         )
         if text:
             content = text + '\n\nLog Output:\n```\n{}```'.format(self.window.log.toPlainText())

--- a/lca_activity_browser/app/ui/toolbar.py
+++ b/lca_activity_browser/app/ui/toolbar.py
@@ -1,25 +1,9 @@
 # -*- coding: utf-8 -*-
-from ..signals import signals
-from .icons import icons
 from brightway2 import projects
 from PyQt5 import QtGui, QtWidgets
-from requests_oauthlib import OAuth1Session
 
-
-def create_issue(content):
-    issues = OAuth1Session(
-        '4DBX8xKMvaUShgUHW9',
-        client_secret='Lzman2V4v52YqMHazNNrpstHSLGgyhWH'
-    )
-    data = {
-        'title': 'New issue reported from app',
-        'content': content,
-        'status': 'new',
-        'priority': 'trivial',
-        'kind': 'bug'
-    }
-    URL = "https://bitbucket.org/api/1.0/repositories/cmutel/activity-browser/issues/"
-    issues.post(URL, data=data)
+from .icons import icons
+from ..signals import signals
 
 
 class StackButton(QtWidgets.QPushButton):
@@ -45,9 +29,6 @@ class Toolbar(QtWidgets.QToolBar):
         self.window = window
 
         # Toolbar elements are layed out left to right.
-        new_issue_button = QtWidgets.QPushButton(QtGui.QIcon(icons.debug), 'Report Bug')
-        new_issue_button.setStyleSheet('QPushButton {color: red;}')
-
         switch_stack_button = StackButton(
             self.window,
             QtGui.QIcon(icons.switch),
@@ -68,7 +49,6 @@ class Toolbar(QtWidgets.QToolBar):
         self.delete_project_button = QtWidgets.QPushButton(QtGui.QIcon(icons.delete), 'Delete current')
 
         self.addWidget(QtWidgets.QLabel('Brightway2 Activity Browser'))
-        self.addWidget(new_issue_button)
         self.addWidget(switch_stack_button)
         self.addWidget(self.project_name_label)
         self.addWidget(self.project_read_only)
@@ -89,17 +69,7 @@ class Toolbar(QtWidgets.QToolBar):
 
         self.window.addToolBar(self)
 
-        new_issue_button.clicked.connect(self.create_issue_dialog)
-
         self.connect_signals()
-
-    def create_issue_dialog(self):
-        text = self.window.dialog(
-            'Report new bug',
-            'Please describe the buggy behaviour. Existing bugs can be viewed at `https://bitbucket.org/cmutel/activity-browser/issues?status=new&status=open`'
-        )
-        if text:
-            create_issue(text)
 
     def connect_signals(self):
         # SIGNALS

--- a/lca_activity_browser/app/ui/utils.py
+++ b/lca_activity_browser/app/ui/utils.py
@@ -42,3 +42,6 @@ def get_name(obj):
 
 def new_id():
     return uuid.uuid4().hex
+
+
+abt1 = '16z7c78fbfdzb9fbe893c2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 brightway2
 pyqt
-requests-oauthlib
 seaborn
 arrow
 pandas
+beautifulsoup4
+patool

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,15 @@ setup(
     author="Adrian Haas",
     author_email="haasad@student.ethz.ch",
     license=open('LICENSE.txt').read(),
-    install_requires=['brightway2', 'pyqt5', 'requests-oauthlib', 'seaborn',
-                      'arrow', 'pandas', 'beautifulsoup4', 'patool'],
+    install_requires=[
+        'brightway2',
+        'pyqt5',
+        'seaborn',
+        'arrow',
+        'pandas',
+        'beautifulsoup4',
+        'patool'
+    ],
     url="https://github.com/haasad/activity-browser",
     long_description=open('README.md').read(),
     description=('Brightway2 GUI'),

--- a/travis-recipe/meta.yaml
+++ b/travis-recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - matplotlib
     - seaborn
     - arrow
-    - requests-oauthlib
     - pandas
     - patool
     - beautifulsoup4


### PR DESCRIPTION
- :beetle: button removed from toolbar
- option to raise issue on github from menubar
- option to raise issue from app in menubar
- some obfuscation for the github auth
- api-access only allows access to other public repos, therefore risk acceptable imo

Further TODOs after this:
- toolbar needs a new layout, eg. where to place debug window button?
- link in Report new bug window is not clickable