### PR TITLE
Model value conversion

### DIFF
--- a/activity_browser/app/ui/tables/models.py
+++ b/activity_browser/app/ui/tables/models.py
@@ -27,7 +27,7 @@ class PandasModel(QAbstractTableModel):
             return QVariant()
 
         if role == Qt.DisplayRole:
-            value = self._dataframe.iloc[index.row(), index.column()]
+            value = self._dataframe.iat[index.row(), index.column()]
             if isinstance(value, np.float):
                 value = float(value)
             elif isinstance(value, np.bool_):
@@ -83,7 +83,7 @@ class EditablePandasModel(PandasModel):
         """ Inserts the given validated data into the given index
         """
         if index.isValid() and role == Qt.EditRole:
-            self._dataframe.iloc[index.row(), index.column()] = value
+            self._dataframe.iat[index.row(), index.column()] = value
             self.dataChanged.emit(index, index, [role])
             return True
         return False

--- a/activity_browser/app/ui/tables/models.py
+++ b/activity_browser/app/ui/tables/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import numpy as np
 from pandas import DataFrame
 from PyQt5.QtCore import QAbstractTableModel, Qt, QVariant
 from PyQt5.QtGui import QBrush
@@ -27,11 +28,15 @@ class PandasModel(QAbstractTableModel):
 
         if role == Qt.DisplayRole:
             value = self._dataframe.iloc[index.row(), index.column()]
-            try:
-                return QVariant(float(value))
-            except (ValueError, TypeError) as e:
-                # Also handle 'None' values from dataframe.
-                return QVariant(str(value)) if value else QVariant()
+            if isinstance(value, np.float):
+                value = float(value)
+            elif isinstance(value, np.bool_):
+                value = bool(value)
+            elif isinstance(value, np.int64):
+                value = int(value)
+            elif isinstance(value, tuple):
+                value = str(value)
+            return QVariant() if value is None else QVariant(value)
 
         if role == Qt.ForegroundRole:
             col_name = self._dataframe.columns[index.column()]
@@ -39,7 +44,7 @@ class PandasModel(QAbstractTableModel):
                 col_name = AB_names_to_bw_keys.get(col_name, "")
             return QBrush(style_item.brushes.get(col_name, style_item.brushes.get("default")))
 
-        return None
+        return QVariant()
 
     def flags(self, index):
         return Qt.ItemIsSelectable | Qt.ItemIsEnabled


### PR DESCRIPTION
QVariant cannot recognize numpy or tuple types, presenting them as ['object' values](https://www.riverbankcomputing.com/static/Docs/PyQt5/pyqt_qvariant.html) instead. Converting `value` to the proper type before placing it in a QVariant instance will likely avoid issues with sorting down the line.

Also, [replaced the usage](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.iat.html#pandas.DataFrame.iat) of `iloc` with `iat` for getting and setting single values.