### PR TITLE
Compatibility with regionalization

### DIFF
--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -24,10 +24,10 @@ def format_activity_label(act, style='pnl', max_length=40):
         if style == 'pnl':
             label = wrap_text(
                 '\n'.join([a.get('reference product', ''), a.get('name', ''),
-                           a.get('location', '')]), max_length=max_length)
+                           str(a.get('location', ''))]), max_length=max_length)
         elif style == 'pl':
             label = wrap_text(', '.join([a.get('reference product', '') or a.get('name', ''),
-                                         a.get('location', ''),
+                                         str(a.get('location', '')),
                                          ]), max_length=40)
         elif style == 'key':
             label = wrap_text(str(a.key))  # safer to use key, code does not always exist
@@ -39,7 +39,7 @@ def format_activity_label(act, style='pnl', max_length=40):
         else:
             label = wrap_text(
                 '\n'.join([a.get('reference product', ''), a.get('name', ''),
-                           a.get('location', '')]))
+                           str(a.get('location', ''))]))
     except:
         if isinstance(act, tuple):
             return wrap_text(str(''.join(act)))

--- a/activity_browser/app/ui/tables/LCA_setup.py
+++ b/activity_browser/app/ui/tables/LCA_setup.py
@@ -72,7 +72,7 @@ class CSActivityTable(ABTableWidget):
             self.setItem(new_row, 2, ABTableItem(act.get('reference product'),
                                                  key=key, color="product"))
             self.setItem(new_row, 3, ABTableItem(act.get('name'), key=key, color="name"))
-            self.setItem(new_row, 4, ABTableItem(act.get('location'), key=key, color="location"))
+            self.setItem(new_row, 4, ABTableItem(str(act.get('location')), key=key, color="location"))
             self.setItem(new_row, 5, ABTableItem(act.get('database'), key=key, color="database"))
         except:
             print("Could not load key in Calculation Setup: ", key)

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -164,7 +164,7 @@ class ExchangeTable(ABTableWidget):
                 self.setItem(row, 3, ABTableItem(
                     obj.get('name'), exchange=exc, direction=direction, color="name")
                 )
-                self.setItem(row, 4, ABTableItem(obj.get('location', 'Unknown'), color="location"))
+                self.setItem(row, 4, ABTableItem(str(obj.get('location', 'Unknown')), color="location"))
                 self.setItem(row, 5, ABTableItem(obj.get('database'), color="database"))
                 self.setItem(row, 6, ABTableItem(
                     "True" if exc.get("uncertainty type", 0) > 1 else "False")

--- a/activity_browser/app/ui/tables/history.py
+++ b/activity_browser/app/ui/tables/history.py
@@ -56,7 +56,10 @@ class ActivitiesHistoryTable(ABTableWidget):
         ds = bw.get_activity(key)
         self.insertRow(0)
         for col, value in self.COLUMNS.items():
-            self.setItem(0, col, ABTableItem(ds.get(value, ''), key=key, color=value))
+            if value == 'location':
+                self.setItem(0, col, ABTableItem(str(ds.get(value, '')), key=key, color=value))
+            else:
+                self.setItem(0, col, ABTableItem(ds.get(value, ''), key=key, color=value))
 
         self.resizeColumnsToContents()
         self.resizeRowsToContents()

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -218,9 +218,12 @@ class ActivitiesTable(ABTableWidget):
         self.setHorizontalHeaderLabels(self.HEADERS)
         for row, ds in enumerate(data):
             for col, value in self.COLUMNS.items():
-                self.setItem(row, col, ABTableItem(ds.get(value, ''), key=ds.key, color=value))
                 if value == "key":
                     self.setItem(row, col, ABTableItem(str(ds.key), key=ds.key, color=value))
+                elif value == "location":
+                    self.setItem(row, col, ABTableItem(str(ds.get(value, '')), key=ds.key, color=value))
+                else:
+                    self.setItem(row, col, ABTableItem(ds.get(value, ''), key=ds.key, color=value))
 
     def filter_database_changed(self, database_name):
         if not hasattr(self, "database") or self.database.name != database_name:

--- a/activity_browser/app/ui/widgets/activity.py
+++ b/activity_browser/app/ui/widgets/activity.py
@@ -95,7 +95,7 @@ class ActivityDataGrid(QtWidgets.QWidget):
         self.database.setText(self.activity['database'])
         self.name_box.setText(self.activity['name'])
         self.name_box._key = self.activity.key
-        self.location_box.setText(self.activity.get('location', ''))
+        self.location_box.setText(str(self.activity.get('location', '')))
         self.location_box._key = self.activity.key
         self.comment_box.setPlainText(self.activity.get('comment', ''))
         # the <font> html-tag has no effect besides making the tooltip rich text


### PR DESCRIPTION
`bw2regional` namespaces locations using tuples, just like activity keys. So e.g. `"Europe with Switzerland"` becomes `("ecoinvent", "Europe with Switzerland")`. The current code doesn't like these tuples, so this PR casts them to strings. This effectively makes them read only (storing them as strings would break the functionality in regionalized calculations), but that is fine for now.

Before merging, this PR should be reviewed carefully by someone who understands the AB code base better than me; I tried to be careful but it is entirely possible that I am missing something important, or violating some hidden assumptions.