### PR TITLE
Increase strictness of FloatDelegate validation

### DIFF
--- a/activity_browser/app/ui/tables/delegates.py
+++ b/activity_browser/app/ui/tables/delegates.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PyQt5.QtCore import QAbstractItemModel, QModelIndex, Qt
+from PyQt5.QtCore import QAbstractItemModel, QLocale, QModelIndex, Qt
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import QComboBox, QLineEdit, QStyledItemDelegate
 
@@ -13,7 +13,11 @@ class FloatDelegate(QStyledItemDelegate):
 
     def createEditor(self, parent, option, index):
         editor = QLineEdit(parent)
-        editor.setValidator(QDoubleValidator())
+        locale = QLocale(QLocale.English)
+        locale.setNumberOptions(QLocale.RejectGroupSeparator)
+        validator = QDoubleValidator()
+        validator.setLocale(locale)
+        editor.setValidator(validator)
         return editor
 
     def setEditorData(self, editor: QLineEdit, index: QModelIndex):

--- a/activity_browser/app/ui/tables/delegates.py
+++ b/activity_browser/app/ui/tables/delegates.py
@@ -31,8 +31,11 @@ class FloatDelegate(QStyledItemDelegate):
                      index: QModelIndex):
         """ Take the editor, read the given value and set it in the model
         """
-        value = float(editor.text())
-        model.setData(index, value, Qt.EditRole)
+        try:
+            value = float(editor.text())
+            model.setData(index, value, Qt.EditRole)
+        except ValueError:
+            pass
 
 
 class StringDelegate(QStyledItemDelegate):


### PR DESCRIPTION
Ensures users cannot enter a ',' (comma) in a `FloatDelegate` field, float() cast only allows a single '.' (period).

Qt uses the system locale to determine if it shows float values with a comma or a period, but python will only cast values to float when they use periods.

Note that `e` is still a valid character-input, so adding values in scientific notation is not impacted.