### PR TITLE
capture unused args and kwargs

### DIFF
--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -656,7 +656,7 @@ class ActivityBrowserExtractor(Ecospold2DataExtractor):
     - need to display progress in gui
     """
     @classmethod
-    def extract(cls, dirpath, db_name):
+    def extract(cls, dirpath, db_name, *args, **kwargs):
         assert os.path.exists(dirpath), dirpath
         if os.path.isdir(dirpath):
             filelist = [filename for filename in os.listdir(dirpath)


### PR DESCRIPTION
this is a fix for a bug caused by this upstream change in bw2io: https://bitbucket.org/cmutel/brightway2-io/commits/5ad0c27a9616eceeb9dceeb51afe1bfcbb027b1d?at=default