### PR TITLE
tables in activity tab to a toggleable groupbox

### DIFF
--- a/lca_activity_browser/app/ui/tabs/activity.py
+++ b/lca_activity_browser/app/ui/tabs/activity.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-import functools
-
 import brightway2 as bw
 from PyQt5 import QtCore, QtWidgets
 
-from ..style import header
 from ..tables import ExchangeTable
-from ..widgets import ActivityDataGrid
+from ..widgets import ActivityDataGrid, DetailsGroupBox
 
 
 class ActivityDetailsTab(QtWidgets.QWidget):
@@ -25,16 +22,6 @@ class ActivityDetailsTab(QtWidgets.QWidget):
         if activity:
             self.populate(activity)
 
-    def toggle_visible(self, table):
-        if table.state == "shown":
-            table.state = "hidden"
-            table.toggle_button.setText("Show")
-            table.hide()
-        else:
-            table.state = "shown"
-            table.show()
-            table.toggle_button.setText("Hide")
-
     def get_details_widget(self):
         self.production = ExchangeTable(self, production=True)
         self.inputs = ExchangeTable(self)
@@ -45,7 +32,7 @@ class ActivityDetailsTab(QtWidgets.QWidget):
         self.metadata = ActivityDataGrid()
         layout.addWidget(self.metadata)
 
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        # splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
 
         tables = [
             (self.production, "Products:"),
@@ -55,48 +42,13 @@ class ActivityDetailsTab(QtWidgets.QWidget):
         ]
 
         for table, label in tables:
-            table.state = "shown"
-            table.toggle_button = QtWidgets.QPushButton("Hide")
-            table.toggle_button.clicked.connect(functools.partial(self.toggle_visible, table=table))
+            layout.addWidget(DetailsGroupBox(label, table))
 
-            inside_widget = QtWidgets.QWidget()
-            inside_layout = QtWidgets.QHBoxLayout()
-            inside_layout.addWidget(header(label))
-            inside_layout.addWidget(table.toggle_button)
-            inside_layout.addStretch()
-            inside_widget.setLayout(inside_layout)
-
-            # layout.addWidget(inside_widget)
-            # layout.addWidget(table)
-
-            inside_widget.setSizePolicy(QtWidgets.QSizePolicy(
-                QtWidgets.QSizePolicy.Maximum,
-                QtWidgets.QSizePolicy.Maximum)
-            )
-
-            table.setSizePolicy(QtWidgets.QSizePolicy(
-                QtWidgets.QSizePolicy.Minimum,
-                QtWidgets.QSizePolicy.Preferred)
-            )
-
-            table_layout = QtWidgets.QVBoxLayout()
-            table_layout.addWidget(inside_widget)
-            table_layout.addWidget(table)
-            table_container = QtWidgets.QWidget()
-
-
-
-            table_container.setLayout(table_layout)
-            splitter.addWidget(table_container)
-
-
-
-        layout.addWidget(splitter)
-        layout.addStretch(0)
-
-        # layout.addStretch()
+        # layout.addWidget(splitter)
+        layout.addStretch()
         widget = QtWidgets.QWidget(self)
         widget.setLayout(layout)
+
         return widget
 
     def populate(self, key):

--- a/lca_activity_browser/app/ui/widgets/__init__.py
+++ b/lca_activity_browser/app/ui/widgets/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from .activity import ActivityDataGrid
+from .activity import ActivityDataGrid, DetailsGroupBox

--- a/lca_activity_browser/app/ui/widgets/activity.py
+++ b/lca_activity_browser/app/ui/widgets/activity.py
@@ -4,6 +4,26 @@ from PyQt5 import QtCore, QtWidgets
 from .line_edit import SignalledLineEdit, SignalledPlainTextEdit
 
 
+class DetailsGroupBox(QtWidgets.QGroupBox):
+    def __init__(self, label, widget):
+        super().__init__(label)
+        self.widget = widget
+        self.setCheckable(True)
+        self.toggled.connect(self.showhide)
+        self.setChecked(False)
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(widget)
+        self.setLayout(layout)
+        if isinstance(self.widget, QtWidgets.QTableWidget):
+            self.widget.itemChanged.connect(self.toggle_empty_table)
+
+    def showhide(self):
+        self.widget.setVisible(self.isChecked())
+
+    def toggle_empty_table(self):
+        self.setChecked(bool(self.widget.rowCount()))
+
+
 class ActivityDataGrid(QtWidgets.QWidget):
     def __init__(self, parent=None, activity=None):
         super(ActivityDataGrid, self).__init__(parent)
@@ -43,13 +63,19 @@ class ActivityDataGrid(QtWidgets.QWidget):
         self.location_box.setPlaceholderText("ISO 2-letter code or custom name")
         grid.addWidget(self.location_box, 3, 2, 1, right_side)
 
-        grid.addWidget(QtWidgets.QLabel('Description'), 4, 1, 2, 1)
+        # grid.addWidget(QtWidgets.QLabel('Description'), 4, 1, 2, 1)
         self.comment_box = SignalledPlainTextEdit(
             key=getattr(self.activity, "key", None),
             field="comment",
             parent=self,
         )
-        grid.addWidget(self.comment_box, 4, 2, 2, right_side)
+        self.comment_groupbox = DetailsGroupBox(
+            'Description', self.comment_box
+        )
+        self.comment_groupbox.setChecked(False)
+
+        grid.addWidget(self.comment_groupbox, 4, 1, 2, right_side + 1)
+        # grid.addWidget(self.comment_box, 4, 2, 2, right_side)
 
         # grid.addWidget(QtWidgets.QLabel('Unit'), 5, 1)
         # self.unit_box = SignalledLineEdit(
@@ -72,6 +98,11 @@ class ActivityDataGrid(QtWidgets.QWidget):
         self.location_box.setText(self.activity.get('location', ''))
         self.location_box._key = self.activity.key
         self.comment_box.setPlainText(self.activity.get('comment', ''))
+        # the <font> html-tag has no effect besides making the tooltip rich text
+        # this is required for line breaks of long comments
+        self.comment_groupbox.setToolTip(
+            '<font>{}</font>'.format(self.comment_box.toPlainText())
+        )
         # print("Commentbox Width/Height: {}/{}".format(self.comment_box.width(), self.comment_box.width()))
         self.comment_box._before = self.activity.get('comment', '')
         self.comment_box._key = self.activity.key


### PR DESCRIPTION
This is my take on the activity tab. I am aware that this PR reverts some of your recent changes and I would therefore like to hear your opinion before I invest more time into this.

This PR includes the following changes:
- Description:
    - not shown by default
    - displayed as tooltip if hovered with mouse
    - the groupbox can be checked to display/edit the description

- exchanges tables:
    - all tables are part of a groupbox that can be checked/unchecked to show/hide the tables, this replaces the old title + show/hide buttons, which required way more screen space
    - empty tables are unchecked (-> hidden) by default

- splitter:
    - i removed the vertical splitter for now, but I feel there is a trade-off between the dynamic updating of the layout (without splitter) vs more control for the user
    - if we find a way to have the splitter and make it react to changes (ie show/hide) this would be ideal

![image](https://user-images.githubusercontent.com/11636405/34256323-104a13ea-e655-11e7-92b8-c5afb3aab029.png)