### PR TITLE
Do not assume reference product exits

### DIFF
--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -10,12 +10,12 @@ def format_activity_label(act, style='pnl'):
         a = bw.get_activity(act)
 
         if style == 'pnl':
-            label = '\n'.join([a['reference product'],
+            label = '\n'.join([a.get('reference product',''),
                                a['name'],
                                a['location'],
                                ])
         elif style == 'pl':
-            label = ', '.join([a['reference product'],
+            label = ', '.join([a.get('reference product') or a.get('name'),
                                a['location'],
                                ])
         elif style == 'key':
@@ -26,7 +26,7 @@ def format_activity_label(act, style='pnl'):
                                str(a['categories']),
                                ])
         else:
-            label = '\n'.join([a['reference product'],
+            label = '\n'.join([a.get('reference product',''),
                                a['name'],
                                a['location'],
                                ])


### PR DESCRIPTION
Fix when reference products do not exist (e.g. in ecoinvent 2.2) and only the processes UUID are returned in `LCA Results` as in the picture:

![screenshot from 2018-02-13 18 30 46](https://user-images.githubusercontent.com/11156305/36164444-a4028948-10ec-11e8-9684-4a67df0c149e.png)

WIth this commit is fixed to:

![screenshot from 2018-02-13 18 36 31](https://user-images.githubusercontent.com/11156305/36164523-dcdb7dba-10ec-11e8-9438-d57daf87b4f1.png)


