### PR TITLE
use appdirs to save user data

### DIFF
--- a/activity_browser/app/settings.py
+++ b/activity_browser/app/settings.py
@@ -10,7 +10,7 @@ from .. import PACKAGE_DIRECTORY
 
 class ABSettings():
     def __init__(self):
-        ab_dir = appdirs.AppDirs('ActivityBrowser', 'ABData')
+        ab_dir = appdirs.AppDirs('ActivityBrowser', 'ActivityBrowser')
         self.data_dir = ab_dir.user_data_dir
         if not os.path.isdir(self.data_dir):
             os.mkdirs(self.data_dir)

--- a/activity_browser/app/settings.py
+++ b/activity_browser/app/settings.py
@@ -9,6 +9,10 @@ from .. import PACKAGE_DIRECTORY
 
 
 class ABSettings():
+    """
+    Interface to the json settings file. Will create a userdata directory via appdirs if not
+    already present.
+    """
     def __init__(self):
         ab_dir = appdirs.AppDirs('ActivityBrowser', 'ActivityBrowser')
         self.data_dir = ab_dir.user_data_dir
@@ -22,6 +26,10 @@ class ABSettings():
             self.settings = {}
 
     def move_old_settings(self):
+        """
+        legacy code: This function is only required for compatibility with the old settings file and
+        can be removed in a future release
+        """
         if not os.path.exists(self.settings_file):
             old_settings = os.path.join(PACKAGE_DIRECTORY, 'ABsettings.json')
             if os.path.exists(old_settings):

--- a/activity_browser/app/settings.py
+++ b/activity_browser/app/settings.py
@@ -13,7 +13,7 @@ class ABSettings():
         ab_dir = appdirs.AppDirs('ActivityBrowser', 'ActivityBrowser')
         self.data_dir = ab_dir.user_data_dir
         if not os.path.isdir(self.data_dir):
-            os.mkdirs(self.data_dir)
+            os.makedirs(self.data_dir, exist_ok=True)
         self.settings_file = os.path.join(self.data_dir, 'ABsettings.json')
         self.move_old_settings()
         if os.path.isfile(self.settings_file):

--- a/activity_browser/app/settings.py
+++ b/activity_browser/app/settings.py
@@ -1,17 +1,34 @@
 # -*- coding: utf-8 -*-
 import os
 import json
+import shutil
+
+import appdirs
 
 from .. import PACKAGE_DIRECTORY
 
 
 class ABSettings():
     def __init__(self):
-        self.settings_file = os.path.join(PACKAGE_DIRECTORY, 'ABsettings.json')
+        ab_dir = appdirs.AppDirs('ActivityBrowser', 'ABData')
+        self.data_dir = ab_dir.user_data_dir
+        if not os.path.isdir(self.data_dir):
+            os.mkdir(self.data_dir)
+        self.settings_file = os.path.join(self.data_dir, 'ABsettings.json')
+        self.move_old_settings()
         if os.path.isfile(self.settings_file):
             self.load_settings()
         else:
             self.settings = {}
+
+    def move_old_settings(self):
+        if not os.path.exists(self.settings_file):
+            old_settings = os.path.join(PACKAGE_DIRECTORY, 'ABsettings.json')
+            print(old_settings)
+            print(os.path.exists(old_settings))
+            if os.path.exists(old_settings):
+                print('called')
+                shutil.copyfile(old_settings, self.settings_file)
 
     def load_settings(self):
         with open(self.settings_file, 'r') as infile:

--- a/activity_browser/app/settings.py
+++ b/activity_browser/app/settings.py
@@ -13,7 +13,7 @@ class ABSettings():
         ab_dir = appdirs.AppDirs('ActivityBrowser', 'ABData')
         self.data_dir = ab_dir.user_data_dir
         if not os.path.isdir(self.data_dir):
-            os.mkdir(self.data_dir)
+            os.mkdirs(self.data_dir)
         self.settings_file = os.path.join(self.data_dir, 'ABsettings.json')
         self.move_old_settings()
         if os.path.isfile(self.settings_file):
@@ -24,10 +24,7 @@ class ABSettings():
     def move_old_settings(self):
         if not os.path.exists(self.settings_file):
             old_settings = os.path.join(PACKAGE_DIRECTORY, 'ABsettings.json')
-            print(old_settings)
-            print(os.path.exists(old_settings))
             if os.path.exists(old_settings):
-                print('called')
                 shutil.copyfile(old_settings, self.settings_file)
 
     def load_settings(self):


### PR DESCRIPTION
This is an old topic, that we already discussed earlier: https://github.com/LCA-ActivityBrowser/activity-browser/pull/103#discussion_r168744317
In my opinion, we should not write anything to `PACKAGE_DIRECTORY`, since it's a) under version control and b) not guaranteed to be writable (see old comment linked above). I also think that the AB settings shouldn't be tied to a specific conda env, same as brightway-projects aren't tied to a single brightway installation.

You had some reservations about this @bsteubing the last time we discussed this, any thoughts on this?