### PR TITLE
Extract sync decorator

### DIFF
--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from activity_browser.app.settings import project_settings
 from .table import ABTableWidget, ABTableItem
-from .views import ABDataFrameView
+from .views import ABDataFrameView, dataframe_sync
 from ..icons import icons
 from ...signals import signals
 from ...bwutils.metadata import AB_metadata
@@ -229,7 +229,7 @@ class ActivitiesBiosphereTable(ABDataFrameView):
     #         for key, amount in func_unit.items():
     #             self.append_row(key, str(amount))
 
-    @ABDataFrameView.decorated_sync
+    @dataframe_sync
     def sync(self, db_name, df=None):
         if isinstance(df, pd.DataFrame):  # skip the rest of the sync here if a dataframe is directly supplied
             print('Pandas Dataframe passed to sync.', df.shape)

--- a/activity_browser/app/ui/tables/lca_results.py
+++ b/activity_browser/app/ui/tables/lca_results.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from .views import ABDataFrameView
-# from ...bwutils.commontasks import wrap_text
+from .views import ABDataFrameView, dataframe_sync
+
 
 class LCAResultsTable(ABDataFrameView):
-    @ABDataFrameView.decorated_sync
+    @dataframe_sync
     def sync(self, df):
         self.dataframe = df
 
 
 class InventoryTable(ABDataFrameView):
-    @ABDataFrameView.decorated_sync
+    @dataframe_sync
     def sync(self, df):
         self.dataframe = df
         # sort ignoring case sensitivity
@@ -24,7 +24,7 @@ class ContributionTable(ABDataFrameView):
         super(ContributionTable, self).__init__(parent)
         self.parent = parent
 
-    @ABDataFrameView.decorated_sync
+    @dataframe_sync
     def sync(self):
         # df = self.parent.df.replace(np.nan, '', regex=True)
         # df.columns = [wrap_text(k, max_length=20) for k in df.columns]

--- a/activity_browser/app/ui/tables/views.py
+++ b/activity_browser/app/ui/tables/views.py
@@ -13,6 +13,27 @@ from .models import (DragPandasModel, EditableDragPandasModel,
                      SimpleCopyDragPandasModel, SimpleCopyPandasModel)
 
 
+def dataframe_sync(sync):
+    """ Syncs the data from the dataframe into the table view.
+
+    Uses either of the PandasModel classes depending if the class is
+    'drag-enabled'.
+    """
+    @wraps(sync)
+    def wrapper(self, *args, **kwargs):
+        sync(self, *args, **kwargs)
+
+        self.model = self._select_model()
+        # See: http://doc.qt.io/qt-5/qsortfilterproxymodel.html#details
+        self.proxy_model = QSortFilterProxyModel()
+        self.proxy_model.setSourceModel(self.model)
+        self.proxy_model.setSortCaseSensitivity(Qt.CaseInsensitive)
+        self.setModel(self.proxy_model)
+        self._resize()
+
+    return wrapper
+
+
 class ABDataFrameView(QTableView):
     """ Base class for showing pandas dataframe objects as tables.
     """

--- a/activity_browser/app/ui/tables/views.py
+++ b/activity_browser/app/ui/tables/views.py
@@ -61,27 +61,6 @@ class ABDataFrameView(QTableView):
     def sizeHint(self):
         return QSize(self.width(), self.get_max_height())
 
-    @classmethod
-    def decorated_sync(cls, sync):
-        """ Syncs the data from the dataframe into the table view.
-
-        Uses either of the PandasModel classes depending if the class is
-        'drag-enabled'.
-        """
-        @wraps(sync)
-        def wrapper(self, *args, **kwargs):
-            sync(self, *args, **kwargs)
-
-            self.model = self._select_model()
-            # See: http://doc.qt.io/qt-5/qsortfilterproxymodel.html#details
-            self.proxy_model = QSortFilterProxyModel()
-            self.proxy_model.setSourceModel(self.model)
-            self.proxy_model.setSortCaseSensitivity(Qt.CaseInsensitive)
-            self.setModel(self.proxy_model)
-            self._resize()
-
-        return wrapper
-
     def _select_model(self) -> QAbstractTableModel:
         """ Select which model to use for the proxy model.
         """


### PR DESCRIPTION
By extracting the sync decorator for the dataframe QTableViews and using overridable protected methods to select the model and perform resizing after setting the proxy model we will have a lot more fine-grained control over the way tables are presented to the user (eg. Hiding specific columns. Use specific column coloring).