### PR TITLE
Loading new brightway directory should work now...

### DIFF
--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -101,10 +101,7 @@ def get_exchanges_data(exchanges):
 def get_startup_bw_dir():
     """Returns the brightway directory as defined in the settings file.
     If it has not been defined here, it returns the brightway default directory."""
-    if ab_settings.settings.get('custom_bw_dir') is not None:
-        return ab_settings.settings['custom_bw_dir']
-    else:  # not defined in settings
-        return get_default_bw_dir()
+    return ab_settings.settings.get('custom_bw_dir', get_default_bw_dir())
 
 
 def get_default_bw_dir():
@@ -113,13 +110,14 @@ def get_default_bw_dir():
 
 
 def get_current_bw_dir():
+    """Returns the current used brightway directory."""
     return bw.projects._base_data_dir
 
 
 def get_startup_project_name():
     """Returns the startup or default project name."""
     custom_startup = ab_settings.settings.get('startup_project')
-    if custom_startup is not None and custom_startup in bw.projects:
+    if custom_startup in bw.projects:
         return ab_settings.settings['startup_project']
     else:
         return get_default_project_name()

--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -6,6 +6,8 @@ import brightway2 as bw
 from bw2data.utils import natural_sort
 from bw2data import databases
 
+from ..settings import ab_settings
+
 
 def wrap_text(string, max_lenght=80):
     """wrap the label making sure that key and name are in 2 rows"""
@@ -94,3 +96,40 @@ def get_exchanges_data(exchanges):
         results.append(exc)
     for r in results:
         print(r)
+
+
+def get_startup_bw_dir():
+    """Returns the brightway directory as defined in the settings file.
+    If it has not been defined here, it returns the brightway default directory."""
+    if ab_settings.settings.get('custom_bw_dir') is not None:
+        return ab_settings.settings['custom_bw_dir']
+    else:  # not defined in settings
+        return get_default_bw_dir()
+
+
+def get_default_bw_dir():
+    """Returns the default brightway directory."""
+    return bw.projects._get_base_directories()[0]
+
+
+def get_current_bw_dir():
+    return bw.projects._base_data_dir
+
+
+def get_startup_project_name():
+    """Returns the startup or default project name."""
+    custom_startup = ab_settings.settings.get('startup_project')
+    if custom_startup is not None and custom_startup in bw.projects:
+        return ab_settings.settings['startup_project']
+    else:
+        return get_default_project_name()
+
+
+def get_default_project_name():
+    """Returns the default project name."""
+    if "default" in bw.projects:
+        return "default"
+    elif len(bw.projects):
+        return next(iter(bw.projects)).name
+    else:
+        return None

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -20,10 +20,11 @@ class Controller(object):
     def __init__(self, window):
         self.window = window
         self.connect_signals()
-        print('Brightway2 data directory: {}'.format(bw.projects._base_data_dir))
-        print('Brightway2 active project: {}'.format(bw.projects.current))
+        signals.project_selected.emit()
         self.load_settings()
         self.db_wizard = None
+        print('Brightway2 data directory: {}'.format(bw.projects._base_data_dir))
+        print('Brightway2 active project: {}'.format(bw.projects.current))
 
     def load_settings(self):
         if ab_settings.settings:
@@ -32,8 +33,6 @@ class Controller(object):
                 self.switch_brightway2_dir_path(dirpath=ab_settings.settings['custom_bw_dir'])
             if ab_settings.settings.get('startup_project'):
                 self.change_project(ab_settings.settings['startup_project'])
-        else:
-            signals.project_selected.emit()
 
     def connect_signals(self):
         # SLOTS

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -28,9 +28,9 @@ class Controller(object):
     def load_settings(self):
         if ab_settings.settings:
             print("Loading user settings:")
-            if ab_settings.settings.get('custom_bw_dir') is not None:
+            if ab_settings.settings.get('custom_bw_dir'):
                 self.switch_brightway2_dir_path(dirpath=ab_settings.settings['custom_bw_dir'])
-            if ab_settings.settings.get('startup_project') is not None:
+            if ab_settings.settings.get('startup_project'):
                 self.change_project(ab_settings.settings['startup_project'])
         else:
             signals.project_selected.emit()

--- a/activity_browser/app/ui/tables/LCA_setup.py
+++ b/activity_browser/app/ui/tables/LCA_setup.py
@@ -61,18 +61,21 @@ class CSActivityTable(ABTableWidget):
         signals.calculation_setup_selected.connect(self.sync)
 
     def append_row(self, key, amount='1.0'):
