### PR TITLE
Revert "Improve graphics"

### DIFF
--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -3,49 +3,38 @@ import arrow
 import brightway2 as bw
 from bw2data.utils import natural_sort
 from bw2data import databases
-import textwrap
 
-def wrap_text(string, max_lenght=50):
-    """wrap the label making sure that key and name are in 2 rows"""
-    # idea from https://stackoverflow.com/a/39134215/4929813
-    wrapArgs = {'width': max_lenght, 'break_long_words': True, 'replace_whitespace': False}
-    fold = lambda line, wrapArgs: textwrap.fill(line, **wrapArgs)
-    return '\n'.join([fold(line, wrapArgs) for line in string.splitlines()])
 
 def format_activity_label(act, style='pnl'):
     try:
         a = bw.get_activity(act)
 
         if style == 'pnl':
-            label = wrap_text('\n'.join([a.get('reference product',''),
-                               a.get('name',''),
-                               a.get('location',''),
-                               ]))
+            label = '\n'.join([a.get('reference product',''),
+                               a['name'],
+                               a['location'],
+                               ])
         elif style == 'pl':
-            label = wrap_text(', '.join([a.get('reference product','') or a.get('name',''),
-                               a.get('location',''),
-                               ]), max_lenght=25)    
+            label = ', '.join([a.get('reference product') or a.get('name'),
+                               a['location'],
+                               ])
         elif style == 'key':
-            label = wrap_text(str(a.key)) #safer to use key, code does not always exist
+            label = tuple([a['database'], a['code']])
 
         elif style == 'bio':
-            label = wrap_text(',\n'.join([a.get('name',''),
-                               str(a.get('categories','')),
-                               ]), max_lenght=25)
-        elif style == 'fu':              
-            label =  wrap_text('\n'.join([str(a.key),
-                     a.get('reference product','') or a.get('name','')
-                     ]))
+            label = ', '.join([a['name'],
+                               str(a['categories']),
+                               ])
         else:
-            label = wrap_text('\n'.join([a.get('reference product',''),
-                               a.get('name',''),
-                               a.get('location',''),
-                               ]))
+            label = '\n'.join([a.get('reference product',''),
+                               a['name'],
+                               a['location'],
+                               ])
     except:
         if isinstance(act, tuple):
-            return wrap_text(str(''.join(act)))
+            return str(''.join(act))
         else:
-            return wrap_text(str(act))
+            return str(act)
     return label
 
 def get_database_metadata(name):

--- a/activity_browser/app/ui/graphics.py
+++ b/activity_browser/app/ui/graphics.py
@@ -7,7 +7,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from PyQt5 import QtWidgets
 
-from ..bwutils.commontasks import format_activity_label,wrap_text
+from ..bwutils.commontasks import format_activity_label
 
 
 class Canvas(FigureCanvasQTAgg):
@@ -31,8 +31,8 @@ class Canvas(FigureCanvasQTAgg):
 
 
 class CorrelationPlot(FigureCanvasQTAgg):
-    def __init__(self, parent, data, labels, dpi=100):
-        figure = Figure(figsize=(4+len(labels)*0.3, 4+len(labels)*0.3), dpi=dpi, tight_layout=True)
+    def __init__(self, parent, data, labels, width=6, height=6, dpi=100):
+        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(111)
 
         super(CorrelationPlot, self).__init__(figure)
@@ -57,11 +57,11 @@ class CorrelationPlot(FigureCanvasQTAgg):
                     square=True, linecolor="lightgray", linewidths=1, ax=axes)
         for i in range(len(corr)):
             axes.text(i + 0.5, i + 0.5, corr.columns[i],
-                      ha="center", va="center", rotation=0 if len(labels) <=8 else 45,size=11 if len(labels) <=8 else 9)
+                      ha="center", va="center", rotation=0)
             for j in range(i + 1, len(corr)):
                 s = "{:.3f}".format(corr.values[i, j])
                 axes.text(j + 0.5, i + 0.5, s,
-                          ha="center", va="center", rotation=0 if len(labels) <=8 else 45,size=11 if len(labels) <=8 else 9)
+                          ha="center", va="center")
         axes.axis("off")
         # If uncommented, fills widget
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
@@ -71,12 +71,12 @@ class CorrelationPlot(FigureCanvasQTAgg):
 
 class LCAResultsPlot(FigureCanvasQTAgg):
     def __init__(self, parent, mlca, width=6, height=6, dpi=100):
