### PR TITLE
Refactor databases table

### DIFF
--- a/activity_browser/app/ui/tables/delegates.py
+++ b/activity_browser/app/ui/tables/delegates.py
@@ -2,7 +2,8 @@
 import brightway2 as bw
 from PyQt5.QtCore import QAbstractItemModel, QModelIndex, Qt
 from PyQt5.QtGui import QDoubleValidator
-from PyQt5.QtWidgets import QComboBox, QLineEdit, QStyledItemDelegate
+from PyQt5.QtWidgets import (QApplication, QComboBox, QLineEdit, QStyle,
+                             QStyledItemDelegate, QStyleOptionButton)
 
 
 class FloatDelegate(QStyledItemDelegate):
@@ -81,6 +82,29 @@ class DatabaseDelegate(QStyledItemDelegate):
         """
         value = editor.currentText()
         model.setData(index, value, Qt.EditRole)
+
+
+class CheckboxDelegate(QStyledItemDelegate):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def createEditor(self, parent, option, index):
+        return None
+
+    def paint(self, painter, option, index):
+        """ Paint the cell with a styled option button, showing a checkbox
+
+        See links below for inspiration:
+        https://stackoverflow.com/a/11778012
+        https://stackoverflow.com/q/15235273
+        """
+        value = bool(index.data(Qt.DisplayRole))
+        button = QStyleOptionButton()
+        button.state = QStyle.State_Enabled
+        button.state |= QStyle.State_Off if not value else QStyle.State_On
+        button.rect = option.rect
+        # button.text = "False" if not value else "True"  # This also adds text
+        QApplication.style().drawControl(QStyle.CE_CheckBox, button, painter)
 
 
 class ViewOnlyDelegate(QStyledItemDelegate):

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -119,6 +119,8 @@ class DatabasesTable(ABDataFrameView):
             QtWidgets.QSizePolicy.Maximum)
         )
 
+    def rowCount(self) -> int:
+        return self.model.rowCount()
 
 class DatabasesTable(ABTableWidget):
     """Displays metadata for the databases found within the selected project

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -31,8 +31,12 @@ class DatabasesTable(ABDataFrameView):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.verticalHeader().setVisible(False)
-        self.setSelectionMode(ABDataFrameView.SingleSelection)
+        self.setSelectionMode(QtWidgets.QTableView.SingleSelection)
         self.setItemDelegateForColumn(2, CheckboxDelegate(self))
+        self.setSizePolicy(QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Preferred,
+            QtWidgets.QSizePolicy.Maximum)
+        )
         self._connect_signals()
 
     def _connect_signals(self):
@@ -54,7 +58,7 @@ class DatabasesTable(ABDataFrameView):
             qicons.add, "Add new activity",
             lambda: signals.new_activity.emit(self.selected_db_name)
         )
-        menu.popup(QtGui.QCursor.pos())
+        menu.popup(a0.globalPos())
         menu.exec()
 
     def mousePressEvent(self, e):
@@ -69,7 +73,7 @@ class DatabasesTable(ABDataFrameView):
         if e.button() == QtCore.Qt.LeftButton:
             index = self.indexAt(e.pos())
             if index.column() == 2:
-                value = self.dataframe.iloc[index.row(), index.column()]
+                value = bool(index.data())
                 new_value = True if not value else False
                 db_name = self.dataframe.iloc[index.row(), ]["Name"]
                 self.read_only_changed(db_name, new_value)
@@ -118,15 +122,6 @@ class DatabasesTable(ABDataFrameView):
             })
 
         self.dataframe = pd.DataFrame(data, columns=self.HEADERS)
-
-    def _resize(self):
-        self.setSizePolicy(QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Preferred,
-            QtWidgets.QSizePolicy.Maximum)
-        )
-
-    def rowCount(self) -> int:
-        return self.model.rowCount()
 
 
 class ActivitiesBiosphereTable(ABDataFrameView):

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -11,7 +11,6 @@ import pandas as pd
 from activity_browser.app.settings import project_settings
 
 from .delegates import CheckboxDelegate
-from .table import ABTableWidget, ABTableItem
 from .views import ABDataFrameView, dataframe_sync
 from ..icons import icons, qicons
 from ...signals import signals
@@ -20,6 +19,13 @@ from ...bwutils.commontasks import is_technosphere_db
 
 
 class DatabasesTable(ABDataFrameView):
+    """ Displays metadata for the databases found within the selected project.
+
+    Databases can be read-only or writable, with users preference persisted
+    in settings file.
+    - User double-clicks to see the activities and flows within a db
+    - A context menu (right click) provides further functionality
+    """
     HEADERS = ["Name", "Records", "Read-only", "Depends", "Modified"]
 
     def __init__(self, parent=None):
@@ -121,105 +127,6 @@ class DatabasesTable(ABDataFrameView):
 
     def rowCount(self) -> int:
         return self.model.rowCount()
