### PR TITLE
Cleanup inventory table classes

### DIFF
--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -110,6 +110,8 @@ AB_names_to_bw_keys = {
     "Database": "database",
     "Uncertainty": "uncertainty type",
     "Formula": "formula",
+    "Categories": "categories",
+    "Type": "type",
 }
 
 bw_keys_to_AB_names = {v: k for k, v in AB_names_to_bw_keys.items()}

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -37,8 +37,8 @@ class DatabasesTable(ABDataFrameView):
         # self.setItemDelegateForColumn(2, CheckboxDelegate(self))
         self.setSizePolicy(QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Preferred,
-            QtWidgets.QSizePolicy.Maximum)
-        )
+            QtWidgets.QSizePolicy.Maximum
+        ))
         self._connect_signals()
 
     def _connect_signals(self):
@@ -60,8 +60,7 @@ class DatabasesTable(ABDataFrameView):
             qicons.add, "Add new activity",
             lambda: signals.new_activity.emit(self.selected_db_name)
         )
-        menu.popup(a0.globalPos())
-        menu.exec()
+        menu.exec(a0.globalPos())
 
     def mousePressEvent(self, e):
         """ A single mouseclick should trigger the 'read-only' column to alter
@@ -75,9 +74,9 @@ class DatabasesTable(ABDataFrameView):
         if e.button() == QtCore.Qt.LeftButton:
             index = self.indexAt(e.pos())
             if index.column() == 2:
-                value = bool(index.data())
-                new_value = True if not value else False
-                db_name = self.dataframe.iloc[index.row(), ]["Name"]
+                # Flip the read-only value for the database
+                new_value = not bool(index.data())
+                db_name = self.model.index(index.row(), 0).data()
                 self.read_only_changed(db_name, new_value)
                 self.sync()
         super().mousePressEvent(e)
@@ -86,12 +85,12 @@ class DatabasesTable(ABDataFrameView):
     def selected_db_name(self) -> str:
         """ Return the database name of the user-selected index.
         """
-        index = self.get_source_index(next(p for p in self.selectedIndexes()))
-        return self.dataframe.iloc[index.row(), ]["Name"]
+        index = self.get_source_index(self.currentIndex())
+        return self.model.index(index.row(), 0).data()
 
     def open_database(self, proxy):
         index = self.get_source_index(proxy)
-        signals.database_selected.emit(self.dataframe.iloc[index.row(), ]["Name"])
+        signals.database_selected.emit(self.model.index(index.row(), 0).data())
 
     @staticmethod
     @QtCore.pyqtSlot(str, bool)

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -74,10 +74,11 @@ class DatabasesTable(ABDataFrameView):
         (inspired by: https://stackoverflow.com/a/11778012)
         """
         if e.button() == QtCore.Qt.LeftButton:
-            index = self.indexAt(e.pos())
-            if index.column() == 2:
+            proxy = self.indexAt(e.pos())
+            if proxy.column() == 2:
                 # Flip the read-only value for the database
-                new_value = not bool(index.data())
+                new_value = not bool(proxy.data())
+                index = self.get_source_index(proxy)
                 db_name = self.model.index(index.row(), 0).data()
                 self.read_only_changed(db_name, new_value)
                 self.sync()

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -126,22 +126,19 @@ class DatabasesTable(ABDataFrameView):
 
 
 class ActivitiesBiosphereTable(ABDataFrameView):
-    def __init__(self):
-        super(ActivitiesBiosphereTable, self).__init__()
+    def __init__(self, parent=None):
+        super().__init__(parent)
         self.database_name = None
-        self.dataframe = pd.DataFrame()
         self.technosphere = True
         self.act_fields = lambda: AB_metadata.get_existing_fields(['reference product', 'name', 'location', 'unit'])
         self.ef_fields = lambda: AB_metadata.get_existing_fields(['name', 'categories', 'type', 'unit'])
         self.fields = list()  # set during sync
+        self.db_read_only = True
 
         self.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
         self.setDragEnabled(True)
         self.drag_model = True  # to enable the DragPandasModel (with flags for dragging)
-        self.setDragDropMode(1)  # QtGui.QAbstractItemView.DragOnly
-
-        self.setup_context_menu()
-        self.connect_signals()
+        self.setDragDropMode(QtWidgets.QTableView.DragOnly)
 
     def setup_context_menu(self):
         # context menu items are enabled/disabled elsewhere, in update_activity_table_read_only()

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+from ast import literal_eval
 import datetime
+import functools
+
 import arrow
 import brightway2 as bw
 from PyQt5 import QtWidgets, QtCore
 from bw2data.utils import natural_sort
-import functools
 import numpy as np
 import pandas as pd
 
@@ -194,10 +196,15 @@ class ActivitiesBiosphereTable(ABDataFrameView):
         self.database_name = None
         self.dataframe = pd.DataFrame()
 
-    def get_key(self, proxy_index):
-        """Get the key from the mode.dataframe assuming the index provided refers to the proxy model."""
-        index = self.get_source_index(proxy_index)
-        return self.dataframe.iloc[index.row()]['key']
+    def get_key(self, proxy: QtCore.QModelIndex) -> tuple:
+        """ Get the key from the model using the given proxy index.
+
+        NOTE: PandasModel converts tuples to strings in the `data` method
+        due to PyQt QVariant typing nonsense.
+        """
+        index = self.get_source_index(proxy)
+        key = self.model.index(index.row(), self.fields.index("key")).data()
+        return literal_eval(key)
 
     @QtCore.pyqtSlot(QtCore.QModelIndex)
     def open_activity_tab(self, proxy: QtCore.QModelIndex) -> None:

--- a/activity_browser/app/ui/tabs/project_manager.py
+++ b/activity_browser/app/ui/tabs/project_manager.py
@@ -188,7 +188,7 @@ class ActivityBiosphereWidget(QtWidgets.QWidget):
         super(ActivityBiosphereWidget, self).__init__(parent)
         self.header = 'Datasets'
 
-        self.table = ActivitiesBiosphereTable()
+        self.table = ActivitiesBiosphereTable(self)
 
         # Header widget
         self.header_widget = QtWidgets.QWidget()


### PR DESCRIPTION
Clean up some of the code in `tables/inventory.py` and use the AB column headers for the `ActivitiesBiosphereTable` view.

Also added a TODO for moving the filtering logic out of the table class itself and using the existing proxy model constructed during `sync` instead.