### PR TITLE
Some minor ui changes

### DIFF
--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PyQt5 import QtCore
+from PyQt5 import QtCore, QtWidgets
 
 
 class Signals(QtCore.QObject):
@@ -66,6 +66,9 @@ class Signals(QtCore.QObject):
 
     method_selected = QtCore.pyqtSignal(tuple)
     method_tabs_changed = QtCore.pyqtSignal()
+
+    # Qt Windows
+    update_windows = QtCore.pyqtSignal()
 
 
 signals = Signals()

--- a/activity_browser/app/ui/main.py
+++ b/activity_browser/app/ui/main.py
@@ -68,13 +68,13 @@ class MainWindow(QtWidgets.QMainWindow):
         working_layout.addWidget(header("Program output:"))
         working_layout.addWidget(self.log)
 
-        self.working_widget = QtWidgets.QWidget()
-        self.working_widget.name = "&Debug Window"
-        self.working_widget.setLayout(working_layout)
+        self.debug_widget = QtWidgets.QWidget()
+        self.debug_widget.name = "&Debug Window"
+        self.debug_widget.setLayout(working_layout)
 
         self.stacked = QtWidgets.QStackedWidget()
         self.stacked.addWidget(self.main_widget)
-        self.stacked.addWidget(self.working_widget)
+        self.stacked.addWidget(self.debug_widget)
         self.setCentralWidget(self.stacked)
 
         # Layout: extra items outside main layout
@@ -92,12 +92,21 @@ class MainWindow(QtWidgets.QMainWindow):
         self.shortcut_debug.activated.connect(self.toggle_debug_window)
 
     def toggle_debug_window(self):
-        if self.stacked.currentIndex() == self.stacked.indexOf(self.main_widget):
+        """Toggle between any window and the debug window."""
+        if self.stacked.currentWidget() != self.debug_widget:
+            self.last_widget = self.stacked.currentWidget()
+            self.stacked.setCurrentWidget(self.debug_widget)
             # print("Switching to debug window")
-            self.stacked.setCurrentWidget(self.working_widget)
         else:
-            # print("Switching to Main window")
-            self.stacked.setCurrentWidget(self.main_widget)
+            # print("Switching back to last widget")
+            if self.last_widget:
+                try:
+                    self.stacked.setCurrentWidget(self.last_widget)
+                except:
+                    print("Previous Widget has been deleted in the meantime. Switching to main window.")
+                    self.stacked.setCurrentWidget(self.main_widget)
+            else:  # switch to main window
+                self.stacked.setCurrentWidget(self.main_widget)
 
     def add_tab_to_panel(self, obj, label, side):
         panel = self.left_panel if side == 'left' else self.right_panel

--- a/activity_browser/app/ui/main.py
+++ b/activity_browser/app/ui/main.py
@@ -56,12 +56,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.vertical_container.addLayout(self.main_horizontal_box)
 
         self.main_widget = QtWidgets.QWidget()
+        self.main_widget.name = "&Main Window"
         self.main_widget.setLayout(self.vertical_container)
-
-        # Layout: extra items outside main layout
-        self.menu_bar = MenuBar(self)
-        self.toolbar = Toolbar(self)
-        self.statusbar = Statusbar(self)
 
         # Debug/working... stack
         self.log = QtWidgets.QTextEdit(self)
@@ -73,6 +69,7 @@ class MainWindow(QtWidgets.QMainWindow):
         working_layout.addWidget(self.log)
 
         self.working_widget = QtWidgets.QWidget()
+        self.working_widget.name = "&Debug Window"
         self.working_widget.setLayout(working_layout)
 
         self.stacked = QtWidgets.QStackedWidget()
@@ -80,10 +77,27 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stacked.addWidget(self.working_widget)
         self.setCentralWidget(self.stacked)
 
+        # Layout: extra items outside main layout
+        self.menu_bar = MenuBar(self)
+        self.toolbar = Toolbar(self)
+        self.statusbar = Statusbar(self)
+
         self.connect_signals()
 
     def connect_signals(self):
         signals.copy_selection_to_clipboard.connect(self.set_clipboard_text)
+
+        # Keyboard shortcuts
+        self.shortcut_debug = QtWidgets.QShortcut(QtGui.QKeySequence("Ctrl+D"), self)
+        self.shortcut_debug.activated.connect(self.toggle_debug_window)
+
+    def toggle_debug_window(self):
+        if self.stacked.currentIndex() == self.stacked.indexOf(self.main_widget):
+            # print("Switching to debug window")
+            self.stacked.setCurrentWidget(self.working_widget)
+        else:
+            # print("Switching to Main window")
+            self.stacked.setCurrentWidget(self.main_widget)
 
     def add_tab_to_panel(self, obj, label, side):
         panel = self.left_panel if side == 'left' else self.right_panel

--- a/activity_browser/app/ui/menu_bar.py
+++ b/activity_browser/app/ui/menu_bar.py
@@ -16,9 +16,15 @@ class MenuBar(object):
         self.menubar = QtWidgets.QMenuBar()
         self.menubar.addMenu(self.setup_file_menu())
         # self.menubar.addMenu(self.setup_extensions_menu())
+        self.menubar.addMenu(self.setup_windows_menu())
         self.menubar.addMenu(self.setup_help_menu())
         window.setMenuBar(self.menubar)
+        self.connect_signals()
 