-
-class DatabasesTable(ABTableWidget):
-    """Displays metadata for the databases found within the selected project
-    Dbs can be read-only or writable, with users preference persisted in settings file
-    User double-clicks to see the activities and flows within a db
-    A context menu (right click) provides further functionality"""
-    # Column 4 header options: Size / Entries / Flows / Activities / Count / Activity Count..
-    # ... 'Records' seems reasonable for a "database", and is quite short
-    HEADERS = ["Name", "Records", "Read-only", "Depends", "Modified", ]
-    # HEADERS = {
-    #     "Name": 0,
-    #     "Depends": 1,
-    #     "Modified": 2,
-    #     "Records": 3,
-    #     "Read-only": 4,
-    # }
-
-    def __init__(self):
-        super(DatabasesTable, self).__init__()
-        self.name = "undefined"
-        self.setColumnCount(len(self.HEADERS))
-        self.connect_signals()
-        self.setup_context_menu()
-
-    def setup_context_menu(self):
-        # delete database
-        self.delete_database_action = QtWidgets.QAction(
-            QtGui.QIcon(icons.delete), "Delete database", None
-        )
-        self.addAction(self.delete_database_action)
-        self.delete_database_action.triggered.connect(
-            lambda x: signals.delete_database.emit(
-                self.currentItem().db_name
-            )
-        )
-
-        # copy database
-        self.copy_database_action = QtWidgets.QAction(
-            QtGui.QIcon(icons.duplicate), "Copy database", None
-        )
-        self.addAction(self.copy_database_action)
-        self.copy_database_action.triggered.connect(
-            lambda x: signals.copy_database.emit(
-                self.currentItem().db_name
-            )
-        )
-        # add activity (important for empty databases)
-        self.add_activity_action = QtWidgets.QAction(
-            QtGui.QIcon(icons.add), "Add new activity", None
-        )
-        self.addAction(self.add_activity_action)
-        self.add_activity_action.triggered.connect(
-            lambda x: signals.new_activity.emit(
-                self.currentItem().db_name
-            )
-        )
-
-    def connect_signals(self):
-        signals.project_selected.connect(self.sync)
-        signals.databases_changed.connect(self.sync)
-        self.itemDoubleClicked.connect(self.select_database)
-
-    def select_database(self, item):
-        signals.database_selected.emit(item.db_name)
-
-    def read_only_changed(self, read_only, db):
-        """User has clicked to update a db to either read-only or not"""
-        project_settings.modify_db(db, read_only)
-        signals.database_read_only_changed.emit(db, read_only)
-
-    @ABTableWidget.decorated_sync
-    def sync(self):
-        self.setRowCount(len(bw.databases))
-        self.setHorizontalHeaderLabels(self.HEADERS)
-        # self.setHorizontalHeaderLabels(sorted(self.HEADERS.items(), key=lambda kv: kv[1]))
-
-        databases_read_only_settings = project_settings.settings.get('read-only-databases', {})
-
-        for row, name in enumerate(natural_sort(bw.databases)):
-            self.setItem(row, self.HEADERS.index("Name"), ABTableItem(name, db_name=name))
-            depends = bw.databases[name].get('depends', [])
-            self.setItem(row, self.HEADERS.index("Depends"), ABTableItem(", ".join(depends), db_name=name))
-            dt = bw.databases[name].get('modified', '')
-            # code below is based on the assumption that bw uses utc timestamps
-            tz = datetime.datetime.now(datetime.timezone.utc).astimezone()
-            time_shift = - tz.utcoffset().total_seconds()
-            if dt:
-                dt = arrow.get(dt).shift(seconds=time_shift).humanize()
-            self.setItem(row, self.HEADERS.index("Modified"), ABTableItem(dt, db_name=name))
-            self.setItem(
-                row, self.HEADERS.index("Records"), ABTableItem(str(len(bw.Database(name))), db_name=name)
-            )
-            # final column includes interactive checkbox which shows read-only state of db
-            database_read_only = databases_read_only_settings.get(name, True)
-
-            ch = QtWidgets.QCheckBox(parent=self)
-            ch.clicked.connect(lambda checked, db=name: self.read_only_changed(checked, db))
-            ch.setChecked(database_read_only)
-            self.setCellWidget(row, self.HEADERS.index("Read-only"), ch)
 
 
 class ActivitiesBiosphereTable(ABDataFrameView):

--- a/tests/test_add_default_data.py
+++ b/tests/test_add_default_data.py
@@ -26,16 +26,21 @@ def test_add_default_data(qtbot, mock, ab_app):
 
 
 def test_select_biosphere(ab_app):
+    """ Select the 'biosphere3' database from the databases table.
+    """
     project_tab = ab_app.main_window.left_panel.tabs['Project']
     act_bio_widget = project_tab.activity_biosphere_widget
-    # assert act_bio_widget.table.rowCount() == 0
-    # assert act_bio_widget.table.isHidden()
     db_table = project_tab.databases_widget.table
-    dbs = [db_table.item(i, 0).text() for i in range(db_table.rowCount())]
+    dbs = [
+        db_table.model.data(db_table.model.index(i, 0), QtCore.Qt.DisplayRole)
+        for i in range(db_table.rowCount())
+    ]
     assert 'biosphere3' in dbs
     # TODO: ideally replace the signal below with qtbot.mouseDClick on the tableitem
+    # Sadly, there is no simple way of determining where to click to get the
+    # correct row. Example here can be used for precise clicking:
+    # https://github.com/pytest-dev/pytest-qt/issues/27#issuecomment-61897655
     signals.database_selected.emit('biosphere3')
-    # assert not act_bio_widget.table.isHidden()
     assert act_bio_widget.table.dataframe.shape[0] > 0
 
 


### PR DESCRIPTION
Replace the `DatabasesTable` class with one that inherits from ABDataFrameView.

The delegate which presents the checkbox for the user can easily be edited to instead make the cell a 'push button' showing the state.