### PR TITLE
Fix for failing appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ build: false
 environment:
   matrix:
     - JOB: "Python 3.6, 64bit"
-      PYTHON: "C:\\Python36_64"
+      PYTHON: "C:\\Python37_64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "37"
@@ -15,7 +15,6 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "conda info"
   - "DIR"
-  - "DIR C:\\projects\\activity-browser"
   - "conda update conda"
   - "conda config --set always_yes yes --set changeps1 no"
   - "conda config --append channels conda-forge"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ build: false
 environment:
   matrix:
     - JOB: "Python 3.6, 64bit"
-      PYTHON: "C:\\Python36_64"
-      PYTHON_VERSION: "3.6"
+      PYTHON: "C:\\Python37_64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
-      CONDA_PY: "36"
+      CONDA_PY: "37"
       CONDA_ENV_PY: "3.6"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ environment:
 
 install:
   - "powershell .\\ci\\appveyor\\install_miniconda.ps1"
+  - "conda info"
+  - "DIR"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "conda update conda"
   - "conda config --set always_yes yes --set changeps1 no"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
   - "conda config --append channels conda-forge"
   - "conda config --append channels cmutel"
   - "conda config --append channels haasad"
+  - "conda install conda-build=3.15"
   - "conda build .\\ci\\travis\\recipe"
   - "conda create -n test_env python=%CONDA_ENV_PY%"
   - "activate test_env"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,10 @@ environment:
 
 install:
   - "powershell .\\ci\\appveyor\\install_miniconda.ps1"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "conda info"
   - "DIR"
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "DIR C:\\projects\\activity-browser"
   - "conda update conda"
   - "conda config --set always_yes yes --set changeps1 no"
   - "conda config --append channels conda-forge"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ build: false
 environment:
   matrix:
     - JOB: "Python 3.6, 64bit"
-      PYTHON: "C:\\Python37_64"
+      PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "37"

--- a/ci/appveyor/install_miniconda.ps1
+++ b/ci/appveyor/install_miniconda.ps1
@@ -7,7 +7,7 @@ $MINICONDA_URL = "http://repo.continuum.io/miniconda/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -match "3.6") {
+    if ($python_version -match "3.7") {
         $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     } else {
         $filename = "Miniconda-latest-Windows-" + $platform_suffix + ".exe"

--- a/ci/appveyor/install_miniconda.ps1
+++ b/ci/appveyor/install_miniconda.ps1
@@ -7,11 +7,12 @@ $MINICONDA_URL = "http://repo.continuum.io/miniconda/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -match "3.7") {
-        $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
-    } else {
-        $filename = "Miniconda-latest-Windows-" + $platform_suffix + ".exe"
-    }
+    #if ($python_version -match "3.7") {
+    #    $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
+    #} else {
+    #    $filename = "Miniconda-latest-Windows-" + $platform_suffix + ".exe"
+    #}
+    $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     $url = $MINICONDA_URL + $filename
 
     $basedir = $pwd.Path + "\"


### PR DESCRIPTION
- miniconda base env is now python 3.7
- pin `conda-build` to 3.15 on appveyor because there appears to be a bug in 3.16
- install miniconda with python 3 always