### PR TITLE
Copy activity from one database to another

### DIFF
--- a/activity_browser/app/bwutils/activity.py
+++ b/activity_browser/app/bwutils/activity.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import copy
+
+from bw2data.backends.peewee.proxies import ExchangeDataset, Activity
+from bw2data.backends.peewee.utils import dict_as_exchangedataset
+
+
+def copy_to_db(activity, database):
+    """modified from bw2data.backends.peewee.proxies.Activity.copy"""
+    new_act = Activity()
+    for key, value in activity.items():
+        new_act[key] = value
+    new_act._data['database'] = database.name
+    new_act.save()
+    for exc in activity.exchanges():
+        data = copy.deepcopy(exc._data)
+        data['output'] = new_act.key
+        # Change `input` for production exchanges
+        if exc['input'] == exc['output']:
+            data['input'] = new_act.key
+        ExchangeDataset.create(**dict_as_exchangedataset(data))
+    return new_act

--- a/activity_browser/app/bwutils/activity.py
+++ b/activity_browser/app/bwutils/activity.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
 
+import brightway2 as bw
 from bw2data.backends.peewee.proxies import ExchangeDataset, Activity
 from bw2data.backends.peewee.utils import dict_as_exchangedataset
 
@@ -19,4 +20,5 @@ def copy_to_db(activity, database):
         if exc['input'] == exc['output']:
             data['input'] = new_act.key
         ExchangeDataset.create(**dict_as_exchangedataset(data))
+    bw.databases.clean()
     return new_act

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -44,6 +44,7 @@ class Signals(QtCore.QObject):
     open_activity_tab = QtCore.pyqtSignal(str, tuple)
     activity_tabs_changed = QtCore.pyqtSignal()
     delete_activity = QtCore.pyqtSignal(tuple)
+    copy_to_db = QtCore.pyqtSignal(tuple)
 
     # Exchanges
     exchanges_output_modified = QtCore.pyqtSignal(list, tuple)

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -11,9 +11,11 @@ from ...signals import signals
 class ExchangeTable(ABTableWidget):
     COLUMN_LABELS = {
         # Production
-        (False, True): ["Amount", "Unit", "Product", "Activity","Location", "Database", "Uncertain"],
+        (False, True): ["Amount", "Unit", "Product", "Activity",
+                        "Location", "Database", "Uncertain"],
         # Normal technosphere
-        (False, False): ["Amount", "Unit", "Product", "Activity","Location", "Database", "Uncertain" ,"Formula"],
+        (False, False): ["Amount", "Unit", "Product", "Activity",
+                         "Location", "Database", "Uncertain", "Formula"],
         # Biosphere
         (True, False): ["Amount", "Unit", "Name", "Categories", "Database", "Uncertain"],
     }
@@ -126,28 +128,41 @@ class ExchangeTable(ABTableWidget):
             edit_flag = [QtCore.Qt.ItemIsEditable]
 
             self.setItem(row, 3, ABTableItem(obj.get('database')))
-            self.setItem(row, 5, ABTableItem("True" if exc.get("uncertainty type", 0) > 1 else "False"))
+            self.setItem(row, 5, ABTableItem(
+                "True" if exc.get("uncertainty type", 0) > 1 else "False"
+            ))
 
             if self.biosphere:  # "Name", "Amount", "Unit", "Database", "Categories", "Uncertain"
-                self.setItem(row, 0, ABTableItem("{:.4g}".format(exc.get('amount')), exchange=exc, set_flags=edit_flag,
-                                                 color="amount"))
+                self.setItem(row, 0, ABTableItem("{:.4g}".format(exc.get('amount')), exchange=exc,
+                                                 set_flags=edit_flag, color="amount"))
                 self.setItem(row, 1, ABTableItem(obj.get('unit', 'Unknown'), color="unit"))
-                self.setItem(row, 2, ABTableItem(obj.get('name'), exchange=exc, direction=direction, color="name"))
-                self.setItem(row, 3, ABTableItem(" - ".join(obj.get('categories', [])), color="categories"))
+                self.setItem(row, 2, ABTableItem(
+                    obj.get('name'), exchange=exc, direction=direction, color="name"
+                ))
+                self.setItem(row, 3, ABTableItem(
+                    " - ".join(obj.get('categories', [])), color="categories"
+                ))
                 self.setItem(row, 4, ABTableItem(obj.get('database'), color="database"))
-                self.setItem(row, 5, ABTableItem("True" if exc.get("uncertainty type", 0) > 1 else "False"))
+                self.setItem(row, 5, ABTableItem(
+                    "True" if exc.get("uncertainty type", 0) > 1 else "False"
+                ))
 
             else:  # "Activity", "Product", "Amount", "Database", "Location", "Unit", "Uncertain", "Formula"