-        activity_names = [format_activity_label(next(iter(f.keys())),style='fu') for f in mlca.func_units]
-        figure = Figure(figsize=(2+len(mlca.methods)*0.5, 4+len(activity_names)*0.55), dpi=dpi, tight_layout=True)
+        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(111)
 
         super(LCAResultsPlot, self).__init__(figure)
         self.setParent(parent)
+        activity_names = [format_activity_label(next(iter(f.keys()))) for f in mlca.func_units]
         # From https://stanford.edu/~mwaskom/software/seaborn/tutorial/color_palettes.html
         cmap = sns.cubehelix_palette(8, start=.5, rot=-.75, as_cmap=True)
         hm = sns.heatmap(
@@ -85,11 +85,10 @@ class LCAResultsPlot(FigureCanvasQTAgg):
             annot=True,
             linewidths=.05,
             cmap=cmap,
-            xticklabels=[wrap_text(",".join(x),max_lenght=40) for x in mlca.methods],
+            xticklabels=["\n".join(x) for x in mlca.methods],
             yticklabels=activity_names,
             ax=axes,
             square=False,
-            annot_kws={"size": 11 if len(mlca.methods) <=8 else 9,'rotation':0 if len(mlca.methods) <=8 else 60}
         )
         hm.tick_params(labelsize=8)
 
@@ -98,8 +97,7 @@ class LCAResultsPlot(FigureCanvasQTAgg):
 
 
 class LCAProcessContributionPlot(FigureCanvasQTAgg):
-    def __init__(self, parent, mlca, width=6, dpi=100):
-        height=4+len(mlca.func_units)*0.3
+    def __init__(self, parent, mlca, width=6, height=6, dpi=100):
         figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(121)
 
@@ -109,7 +107,7 @@ class LCAProcessContributionPlot(FigureCanvasQTAgg):
         method = 0  # TODO let user choose the LCIA method
         tc = mlca.top_process_contributions(method=method, limit=5, relative=True)
         df_tc = pd.DataFrame(tc)
-        df_tc.columns = [format_activity_label(a, style='fu') for a in tc.keys()]
+        df_tc.columns = [format_activity_label(a) for a in tc.keys()]
         df_tc.index = [format_activity_label(a, style='pl') for a in df_tc.index]
         plot = df_tc.T.plot.barh(
             stacked=True,
@@ -118,14 +116,14 @@ class LCAProcessContributionPlot(FigureCanvasQTAgg):
             ax=axes
         )
         plot.tick_params(labelsize=8)
-        plt.rc('legend', **{'fontsize': 8}) #putting below affects only LCAElementaryFlowContributionPlot
-        axes.legend(loc='center left', bbox_to_anchor=(1, 0.5),ncol=ceil((len(df_tc.index)*0.22)/height))
+        axes.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+        plt.rc('legend', **{'fontsize': 8})
         self.setMinimumSize(self.size())
 
 
 class LCAElementaryFlowContributionPlot(FigureCanvasQTAgg):
-    def __init__(self, parent, mlca, width=6, dpi=100):
-        figure = Figure(figsize=(width, 4+len(mlca.func_units)*0.3), dpi=dpi, tight_layout=True)
+    def __init__(self, parent, mlca, width=6, height=6, dpi=100):
+        figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
         axes = figure.add_subplot(121)
 
         super(LCAElementaryFlowContributionPlot, self).__init__(figure)
@@ -134,7 +132,7 @@ class LCAElementaryFlowContributionPlot(FigureCanvasQTAgg):
         method = 0  # TODO let user choose the LCIA method
         tc = mlca.top_elementary_flow_contributions(method=method, limit=5, relative=True)
         df_tc = pd.DataFrame(tc)
-        df_tc.columns = [format_activity_label(a, style='fu') for a in tc.keys()]
+        df_tc.columns = [format_activity_label(a) for a in tc.keys()]
         df_tc.index = [format_activity_label(a, style='bio') for a in df_tc.index]
         plot = df_tc.T.plot.barh(
             stacked=True,


### PR DESCRIPTION
Reverts LCA-ActivityBrowser/activity-browser#109

Sorry, I don't think this is ready yet. The labels were more informative before :
![image](https://user-images.githubusercontent.com/33026150/37451968-85e79e72-2833-11e8-949f-3dc38c8e4790.png)
Now I get this, which is less useful to the average user:
![image](https://user-images.githubusercontent.com/33026150/37451997-9cc0cee8-2833-11e8-9e0b-73e31705d12f.png)

Also, the code still contains an error as the reference for "ceil" cannot be resolved.
I suggest to improve these parts before we can merge it into the master code.
