### PR TITLE
Unpin pytest and improve pytest fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ matrix:
       os: linux
       env: VERSION=2.3.4.dev PKG_NAME=activity-browser-dev
     - python: "3.7"
+      os: linux
+      env: VERSION=2.3.4.dev PKG_NAME=activity-browser-dev
+    - python: "3.6"
+      language: generic-covered
+      os: osx
+      env: pyver=3.6 VERSION=2.3.4.dev PKG_NAME=activity-browser-dev
+    - python: "3.7"
       language: generic-covered
       os: osx
       env: pyver=3.7 VERSION=2.3.4.dev PKG_NAME=activity-browser-dev
@@ -39,16 +46,15 @@ install:
 
   # Create a test environment because travis trips over itself otherwise
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      conda create -q -n test-environment python=$pyver pytest;
+      conda create -q -n test-environment python=$pyver pytest pytest-qt pytest-mock;
     else
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pytest-qt pytest-mock;
     fi
   - source activate test-environment
   - conda install -q --use-local activity-browser-dev
-  - conda install -q "pytest<3.5" pytest-qt pytest-mock
   # Include coverage packages for linux distro
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      conda install -q "pytest-cov<2.6" python-coveralls;
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+      conda install -q pytest-cov python-coveralls;
     fi
 
 before_script:
@@ -60,16 +66,15 @@ before_script:
 
 script:
   # Run tests on the installed package, also do code coverage in linux.
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      py.test;
-      python -m pytest --cov=activity_browser;
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+      py.test --cov=activity_browser;
     else
       py.test;
     fi
 
 after_success:
   # Only upload the code coverage if tests were successful
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then coveralls; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then coveralls; fi
 
 # https://docs.travis-ci.com/user/deployment/script/
 # https://docs.travis-ci.com/user/deployment/#pull-requests

--- a/activity_browser/app/application.py
+++ b/activity_browser/app/application.py
@@ -10,3 +10,9 @@ class Application(object):
 
     def show(self):
         self.main_window.showMaximized()
+
+    def close(self):
+        self.main_window.close()
+
+    def deleteLater(self):
+        self.main_window.deleteLater()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
   - conda info -a
   # Install package requirements & test suite
   # Do not use the conda-forge pytest version 3.2.2, it includes an old version of pluggy which breaks the test.
-  - conda install -q -c defaults -c conda-forge -c cmutel -c haasad arrow brightway2 bw2io bw2data eidl fuzzywuzzy matplotlib networkx pandas "pyqt==5.9.2" seaborn pytest pytest-qt pytest-mock
+  - conda install -q -c defaults -c conda-forge -c cmutel -c haasad arrow brightway2 bw2io bw2data eidl fuzzywuzzy matplotlib networkx pandas "pyqt==5.9.2" seaborn "pytest>=5.2" pytest-qt pytest-mock
 
 test_script:
   - py.test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ environment:
   matrix:
     - CONDA_PY: "36"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: "37"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
 
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
@@ -18,7 +20,7 @@ install:
   - conda info -a
   # Install package requirements & test suite
   # Do not use the conda-forge pytest version 3.2.2, it includes an old version of pluggy which breaks the test.
-  - conda install -q -c defaults -c conda-forge -c cmutel -c haasad arrow brightway2 bw2io bw2data eidl fuzzywuzzy matplotlib networkx pandas "pyqt==5.9.2" seaborn "pytest>3.2.2,<3.5" pytest-qt pytest-mock
+  - conda install -q -c defaults -c conda-forge -c cmutel -c haasad arrow brightway2 bw2io bw2data eidl fuzzywuzzy matplotlib networkx pandas "pyqt==5.9.2" seaborn pytest pytest-qt pytest-mock
 
 test_script:
-  - python -m pytest
+  - py.test

--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -2,7 +2,7 @@
 # Script for building and uploading the dev and/or stable packages to conda
 
 # Only upload from linux, and use different variables for dev and stable builds
-if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
     USER=bsteubing
     mkdir -p ~/conda-bld
     conda config --set anaconda_upload no
@@ -36,5 +36,5 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l main $CONDA_BLD_PATH/noarch/$PKG_NAME-$VERSION-py_0.tar.bz2 $UPLOAD_ARGS
     echo "BUILD UPLOADED: $USER"
 else
-    echo "No uploads from MacOS"
+    echo "No uploads from MacOS or Linux python 3.6"
 fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,5 @@ def ab_application():
 
 @pytest.fixture()
 def ab_app(qtbot, ab_application):
-    qtbot.addWidget(ab_application)
     ab_application.show()
     return ab_application

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,15 @@ from activity_browser import Application
 
 
 @pytest.fixture(scope='session')
-def ab_app():
+def ab_application():
+    app = Application()
+    yield app
     if 'pytest_project' in bw.projects:
         bw.projects.delete_project('pytest_project', delete_dir=True)
-    application = Application()
-    application.show()
-    return application
+
+
+@pytest.fixture()
+def ab_app(qtbot, ab_application):
+    qtbot.addWidget(ab_application)
+    ab_application.show()
+    return ab_application


### PR DESCRIPTION
Possible fix for the pytest pin problem.

Started looking into this because of the [introduction of an issue](https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert) with newer versions of the `attrs` dependency of pytest. Which is solved by updating to a newer version of pytest.

The fix does include adding an `__init__.py` file in the tests folder (discussed in a [previous pull request](https://github.com/LCA-ActivityBrowser/activity-browser/pull/233)). This will possibly cause issues if we ever try and move to testing with tox, though by that point I expect that we might as well implement the `src` seperation refactoring suggested by pytest and @Drake-Eidukas.

Summary of changes:

* Use of `yield` to improve cleanup of test environment for local testing (see [here](https://docs.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code)).
* Adding `qtbot` parameter in the fixture which returns the complete application fixes the issue higher versions of pytest had (possibly by indicating to pytest its dealing with Qt?).
* Repin pytest from versions below `3.5` to versions at or above `5.2` in appveyor and travis.
* Changes in appveyor and travis scripts to test python versions `3.6` and `3.7` in all machines.