### PR TITLE
Fix database deletion failure

### DIFF
--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -219,6 +219,7 @@ class Controller(object):
 
     def install_default_data(self):
         self.default_biosphere_dialog = DefaultBiosphereDialog()
+        project_settings.add_db("biosphere3")
 
     def add_database(self):
         name, ok = QtWidgets.QInputDialog.getText(

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -230,6 +230,7 @@ class Controller(object):
         if ok and name:
             if name not in bw.databases:
                 bw.Database(name).register()
+                project_settings.add_db(name)
                 signals.databases_changed.emit()
                 signals.database_selected.emit(name)
             else:
@@ -245,6 +246,7 @@ class Controller(object):
         if ok and new_name:
             if new_name not in bw.databases:
                 self.copydb_dialog = CopyDatabaseDialog(name, new_name)
+                project_settings.add_db(new_name)
             else:
                 QtWidgets.QMessageBox.information(None,
                                                   "Not possible",

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -83,8 +83,7 @@ class DatabasesTable(ABTableWidget):
 
     def read_only_changed(self, read_only, db):
         """User has clicked to update a db to either read-only or not"""
-        project_settings.settings['read-only-databases'][db] = read_only
-        project_settings.write_settings()
+        project_settings.modify_db(db, read_only)
         signals.database_read_only_changed.emit(db, read_only)
 
     @ABTableWidget.decorated_sync


### PR DESCRIPTION
Fixes #235.

On initializing project settings, the key 'read-only-databases' is never added to the dictionary.

- This fix will ensure new users begin with the 'read-only-databases' key present.

- For present users a check is added which finds if the key exists and generates a new 'read-only-databases' database dictionary by reading out the brightway database list if it does not.

- New hooks are added to the existing add/copy/modify database methods which store the databases in the AB project settings on a successful add/copy/modify.