### PR TITLE
Add stopgap measure for InvalidParamsError error

### DIFF
--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -3,6 +3,8 @@ from PyQt5.QtWidgets import (QWidget, QTabWidget, QVBoxLayout, QHBoxLayout,
     QScrollArea, QRadioButton, QLabel, QCheckBox, QPushButton, QComboBox)
 from PyQt5 import QtGui, QtWidgets, QtCore
 
+from stats_arrays.errors import InvalidParamsError
+
 from ..style import horizontal_line, vertical_line, header
 from ..tables import (
     LCAResultsTable,
@@ -94,7 +96,12 @@ class LCAResultsSubTab(QTabWidget):
         """ Update the mlca calculation. """
         self.mlca = MLCA(self.cs_name)
         self.contributions = Contributions(self.mlca)
-        self.mc = CSMonteCarloLCA(self.cs_name)
+        try:
+            self.mc = CSMonteCarloLCA(self.cs_name)
+        except InvalidParamsError as e:
+            # This can occur if uncertainty data is missing or otherwise broken
+            print(e)
+            self.mc = None
         # self.mct = CSMonteCarloLCAThread()
         # self.mct.start()
         # self.mct.initialize(self.cs_name)
@@ -121,8 +128,9 @@ class LCAResultsSubTab(QTabWidget):
         self.process_contributions_tab = ProcessContributionsTab(self, relativity=True)
         self.process_contributions_tab.update_analysis_tab()
 
-        self.monte_carlo_tab = MonteCarloTab(self)
-        self.monte_carlo_tab.update_tab()
+        if self.mc:
+            self.monte_carlo_tab = MonteCarloTab(self)
+            self.monte_carlo_tab.update_tab()
 
         # self.correlations_tab = CorrelationsTab(self)
         # self.correlations_tab.update_analysis_tab()


### PR DESCRIPTION
@CHarpprecht

This change will hide the Monte Carlo tab from the results in the case that some uncertainty data is missing or incorrect.

Actual error:
```bash
Real, positive scale (sigma) values are required for lognormal uncertainties.
```