### PR TITLE
Use environ to change summary text for stable version

### DIFF
--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -17,6 +17,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     else
         export PKG_NAME="activity-browser"
         export VERSION="$TRAVIS_TAG"
+        export SUMMARY="GUI for brightway2"
         BUILD_ARGS=""
         UPLOAD_ARGS=""
         # Strip the last sentence (as this is the stable version) out of the meta.yaml file.

--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - VERSION
     - CONDA_BLD_PATH
   entry_points:
-    - activity-browser = activity_browser.app:run_activity_browser 
+    - activity-browser = activity_browser.app:run_activity_browser
     - activity-browser-cleanup = activity_browser.app.bwutils:cleanup
 
 requirements:
@@ -40,7 +40,7 @@ about:
   license: GPL3+
   license_family: GPL3
   license_file: LICENSE
-  summary: Development version of the Activity Browser
+  summary: "{{ os.environ.get('SUMMARY', 'Development version of the Activity Browser') }}"
   description: |
     The Activity Browser is a graphical user interface for the [brightway2](https://brightwaylca.org/)
     advanced life cycle assessment framework. More details and installation instructions can be found


### PR DESCRIPTION
Noticed both the stable and development versions show the same summary text on anaconda.org.