### PR TITLE
Improve graphics

### DIFF
--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -3,42 +3,49 @@ import arrow
 import brightway2 as bw
 from bw2data.utils import natural_sort
 from bw2data import databases
+import textwrap
 
+def wrap_text(string, max_lenght=50):
+    """wrap the label making sure that key and name are in 2 rows"""
+    # idea from https://stackoverflow.com/a/39134215/4929813
+    wrapArgs = {'width': max_lenght, 'break_long_words': True, 'replace_whitespace': False}
+    fold = lambda line, wrapArgs: textwrap.fill(line, **wrapArgs)
+    return '\n'.join([fold(line, wrapArgs) for line in string.splitlines()])
 
 def format_activity_label(act, style='pnl'):
     try:
         a = bw.get_activity(act)
 
         if style == 'pnl':
-            label = '\n'.join([a.get('reference product',''),
+            label = wrap_text('\n'.join([a.get('reference product',''),
                                a.get('name',''),
                                a.get('location',''),
-                               ])
+                               ]))
         elif style == 'pl':
-            label = ', '.join([a.get('reference product','') or a.get('name',''),
+            label = wrap_text(', '.join([a.get('reference product','') or a.get('name',''),
                                a.get('location',''),
-                               ])            
+                               ]), max_lenght=25)    
         elif style == 'key':
-            label = str(a.key) #safer to use key, code does not always exist
+            label = wrap_text(str(a.key)) #safer to use key, code does not always exist
 
         elif style == 'bio':
-            label = ', '.join([a.get('name',''),
+            label = wrap_text(',\n'.join([a.get('name',''),
                                str(a.get('categories','')),
-                               ])
-        elif style == 'fu':
-            label = '\n'.join([str(a.key),
+                               ]), max_lenght=25)
+        elif style == 'fu':              
+            label =  wrap_text('\n'.join([str(a.key),
                      a.get('reference product','') or a.get('name','')
-                     ])            
+                     ]))
         else:
-            label = '\n'.join([a.get('reference product',''),
+            label = wrap_text('\n'.join([a.get('reference product',''),
                                a.get('name',''),
                                a.get('location',''),
-                               ])
+                               ]))
     except:
         if isinstance(act, tuple):
-            return str(''.join(act))
+            return wrap_text(str(''.join(act)))
         else:
-            return str(act)
+            return wrap_text(str(act))
     return label
 
 def get_database_metadata(name):

--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -19,12 +19,16 @@ def format_activity_label(act, style='pnl'):
                                a['location'],
                                ])
         elif style == 'key':
-            label = tuple([a['database'], a['code']])
+            label = str(a.key) #safer to use key, code does not always exist
 
         elif style == 'bio':
             label = ', '.join([a['name'],
                                str(a['categories']),
                                ])
