### PR TITLE
Don't add extra line break

### DIFF
--- a/activity_browser/app/ui/tables/table.py
+++ b/activity_browser/app/ui/tables/table.py
@@ -89,7 +89,7 @@ class ABTableWidget(QtWidgets.QTableWidget):
                             s += str(self.item(r, c).text()) + "\t"
                         except AttributeError:
                             s += "\t"
-                    s = s[:-1] + "\n"  # eliminate last '\t'
+                    s = (s[:-1]).strip()
                 signals.copy_selection_to_clipboard.emit(s)
 
             elif e.key() == QtCore.Qt.Key_V:  # paste

--- a/activity_browser/app/ui/tables/table.py
+++ b/activity_browser/app/ui/tables/table.py
@@ -89,8 +89,8 @@ class ABTableWidget(QtWidgets.QTableWidget):
                             s += str(self.item(r, c).text()) + "\t"
                         except AttributeError:
                             s += "\t"
-                    s = (s[:-1]).strip()
-                signals.copy_selection_to_clipboard.emit(s)
+                    s = s[:-1] + "\n"  # eliminate last '\t'
+                signals.copy_selection_to_clipboard.emit(s.strip())
 
             elif e.key() == QtCore.Qt.Key_V:  # paste
                 pass


### PR DESCRIPTION
Review this carefully! It is removed something that was put in there on purpose!

Related to #185 (though it doesn't remove the BOM - that is still a mystery).

The line break at the end means that the cell underneath gets erased whenever something is copy-pasted into Excel, at least on MacOS. As there doesn't seem to be a reason for the linebreak, this PR removes it.