### PR TITLE
Tmillross deleteprojectconfirm

### DIFF
--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -167,7 +167,7 @@ class Controller(object):
                                                   "A project with this name already exists.")
 
     def confirm_project_deletion_dialog(self):
-        confirm = QtWidgets.QMessageBox.question(
+        buttonReply = QtWidgets.QMessageBox.question(
             None,
             'Confirm project deletion',
             ("Are you sure you want to delete project '{}'? It has {} databases" +
@@ -177,7 +177,7 @@ class Controller(object):
                 len(bw.methods)
             )
         )
-        return confirm
+        return buttonReply
 
     def delete_project(self):
         if len(bw.projects) == 1:
@@ -185,8 +185,8 @@ class Controller(object):
                                               "Not possible",
                                               "Can't delete last project.")
             return
-        ok = self.confirm_project_deletion_dialog()
-        if ok:
+        buttonReply = self.confirm_project_deletion_dialog()
+        if buttonReply == QtWidgets.QMessageBox.Yes:
             bw.projects.delete_project(bw.projects.current)
             self.change_project(bc.get_startup_project_name(), reload=True)
             signals.projects_changed.emit()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PyQt5 import QtCore
+from PyQt5 import QtCore, QtWidgets
 
 from activity_browser.app.controller import Controller
 
@@ -32,7 +32,8 @@ def test_change_project(qtbot, ab_app):
 def test_delete_project(qtbot, mock, ab_app):
     qtbot.waitForWindowShown(ab_app.main_window)
     assert bw.projects.current == 'pytest_project_del'
-    mock.patch.object(Controller, 'confirm_project_deletion_dialog', return_value=True)
+    mock.patch.object(Controller, 'confirm_project_deletion_dialog',
+                      return_value=QtWidgets.QMessageBox.Yes)
     qtbot.mouseClick(
         ab_app.main_window.right_panel.project_tab.projects_widget.delete_project_button,
         QtCore.Qt.LeftButton


### PR DESCRIPTION
This PR supersedes #193 and fixes #192 

Only addition to #193 is the fixing the failing project deletion test. The test was written under the same wrong assumption that caused the bug described in #192.  `QMessageBox.question` doesn't return `True` or `False` but `QMessageBox.Yes` and `...No`. `bool(QMessageBox.No)` evaluates to `True` and that's why the project was deleted no matter the answer.