+        elif style == 'fu':
+            #join does not work here
+            label = str(a.key) + '\n' + a.get('reference product') or a.get('name')
+
         else:
             label = '\n'.join([a.get('reference product',''),
                                a['name'],

--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -11,28 +11,28 @@ def format_activity_label(act, style='pnl'):
 
         if style == 'pnl':
             label = '\n'.join([a.get('reference product',''),
-                               a['name'],
-                               a['location'],
+                               a.get('name',''),
+                               a.get('location',''),
                                ])
         elif style == 'pl':
-            label = ', '.join([a.get('reference product') or a.get('name'),
-                               a['location'],
-                               ])
+            label = ', '.join([a.get('reference product','') or a.get('name',''),
+                               a.get('location',''),
+                               ])            
         elif style == 'key':
             label = str(a.key) #safer to use key, code does not always exist
 
         elif style == 'bio':
-            label = ', '.join([a['name'],
-                               str(a['categories']),
+            label = ', '.join([a.get('name',''),
+                               str(a.get('categories','')),
                                ])
         elif style == 'fu':
-            #join does not work here
-            label = str(a.key) + '\n' + a.get('reference product') or a.get('name')
-
+            label = '\n'.join([str(a.key),
+                     a.get('reference product','') or a.get('name','')
+                     ])            
         else:
             label = '\n'.join([a.get('reference product',''),
-                               a['name'],
-                               a['location'],
+                               a.get('name',''),
+                               a.get('location',''),
                                ])
     except:
         if isinstance(act, tuple):

--- a/activity_browser/app/ui/graphics.py
+++ b/activity_browser/app/ui/graphics.py
@@ -72,7 +72,7 @@ class CorrelationPlot(FigureCanvasQTAgg):
 class LCAResultsPlot(FigureCanvasQTAgg):
     def __init__(self, parent, mlca, width=6, height=6, dpi=100):
         activity_names = [format_activity_label(next(iter(f.keys())),style='fu') for f in mlca.func_units]
-        figure = Figure(figsize=(2+len(mlca.methods)*0.5, 2+len(activity_names)*0.6), dpi=dpi, tight_layout=True)
+        figure = Figure(figsize=(2+len(mlca.methods)*0.5, 4+len(activity_names)*0.55), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(111)
 
         super(LCAResultsPlot, self).__init__(figure)

--- a/activity_browser/app/ui/graphics.py
+++ b/activity_browser/app/ui/graphics.py
@@ -76,7 +76,7 @@ class LCAResultsPlot(FigureCanvasQTAgg):
 
         super(LCAResultsPlot, self).__init__(figure)
         self.setParent(parent)
-        activity_names = [format_activity_label(next(iter(f.keys()))) for f in mlca.func_units]
+        activity_names = [format_activity_label(next(iter(f.keys())),style='fu') for f in mlca.func_units]
         # From https://stanford.edu/~mwaskom/software/seaborn/tutorial/color_palettes.html
         cmap = sns.cubehelix_palette(8, start=.5, rot=-.75, as_cmap=True)
         hm = sns.heatmap(
@@ -107,7 +107,7 @@ class LCAProcessContributionPlot(FigureCanvasQTAgg):
         method = 0  # TODO let user choose the LCIA method
         tc = mlca.top_process_contributions(method=method, limit=5, relative=True)
         df_tc = pd.DataFrame(tc)
-        df_tc.columns = [format_activity_label(a) for a in tc.keys()]
+        df_tc.columns = [format_activity_label(a, style='fu') for a in tc.keys()]
         df_tc.index = [format_activity_label(a, style='pl') for a in df_tc.index]
         plot = df_tc.T.plot.barh(
             stacked=True,
@@ -132,7 +132,7 @@ class LCAElementaryFlowContributionPlot(FigureCanvasQTAgg):
         method = 0  # TODO let user choose the LCIA method
         tc = mlca.top_elementary_flow_contributions(method=method, limit=5, relative=True)
         df_tc = pd.DataFrame(tc)
-        df_tc.columns = [format_activity_label(a) for a in tc.keys()]
+        df_tc.columns = [format_activity_label(a, style='fu') for a in tc.keys()]
         df_tc.index = [format_activity_label(a, style='bio') for a in df_tc.index]
         plot = df_tc.T.plot.barh(
             stacked=True,

--- a/activity_browser/app/ui/graphics.py
+++ b/activity_browser/app/ui/graphics.py
@@ -57,11 +57,11 @@ class CorrelationPlot(FigureCanvasQTAgg):
                     square=True, linecolor="lightgray", linewidths=1, ax=axes)
         for i in range(len(corr)):
             axes.text(i + 0.5, i + 0.5, corr.columns[i],
-                      ha="center", va="center", rotation=0)
+                      ha="center", va="center", rotation=0 if len(labels) <=8 else 45,size=11 if len(labels) <=8 else 9)
             for j in range(i + 1, len(corr)):
                 s = "{:.3f}".format(corr.values[i, j])
                 axes.text(j + 0.5, i + 0.5, s,
-                          ha="center", va="center")
+                          ha="center", va="center", rotation=0 if len(labels) <=8 else 45,size=11 if len(labels) <=8 else 9)
         axes.axis("off")
         # If uncommented, fills widget
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
@@ -89,7 +89,7 @@ class LCAResultsPlot(FigureCanvasQTAgg):
             yticklabels=activity_names,
             ax=axes,
             square=False,
-            annot_kws={"size": 9,'rotation':0 if len(mlca.methods) <=8 else 60}
+            annot_kws={"size": 11 if len(mlca.methods) <=8 else 9,'rotation':0 if len(mlca.methods) <=8 else 60}
         )
         hm.tick_params(labelsize=8)
 

--- a/activity_browser/app/ui/graphics.py
+++ b/activity_browser/app/ui/graphics.py
@@ -31,8 +31,8 @@ class Canvas(FigureCanvasQTAgg):
 
 
 class CorrelationPlot(FigureCanvasQTAgg):
-    def __init__(self, parent, data, labels, width=6, height=6, dpi=100):
-        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
+    def __init__(self, parent, data, labels, dpi=100):
+        figure = Figure(figsize=(4+len(labels)*0.3, 4+len(labels)*0.3), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(111)
 
         super(CorrelationPlot, self).__init__(figure)
@@ -98,8 +98,8 @@ class LCAResultsPlot(FigureCanvasQTAgg):
 
 
 class LCAProcessContributionPlot(FigureCanvasQTAgg):
-    def __init__(self, parent, mlca, width=6, height=6, dpi=100):
-        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
+    def __init__(self, parent, mlca, width=6, dpi=100):
+        figure = Figure(figsize=(width, 4+len(mlca.func_units)*0.3), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(121)
 
         super(LCAProcessContributionPlot, self).__init__(figure)
@@ -123,8 +123,8 @@ class LCAProcessContributionPlot(FigureCanvasQTAgg):
 
 
 class LCAElementaryFlowContributionPlot(FigureCanvasQTAgg):
-    def __init__(self, parent, mlca, width=6, height=6, dpi=100):
-        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
+    def __init__(self, parent, mlca, width=6, dpi=100):
+        figure = Figure(figsize=(width, 4+len(mlca.func_units)*0.3), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(121)
 
         super(LCAElementaryFlowContributionPlot, self).__init__(figure)

--- a/activity_browser/app/ui/graphics.py
+++ b/activity_browser/app/ui/graphics.py
@@ -99,7 +99,8 @@ class LCAResultsPlot(FigureCanvasQTAgg):
 
 class LCAProcessContributionPlot(FigureCanvasQTAgg):
     def __init__(self, parent, mlca, width=6, dpi=100):
-        figure = Figure(figsize=(width, 4+len(mlca.func_units)*0.3), dpi=dpi, tight_layout=True)
+        height=4+len(mlca.func_units)*0.3
+        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(121)
 
         super(LCAProcessContributionPlot, self).__init__(figure)
@@ -117,8 +118,8 @@ class LCAProcessContributionPlot(FigureCanvasQTAgg):
             ax=axes
         )
         plot.tick_params(labelsize=8)
-        axes.legend(loc='center left', bbox_to_anchor=(1, 0.5))
-        plt.rc('legend', **{'fontsize': 8})
+        plt.rc('legend', **{'fontsize': 8}) #putting below affects only LCAElementaryFlowContributionPlot
+        axes.legend(loc='center left', bbox_to_anchor=(1, 0.5),ncol=ceil((len(df_tc.index)*0.22)/height))
         self.setMinimumSize(self.size())
 
 

--- a/activity_browser/app/ui/graphics.py
+++ b/activity_browser/app/ui/graphics.py
@@ -7,7 +7,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from PyQt5 import QtWidgets
 
-from ..bwutils.commontasks import format_activity_label
+from ..bwutils.commontasks import format_activity_label,wrap_text
 
 
 class Canvas(FigureCanvasQTAgg):
@@ -71,12 +71,12 @@ class CorrelationPlot(FigureCanvasQTAgg):
 
 class LCAResultsPlot(FigureCanvasQTAgg):
     def __init__(self, parent, mlca, width=6, height=6, dpi=100):
-        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
+        activity_names = [format_activity_label(next(iter(f.keys())),style='fu') for f in mlca.func_units]
+        figure = Figure(figsize=(2+len(mlca.methods)*0.5, 2+len(activity_names)*0.6), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(111)
 
         super(LCAResultsPlot, self).__init__(figure)
         self.setParent(parent)
-        activity_names = [format_activity_label(next(iter(f.keys())),style='fu') for f in mlca.func_units]
         # From https://stanford.edu/~mwaskom/software/seaborn/tutorial/color_palettes.html
         cmap = sns.cubehelix_palette(8, start=.5, rot=-.75, as_cmap=True)
         hm = sns.heatmap(
@@ -85,10 +85,11 @@ class LCAResultsPlot(FigureCanvasQTAgg):
             annot=True,
             linewidths=.05,
             cmap=cmap,
-            xticklabels=["\n".join(x) for x in mlca.methods],
+            xticklabels=[wrap_text(",".join(x),max_lenght=40) for x in mlca.methods],
             yticklabels=activity_names,
             ax=axes,
             square=False,
+            annot_kws={"size": 9,'rotation':0 if len(mlca.methods) <=8 else 60}
         )
         hm.tick_params(labelsize=8)
 


### PR DESCRIPTION
This pull changes how the functional unit is displayed in (all) the graphs from this:

![bef](https://user-images.githubusercontent.com/11156305/37338552-154e692e-26b8-11e8-889e-cde0ea143af1.png)

Note:  when the field `code` does not  exist in the bw2 activity dataset (as in this case) this is the result

to this:

![after](https://user-images.githubusercontent.com/11156305/37338557-17cfa064-26b8-11e8-86ba-6a64a30f71cc.png)

Also when the `code` exists have only the bw2 `key` is not very user friendly. 

This pull fix the issue with the `code` and adds the `reference product` or `name` for the functional unit in all the graphs