-        act = bw.get_activity(key)
-        new_row = self.rowCount()
-        self.insertRow(new_row)
-        self.setItem(new_row, 0, ABTableItem(
-            amount, key=key, set_flags=[QtCore.Qt.ItemIsEditable], color="amount")
-        )
-        self.setItem(new_row, 1, ABTableItem(act.get('unit'), key=key, color="unit"))
-        self.setItem(new_row, 2, ABTableItem(act.get('reference product'),
-                                             key=key, color="product"))
-        self.setItem(new_row, 3, ABTableItem(act.get('name'), key=key, color="name"))
-        self.setItem(new_row, 4, ABTableItem(act.get('location'), key=key, color="location"))
-        self.setItem(new_row, 5, ABTableItem(act.get('database'), key=key, color="database"))
+        try:
+            act = bw.get_activity(key)
+            new_row = self.rowCount()
+            self.insertRow(new_row)
+            self.setItem(new_row, 0, ABTableItem(
+                amount, key=key, set_flags=[QtCore.Qt.ItemIsEditable], color="amount")
+            )
+            self.setItem(new_row, 1, ABTableItem(act.get('unit'), key=key, color="unit"))
+            self.setItem(new_row, 2, ABTableItem(act.get('reference product'),
+                                                 key=key, color="product"))
+            self.setItem(new_row, 3, ABTableItem(act.get('name'), key=key, color="name"))
+            self.setItem(new_row, 4, ABTableItem(act.get('location'), key=key, color="location"))
+            self.setItem(new_row, 5, ABTableItem(act.get('database'), key=key, color="database"))
+        except:
+            print("Could not load key in Calculation Setup: ", key)
 
     def sync(self, name):
         self.current_cs = name

--- a/activity_browser/app/ui/tables/projects.py
+++ b/activity_browser/app/ui/tables/projects.py
@@ -24,7 +24,6 @@ class ProjectListWidget(QtWidgets.QComboBox):
         index = self.project_names.index(projects.current)
         self.setCurrentIndex(index)
 
-
     def on_activated(self, index):
         signals.change_project.emit(self.project_names[index])
 

--- a/activity_browser/app/ui/web/webutils.py
+++ b/activity_browser/app/ui/web/webutils.py
@@ -34,12 +34,12 @@ class RestrictedWebViewWidget(QtWidgets.QWidget):
         self.page = RestrictedQWebEnginePage()
 
         if html_file:
-            print("Loading File:", html_file)
+            # print("Loading File:", html_file)
             self.url = QtCore.QUrl.fromLocalFile(html_file)
             self.page.allowed_pages.append(self.url)
             self.page.load(self.url)
         elif url:
-            print("Loading URL:", url)
+            # print("Loading URL:", url)
             self.url = QtCore.QUrl(url)
             self.page.allowed_pages.append(self.url)
             self.page.load(self.url)

--- a/activity_browser/app/ui/widgets/settings_wizard.py
+++ b/activity_browser/app/ui/widgets/settings_wizard.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 from PyQt5 import QtWidgets
+import os
 
 from ...bwutils import commontasks as bc
 from ...signals import signals
@@ -107,7 +108,10 @@ class SettingsPage(QtWidgets.QWizardPage):
             print("No projects found in this directory.")
 
     def restore_defaults(self):
-        self.bwdir_edit.setText(bc.get_default_bw_dir())
+        default_path = bc.get_default_bw_dir()
+        print("Default path:", default_path)
+        print("Default path:", os.path(default_path))
+        self.bwdir_edit.setText(default_path)
         signals.switch_bw2_dir_path.emit(bc.get_default_bw_dir())
         self.update_project_combo()
         if 'default' in self.project_names:

--- a/activity_browser/app/ui/widgets/settings_wizard.py
+++ b/activity_browser/app/ui/widgets/settings_wizard.py
@@ -128,7 +128,7 @@ class SettingsPage(QtWidgets.QWizardPage):
             # ask user if to switch directory (which will update the project combobox correctly)
             reply = QtWidgets.QMessageBox.question(self,
                                                    'Continue?',
-                                                   'Would you like to switch to this directory now? \nThis will close your currently opened project. \nDo this to choose the startup project.',
+                                                   'Would you like to switch to this directory now? \nThis will close your currently opened project. \nClick "Yes" to be able to choose the startup project.',
                                                    QtWidgets.QMessageBox.Yes,
                                                    QtWidgets.QMessageBox.No)
             if reply == QtWidgets.QMessageBox.Yes:


### PR DESCRIPTION
@haasad: this PR links to #135: Could you please check if it works? You can simply switch to any directory in the settings... if no bw projects exist in this directory, it should give you an empty projects combobox (and it will make a projects.db, which you may want to delete afterwards). 

This should also fix the peewee errors in #135, which were related to bw.get_activity() not throwing the TypeError as peewee already throws an error (@cmutel FYI). (I have a calculation setup with an activity that I have deleted...)