### PR TITLE
Fix broken calculation setups

### DIFF
--- a/activity_browser/app/ui/tables/LCA_setup.py
+++ b/activity_browser/app/ui/tables/LCA_setup.py
@@ -122,7 +122,7 @@ class CSActivityTable(ABTableWidget):
         return [{self.item(row, 0).key: self.item(row, 0).text()} for row in range(self.rowCount())]
 
     def filter_amount_change(self, row, col):
-        if col == 1:
+        if col == 0:
             signals.calculation_setup_changed.emit()
 
 

--- a/activity_browser/app/ui/tables/LCA_setup.py
+++ b/activity_browser/app/ui/tables/LCA_setup.py
@@ -39,7 +39,7 @@ class CSActivityTable(ABTableWidget):
         4: "location",
         5: "database",
     }
-    HEADERS = ["Amount", "Unit", "Product", "Activity", "Location", "Database",]
+    HEADERS = ["Amount", "Unit", "Product", "Activity", "Location", "Database"]
 
     def __init__(self):
         super(CSActivityTable, self).__init__()
@@ -60,7 +60,20 @@ class CSActivityTable(ABTableWidget):
         self.cellChanged.connect(self.filter_amount_change)
         signals.calculation_setup_selected.connect(self.sync)
 
-    # @ABTableWidget.decorated_sync
+    def append_row(self, key, amount='1.0'):
+        act = bw.get_activity(key)
+        new_row = self.rowCount()
+        self.insertRow(new_row)
+        self.setItem(new_row, 0, ABTableItem(
+            amount, key=key, set_flags=[QtCore.Qt.ItemIsEditable], color="amount")
+        )
+        self.setItem(new_row, 1, ABTableItem(act.get('unit'), key=key, color="unit"))
+        self.setItem(new_row, 2, ABTableItem(act.get('reference product'),
+                                             key=key, color="product"))
+        self.setItem(new_row, 3, ABTableItem(act.get('name'), key=key, color="name"))
+        self.setItem(new_row, 4, ABTableItem(act.get('location'), key=key, color="location"))
+        self.setItem(new_row, 5, ABTableItem(act.get('database'), key=key, color="database"))
+
     def sync(self, name):
         self.cellChanged.disconnect(self.filter_amount_change)
         self.clear()
@@ -69,15 +82,7 @@ class CSActivityTable(ABTableWidget):
 
         for func_unit in bw.calculation_setups[name]['inv']:
             for key, amount in func_unit.items():
-                act = bw.get_activity(key)
-                new_row = self.rowCount()
-                self.insertRow(new_row)
-                self.setItem(new_row, 0, ABTableItem(amount, key=key, set_flags=[QtCore.Qt.ItemIsEditable], color="amount"))
-                self.setItem(new_row, 1, ABTableItem(act.get('unit'), key=key, color="unit"))
-                self.setItem(new_row, 2, ABTableItem(act.get('reference product'), key=key, color="product"))
-                self.setItem(new_row, 3, ABTableItem(act.get('name'), key=key, color="name"))
-                self.setItem(new_row, 4, ABTableItem(act.get('location'), key=key, color="location"))
-                self.setItem(new_row, 5, ABTableItem(act.get('database'), key=key, color="database"))
+                self.append_row(key, amount)
 
         self.resizeColumnsToContents()
         self.resizeRowsToContents()
@@ -104,12 +109,7 @@ class CSActivityTable(ABTableWidget):
             act = bw.get_activity(key)
             if act.get('type', 'process') != "process":
                 continue
-
-            new_row = self.rowCount()
-            self.insertRow(new_row)
-            self.setItem(new_row, 0, ABTableItem(act['name'], key=key, color="name"))
-            self.setItem(new_row, 1, ABTableItem("1.0", key=key, set_flags=[QtCore.Qt.ItemIsEditable], color="amount"))
-            self.setItem(new_row, 2, ABTableItem(act.get('unit', 'Unknown'), key=key, color="unit"))
+            self.append_row(key)
 
         event.accept()
 
@@ -119,7 +119,7 @@ class CSActivityTable(ABTableWidget):
         self.resizeRowsToContents()
 
     def to_python(self):
-        return [{self.item(row, 0).key: self.item(row, 1).text()} for row in range(self.rowCount())]
+        return [{self.item(row, 0).key: self.item(row, 0).text()} for row in range(self.rowCount())]
 
     def filter_amount_change(self, row, col):
         if col == 1:
@@ -128,6 +128,7 @@ class CSActivityTable(ABTableWidget):
 
 class CSMethodsTable(ABTableWidget):
     HEADERS = ["Name"]
+
     def __init__(self):
         super(CSMethodsTable, self).__init__()
         self.setColumnCount(len(self.HEADERS))


### PR DESCRIPTION
With the changes of column order in 1ca1ddd43dbdf0e9dfcfcbee3bfe4578b5ec4d2b, calculation setups were broken. Any modifications of CS with a version after this commit have been saved in a corrupted state (ie `unit` was saved instead of `amount`).

Also the CS wasn't saved anymore when the amount was edited, because the signals rely on column order.

This PR fixes these issues and also adds additional improvements to the lcia part of the LCA_setup_tab.

@bsteubing and @cardosan, you have both worked with the recent version of the AB in the last days and any Calculation Setups you modified during this time are likely to be broken, just as a heads-up. I will merge this fix immediately.