### PR TITLE
Eidl integration

### DIFF
--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -66,12 +66,6 @@ class DatabaseImportWizard(QtWidgets.QWizard):
         self.downloader.version = self.version
         self.downloader.system_model = self.system_model
 
-    @property
-    def db_url(self):
-        url = 'https://v33.ecoquery.ecoinvent.org'
-        db_key = (self.version, self.system_model)
-        return url + self.ecoinvent_version_page.db_dict[db_key]
-
     def closeEvent(self, event):
         '''
         close event now behaves similarly to cancel, because of self.reject

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -561,6 +561,7 @@ class EcoinventLoginPage(QtWidgets.QWizardPage):
         self.setLayout(layout)
 
         self.login_thread = LoginThread(self.wizard.downloader)
+        import_signals.login_success.connect(self.login_response)
 
     @property
     def username(self):
@@ -582,7 +583,6 @@ class EcoinventLoginPage(QtWidgets.QWizardPage):
     def login(self):
         self.success_label.setText('Trying to login ...')
         self.login_thread.update(self.username, self.password)
-        import_signals.login_success.connect(self.login_response)
         self.login_thread.start()
 
     @QtCore.pyqtSlot(bool)

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -447,7 +447,10 @@ class MainWorkerThread(QtCore.QThread):
             if self.datasets_path is None:
                 if self.archive_path is None:
                     self.downloader.outdir = eidl.eidlstorage.eidl_dir
-                    self.run_download()
+                    if self.downloader.check_stored():
+                        import_signals.download_complete.emit()
+                    else:
+                        self.run_download()
                 else:
                     self.downloader.out_path = self.archive_path
                 if not import_signals.cancel_sentinel:

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -386,7 +386,6 @@ class ImportPage(QtWidgets.QWizardPage):
             self.forwast_thread.update(self.field('db_name'))
             self.forwast_thread.start()
         else:
-            print(self.download_progressbar.minimum(), self.download_progressbar.maximum())
             self.main_worker_thread.update(db_name=self.field('db_name'))
             self.main_worker_thread.start()
 
@@ -720,7 +719,7 @@ class DefaultBiosphereDialog(QtWidgets.QProgressDialog):
             'Adding default biosphere and LCIA methods to project <b>{}</b>:'.format(
                 bw.projects.current)
         )
-        self.Range(0, 0)
+        self.setRange(0, 0)
         self.show()
 
         self.biosphere_thread = DefaultBiosphereThread()

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -602,6 +602,7 @@ class EcoinventLoginPage(QtWidgets.QWizardPage):
             self.complete = True
             self.completeChanged.emit()
             self.login_button.setChecked(False)
+            self.wizard.next()
 
 
 class LoginThread(QtCore.QThread):
@@ -615,8 +616,6 @@ class LoginThread(QtCore.QThread):
 
     def run(self):
         self.downloader.login()
-        success = bool(len(self.downloader.session.cookies))
-        import_signals.login_success.emit(success)
 
 
 class EcoinventVersionPage(QtWidgets.QWizardPage):

--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - beautifulsoup4
     - fuzzywuzzy
     - pyqt==5.9.2
-    - eidl7zip
+    - eidl
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser

--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -26,10 +26,9 @@ requirements:
     - seaborn
     - arrow
     - pandas
-    - beautifulsoup4
     - fuzzywuzzy
     - pyqt==5.9.2
-    - eidl
+    - eidl >=1.2.0
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - beautifulsoup4
     - fuzzywuzzy
     - pyqt==5.9.2
-    - eidl7zip
+    - eidl
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,9 @@ requirements:
     - seaborn
     - arrow
     - pandas
-    - beautifulsoup4
     - fuzzywuzzy
     - pyqt==5.9.2
-    - eidl
+    - eidl >=1.2.0
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser


### PR DESCRIPTION
This is a major overhaul of the database import wizard. It now uses the EcoInventDownLoader ([eidl](https://github.com/haasad/EcoInventDownLoader)) package. A lot of code was "copy-pasted" from eidl before this change, now it can all be developed in one place. This PR also simpliefies the thread management and makes the code more robust in terms of cancelled imports, connection problems etc.