### PR TITLE
version bump 2.2.5

### DIFF
--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.4.dev" %}
+{% set version = "2.2.5.dev" %}
 
 package:
   name: activity-browser-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.4" %}
+{% set version = "2.2.5" %}
 
 package:
   name: activity-browser

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ for dirpath, dirnames, filenames in os.walk('activity_browser'):
 
 setup(
     name='activity-browser',
-    version="2.2.4",
+    version="2.2.5",
     packages=packages,
     include_package_data=True,
     author="Bernhard Steubing",


### PR DESCRIPTION
@bsteubing, I took the liberty to make a new release since Chris just gave us a mention in the brightway newsletter. Most people won't install the dev version and the last release is a long time ago. Also there's a massive performance improvement with #191 that users otherwise miss out on. I think the the state in the master branch is stable enough for a release.