-                self.setItem(row, 0,
-                             ABTableItem("{:.4g}".format(exc.get('amount')), exchange=exc, set_flags=edit_flag,
-                                         color="amount"))
+                self.setItem(row, 0, ABTableItem("{:.4g}".format(exc.get('amount')), exchange=exc,
+                                                 set_flags=edit_flag, color="amount"))
                 self.setItem(row, 1, ABTableItem(obj.get('unit', 'Unknown'), color="unit"))
-                self.setItem(row, 2, ABTableItem(obj.get('reference product') or obj.get("name"), exchange=exc,
-                                                 direction=direction, color="reference product"))
-                self.setItem(row, 3, ABTableItem(obj.get('name'), exchange=exc, direction=direction, color="name"))
+                self.setItem(row, 2, ABTableItem(
+                    obj.get('reference product') or obj.get("name"), exchange=exc,
+                    direction=direction, color="reference product"
+                ))
+                self.setItem(row, 3, ABTableItem(
+                    obj.get('name'), exchange=exc, direction=direction, color="name")
+                )
                 self.setItem(row, 4, ABTableItem(obj.get('location', 'Unknown'), color="location"))
                 self.setItem(row, 5, ABTableItem(obj.get('database'), color="database"))
-                self.setItem(row, 6, ABTableItem("True" if exc.get("uncertainty type", 0) > 1 else "False"))
+                self.setItem(row, 6, ABTableItem(
+                    "True" if exc.get("uncertainty type", 0) > 1 else "False")
+                )
                 self.setItem(row, 7, ABTableItem(exc.get('formula', '')))
 
         self.ignore_changes = False

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -72,13 +72,13 @@ class DatabasesTable(ABTableWidget):
         for row, name in enumerate(natural_sort(bw.databases)):
             self.setItem(row, 0, ABTableItem(name, db_name=name))
             depends = bw.databases[name].get('depends', [])
-            self.setItem(row, 1, ABTableItem("; ".join(depends), db_name=name))
+            self.setItem(row, 1, ABTableItem(", ".join(depends), db_name=name))
             dt = bw.databases[name].get('modified', '')
             if dt:
                 dt = arrow.get(dt).shift(hours=-1).humanize()
             self.setItem(row, 2, ABTableItem(dt, db_name=name))
             self.setItem(
-                row, 3, ABTableItem(str(bw.databases[name].get('number', [])), db_name=name)
+                row, 3, ABTableItem(str(len(bw.Database(name))), db_name=name)
             )
             self.setItem(row, 4, ABTableItem(None, set_flags=[QtCore.Qt.ItemIsUserCheckable]))
 
@@ -159,10 +159,14 @@ class ActivitiesTable(ABTableWidget):
         self.open_left_tab_action = QtWidgets.QAction(
             QtGui.QIcon(icons.left), "Open in new tab", None
         )
+        self.copy_to_db_action = QtWidgets.QAction(
+            QtGui.QIcon(icons.add_db), 'Copy to database', None
+        )
         self.addAction(self.add_activity_action)
         self.addAction(self.copy_activity_action)
         self.addAction(self.delete_activity_action)
         self.addAction(self.open_left_tab_action)
+        self.addAction(self.copy_to_db_action)
         self.add_activity_action.triggered.connect(
             lambda: signals.new_activity.emit(self.database.name)
         )
@@ -174,6 +178,9 @@ class ActivitiesTable(ABTableWidget):
         )
         self.open_left_tab_action.triggered.connect(
             lambda x: signals.open_activity_tab.emit("activities", self.currentItem().key)
+        )
+        self.copy_to_db_action.triggered.connect(
+            lambda: signals.copy_to_db.emit(self.currentItem().key)
         )
 
     def connect_signals(self):


### PR DESCRIPTION
This PR implements the functionality mentioned in #71. This allows to copy an activity from one database (ie. the background dbs) to a new database. This allows for quick iterations of copy/modify/delete tasks of ecoinvent process without modifying the background system. Eg. create a new db, copy an ecoinvent process, modify the flows and check the effects on impacts.

This is in my opinion a prerequisite for read-only-databases (#58), because otherwise working with copies of ecoinvent processes wouldn't be possible, unless they are manually reconstructed.

I'm not sure if I overlooked something in the brightway codebase, but I couldn't find a simple way to do this and it was surprisingly difficult for me to get it working. Do you think `copy_to_db`-function would be a useful addition to bw2data, @cmutel? I can make a PR. 