### PR TITLE
Rework of the DatabaseImportWizard

### DIFF
--- a/activity_browser/app/ui/db_import_wizard.py
+++ b/activity_browser/app/ui/db_import_wizard.py
@@ -112,7 +112,10 @@ class ImportTypePage(QtWidgets.QWizardPage):
             return self.wizard.pages.index(self.wizard.archive_page)
         else:
             self.wizard.import_type = 'homepage'
-            return self.wizard.pages.index(self.wizard.ecoinvent_login_page)
+            if hasattr(self.wizard.ecoinvent_login_page, 'valid_pw'):
+                return self.wizard.pages.index(self.wizard.ecoinvent_version_page)
+            else:
+                return self.wizard.pages.index(self.wizard.ecoinvent_login_page)
 
 
 class ChooseDirPage(QtWidgets.QWizardPage):

--- a/activity_browser/app/ui/db_import_wizard.py
+++ b/activity_browser/app/ui/db_import_wizard.py
@@ -80,6 +80,15 @@ class DatabaseImportWizard(QtWidgets.QWizard):
         self.reject()
         self.import_page.complete = False
         self.import_page.reset_progressbars()
+        if hasattr(self.import_page, 'download_tempdir'):
+            self.import_page.download_tempdir.cleanup()
+        running_threads = []
+        for thread in self.import_page.unarchive_thread_list:
+            if thread.isRunning():
+                running_threads.append(thread)
+            else:
+                thread.tempdir.cleanup()
+        self.import_page.unarchive_thread_list = running_threads
 
 
 class ImportTypePage(QtWidgets.QWizardPage):
@@ -424,8 +433,6 @@ class ImportPage(QtWidgets.QWizardPage):
         self.complete = True
         self.completeChanged.emit()
         signals.databases_changed.emit()
-        if hasattr(self, 'tempdir'):
-            self.tempdir.cleanup()
 
     def update_unarchive(self):
         self.unarchive_progressbar.setMaximum(1)

--- a/tests/test_import_wizard.py
+++ b/tests/test_import_wizard.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import brightway2 as bw
+from PyQt5 import QtCore, QtWidgets
+
+
+def test_open_db_wizard(qtbot, ab_app):
+    assert bw.projects.current == 'pytest_project'
+    qtbot.waitForWindowShown(ab_app.main_window)
+    qtbot.mouseClick(
+        ab_app.main_window.right_panel.inventory_tab.databases_widget.import_database_button,
+        QtCore.Qt.LeftButton
+    )
+    qtbot.mouseClick(
+        ab_app.controller.db_wizard.button(QtWidgets.QWizard.CancelButton),
+        QtCore.Qt.LeftButton
+    )


### PR DESCRIPTION
- Cancel at any point
    - interrupts the import
    - database is deleted
- Proper handling of temporary data
- Reuse the wizard for several imports
- Thread for ecoinvent login
- Only one successful login required per session
- test for initializing the wizard -> more detailed tests still needed