### PR TITLE
dependencies are managed with the conda recipe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-brightway2
-bw2io >= 0.7.dev1
-pyqt
-seaborn
-arrow
-pandas
-beautifulsoup4
-patool
-fuzzywuzzy

--- a/setup.py
+++ b/setup.py
@@ -23,17 +23,7 @@ setup(
     author="Bernhard Steubing",
     author_email="b.steubing@cml.leidenuniv.nl",
     license=open('LICENSE').read(),
-    install_requires=[
-        'brightway2',
-        'bw2io >=0.7.dev1'
-        'pyqt5',
-        'seaborn',
-        'arrow',
-        'pandas',
-        'beautifulsoup4',
-        'patool',
-        'fuzzywuzzy'
-    ],
+    install_requires=[], # dependency management in conda recipe
     url="https://github.com/LCA-ActivityBrowser/activity-browser",
     long_description=open('README.md').read(),
     description=('Brightway2 GUI'),


### PR DESCRIPTION
The AB should only be installed with conda. Installing via pip is technically possible (eg. with `pip install https://github.com/LCA-ActivityBrowser/activity-browser/archive/2.2.4.zip`), but the AB is borderline unusable because it's so slow without pypardiso. There is also no way currently to download a [cross-platfrom 7zip extractor](https://anaconda.org/haasad/eidl7zip) with pip. We also never made the effort to put the AB on pypi because of this.

I propose that we get rid of the `requirements.txt` file and the dependencies in `setup.py`, because these create the wrong impression that the AB is working with pip. Eg. Chris' PR #181.

What do you think @bsteubing?

