### PR TITLE
Stable deploy tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ conda config --append channels cmutel
 conda config --append channels bsteubing
 conda config --append channels haasad
 ```
-If you have already installed brightway2 before, chances are you already have these channels in your config file. You can check your channels with `conda config --show channels`. The output should look something like this if everything is set up correctly: 
+If you have already installed brightway2 before, chances are you already have these channels in your config file. You can check your channels with `conda config --show channels`. The output should look something like this if everything is set up correctly:
 ```
 channels:
   - defaults
@@ -48,8 +48,6 @@ channels:
 ```
 
 ### Install the activity browser
-
-**_Temporary update: please use the development version at this moment (see further below)_**
 
 After configuring your conda channels, the activity browser can be installed with this command:
 ```
@@ -112,14 +110,14 @@ __Brightway2__:
 ## Authors
 
 - Bernhard Steubing (b.steubing@cml.leidenuniv.nl)
-- Adrian Haas (haasad@ethz.ch) 
+- Adrian Haas (haasad@ethz.ch)
 - Chris Mutel (cmutel@gmail.com)
 
 
 ## Copyright
-Copyright (c) 2017-2019, Bernhard Steubing (Leiden University), Adrian Haas (ETH Zurich)   
-Copyright (c) 2016, Chris Mutel and Paul Scherrer Institut  
-Copyright (c) 2015, Bernhard Steubing and ETH Zurich  
+Copyright (c) 2017-2019, Bernhard Steubing (Leiden University), Adrian Haas (ETH Zurich)
+Copyright (c) 2016, Chris Mutel and Paul Scherrer Institut
+Copyright (c) 2015, Bernhard Steubing and ETH Zurich
 
 
 

--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -19,6 +19,9 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
         export VERSION="$TRAVIS_TAG"
         BUILD_ARGS=""
         UPLOAD_ARGS=""
+        # Strip the last sentence (as this is the stable version) out of the meta.yaml file.
+        # NOTE: this can get fiddly.
+        sed -i -e "`wc -l $TRAVIS_BUILD_DIR/ci/travis/recipe/meta.yaml | cut -d ' ' -f 1`d" $TRAVIS_BUILD_DIR/ci/travis/recipe/meta.yaml
     fi
 
     conda install -q conda-build anaconda-client conda-verify


### PR DESCRIPTION
Update the README to remove the line recommending the development version now that we can build stable versions correctly.

Also, added a line to the build script which strips out the 'warning this is the development version' if we're building a stable version.