+    def connect_signals(self):
+        signals.update_windows.connect(self.update_windows_menu)
+
+    # FILE
     def setup_file_menu(self):
         menu = QtWidgets.QMenu('&File', self.window)
         menu.addAction(
@@ -31,6 +37,25 @@ class MenuBar(object):
         )
         return menu
 
+    # WINDOWS
+    def setup_windows_menu(self):
+        self.windows_menu = QtWidgets.QMenu('&Windows', self.window)
+        self.update_windows_menu()
+        return self.windows_menu
+
+    def update_windows_menu(self):
+        print("Updating Windows:")
+        self.windows_menu.clear()
+        for index in range(self.window.stacked.count()):  # iterate over widgets in QStackedWidget
+            widget = self.window.stacked.widget(index)
+            # print(widget)
+            # print(widget.name)
+            self.windows_menu.addAction(
+                widget.name,
+                lambda widget=widget: self.window.stacked.setCurrentWidget(widget),
+            )
+
+    # HELP
     def setup_help_menu(self):
         bug_icon = QtGui.QIcon(icons.debug)
         help_menu = QtWidgets.QMenu('&Help', self.window)

--- a/activity_browser/app/ui/menu_bar.py
+++ b/activity_browser/app/ui/menu_bar.py
@@ -44,12 +44,9 @@ class MenuBar(object):
         return self.windows_menu
 
     def update_windows_menu(self):
-        print("Updating Windows:")
         self.windows_menu.clear()
         for index in range(self.window.stacked.count()):  # iterate over widgets in QStackedWidget
             widget = self.window.stacked.widget(index)
-            # print(widget)
-            # print(widget.name)
             self.windows_menu.addAction(
                 widget.name,
                 lambda widget=widget: self.window.stacked.setCurrentWidget(widget),

--- a/activity_browser/app/ui/tabs/LCA_setup.py
+++ b/activity_browser/app/ui/tabs/LCA_setup.py
@@ -188,3 +188,4 @@ class LCASetupTab(QtWidgets.QWidget):
         self.sankey = SankeyWidget(self)
         self.window.stacked.addWidget(self.sankey)
         self.window.stacked.setCurrentWidget(self.sankey)
+        signals.update_windows.emit()

--- a/activity_browser/app/ui/toolbar.py
+++ b/activity_browser/app/ui/toolbar.py
@@ -47,15 +47,14 @@ class Toolbar(QtWidgets.QToolBar):
         self.copy_project_button = QtWidgets.QPushButton(QtGui.QIcon(icons.copy), 'Copy current')
         self.delete_project_button = QtWidgets.QPushButton(QtGui.QIcon(icons.delete), 'Delete current')
 
-        self.addWidget(QtWidgets.QLabel('Brightway2 Activity Browser'))
         self.addWidget(switch_stack_button)
         self.addWidget(self.project_read_only)
 
         spacer = QtWidgets.QWidget()
-        spacer.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding,
-            QtWidgets.QSizePolicy.Expanding
-        )
+        # spacer.setSizePolicy(
+        #     QtWidgets.QSizePolicy.Expanding,
+        #     QtWidgets.QSizePolicy.Expanding
+        # )
         self.addWidget(spacer)
         self.addSeparator()
 
@@ -86,7 +85,6 @@ class Toolbar(QtWidgets.QToolBar):
             create_issue(text)
 
     def set_project_label(self):
-        name = projects.current
         self.project_read_only.setText('')
         if projects.read_only:
             self.project_read_only.setText('Read Only Project')

--- a/activity_browser/app/ui/toolbar.py
+++ b/activity_browser/app/ui/toolbar.py
@@ -36,7 +36,6 @@ class Toolbar(QtWidgets.QToolBar):
         )
         switch_stack_button.clicked.connect(switch_stack_button.switch_state)
 
-        self.project_name_label = QtWidgets.QLabel('Project: default')
         self.project_read_only = QtWidgets.QLabel('Read only')
         self.project_read_only.setStyleSheet('QLabel {color: red;}')
         if projects.read_only:
@@ -50,7 +49,6 @@ class Toolbar(QtWidgets.QToolBar):
 
         self.addWidget(QtWidgets.QLabel('Brightway2 Activity Browser'))
         self.addWidget(switch_stack_button)
-        self.addWidget(self.project_name_label)
         self.addWidget(self.project_read_only)
 
         spacer = QtWidgets.QWidget()
@@ -89,7 +87,6 @@ class Toolbar(QtWidgets.QToolBar):
 
     def set_project_label(self):
         name = projects.current
-        self.project_name_label.setText('Project: {}'.format(name))
         self.project_read_only.setText('')
         if projects.read_only:
             self.project_read_only.setText('Read Only Project')

--- a/activity_browser/app/ui/web/sankey/sankey.py
+++ b/activity_browser/app/ui/web/sankey/sankey.py
@@ -15,6 +15,7 @@ from .worker_threads import gt_worker_thread
 class SankeyWidget(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.name = "&Sankey Diagram"
         self.label = QtWidgets.QLabel('hello')
         self.grid_lay = QtWidgets.QGridLayout()
         self.grid_lay.addWidget(QtWidgets.QLabel('Activity: '), 0, 0)


### PR DESCRIPTION
Now we are able to switch to any window in the stacked widget of the main window. 
Also implemented a CTRL+D shortcut to toggle between the Debug window and any other window. 
My suggestion would now be to even remove the debug button from the toolbar as we know the shortcut and anyone can still switch to it via the "Windows" Menu. I think the debug window is mostly for developers.. .and they can deal with shortcuts :-) What do you think?