### PR TITLE
Only call sync if database_changed signal is valid

### DIFF
--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -201,9 +201,7 @@ class ActivitiesBiosphereTable(ABDataFrameView):
             lambda name: self.sync(name)
         )
         # signals.database_changed.connect(self.filter_database_changed)
-        signals.database_changed.connect(
-            lambda x: self.sync(self.database_name)
-        )
+        signals.database_changed.connect(self.check_database_changed)
         signals.database_read_only_changed.connect(self.update_activity_table_read_only)
 
         self.doubleClicked.connect(self.item_double_clicked)
@@ -221,6 +219,13 @@ class ActivitiesBiosphereTable(ABDataFrameView):
         key = self.get_key(proxy_index)
         signals.open_activity_tab.emit(key)
         signals.add_activity_to_history.emit(key)
+
+    @QtCore.pyqtSlot(str)
+    def check_database_changed(self, db_name: str) -> None:
+        """ Determine if we need to re-sync (did 'our' db change?).
+        """
+        if db_name == self.database_name and db_name in bw.databases:
+            self.sync(db_name)
 
     # def LCA_calculation(self, key):
     #     print(key)


### PR DESCRIPTION
Fix for sporadic 'error' where on editing exchanges of an activity it would say the database could not be found.