### PR TITLE
Bootstrap conda testing environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
       conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev pytest-cov python-coveralls;
     else
-      conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev
+      conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev;
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,25 @@ matrix:
   include:
     - python: "3.6"
       os: linux
-      env: VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
+      env: PYENV=3.6 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
     - python: "3.7"
       os: linux
-      env: VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
+      env: PYENV=3.7 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
     - python: "3.6"
-      language: generic-covered
+      language: minimal
       os: osx
-      env: pyver=3.6 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
+      env: PYENV=3.6 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
     - python: "3.7"
-      language: generic-covered
+      language: minimal
       os: osx
-      env: pyver=3.7 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
+      env: PYENV=3.7 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
 
 install:
   # As suggested by https://github.com/conda/conda/issues/9337#issuecomment-542466141
   - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe
   - chmod +x conda.exe
   - export CONDA_ALWAYS_YES=1
-  - ./conda.exe create -p $HOME/miniconda -c defaults -c conda-forge python=$TRAVIS_PYTHON_VERSION conda conda-build pytest pytest-qt pytest-mock
+  - ./conda.exe create -p $HOME/miniconda -c defaults -c conda-forge python=$PYENV conda conda-build pytest pytest-qt pytest-mock
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   # Useful for debugging any issues with conda
@@ -33,7 +33,7 @@ install:
   - conda build ./ci/travis/recipe --no-test
 
   # Include coverage packages for linux distro
-  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$PYENV" == "3.7" ]; then
       conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev pytest-cov python-coveralls;
     else
       conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev;
@@ -48,7 +48,7 @@ before_script:
 
 script:
   # Run tests on the installed package, also do code coverage in linux.
-  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$PYENV" == "3.7" ]; then
       py.test --cov=activity_browser;
     else
       py.test;
@@ -56,7 +56,7 @@ script:
 
 after_success:
   # Only upload the code coverage if tests were successful
-  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then coveralls; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$PYENV" == "3.7" ]; then coveralls; fi
 
 # https://docs.travis-ci.com/user/deployment/script/
 # https://docs.travis-ci.com/user/deployment/#pull-requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,43 +18,25 @@ matrix:
       os: osx
       env: pyver=3.7 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
 
-before_install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      sudo apt-get update;
-    fi
-
 install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then MINICONDA_OS=Linux; else MINICONDA_OS=MacOSX; fi
-  - echo "Running on $MINICONDA_OS"
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-$MINICONDA_OS-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
+  # As suggested by https://github.com/conda/conda/issues/9337#issuecomment-542466141
+  - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe
+  - chmod +x conda.exe
+  - export CONDA_ALWAYS_YES=1
+  - ./conda.exe create -p $HOME/miniconda -c defaults -c conda-forge python=$TRAVIS_PYTHON_VERSION conda conda-build pytest pytest-qt pytest-mock
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda install -q conda-build
   # Useful for debugging any issues with conda
   - conda info -a
 
-  # Add conda channels
-  - conda config --append channels conda-forge
-  - conda config --append channels cmutel
-  - conda config --append channels haasad
-
   # Build source into local package for testing
-  - conda build ./ci/travis/recipe
+  - conda build ./ci/travis/recipe --no-test
 
-  # Create a test environment because travis trips over itself otherwise
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      conda create -q -n test-environment python=$pyver pytest pytest-qt pytest-mock;
-    else
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pytest-qt pytest-mock;
-    fi
-  - source activate test-environment
-  - conda install -q --use-local activity-browser-dev
   # Include coverage packages for linux distro
   - if [ "$TRAVIS_OS_NAME" == "linux" -a "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
-      conda install -q pytest-cov python-coveralls;
+      conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev pytest-cov python-coveralls;
+    else
+      conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix:
       os: linux
       env: PYENV=3.7 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
     - python: "3.6"
-      language: minimal
+      language: generic
       os: osx
       env: PYENV=3.6 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
     - python: "3.7"
-      language: minimal
+      language: generic
       os: osx
       env: PYENV=3.7 VERSION=2.3.5.dev PKG_NAME=activity-browser-dev
 
@@ -23,7 +23,7 @@ install:
   - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe
   - chmod +x conda.exe
   - export CONDA_ALWAYS_YES=1
-  - ./conda.exe create -p $HOME/miniconda -c defaults -c conda-forge python=$PYENV conda conda-build pytest pytest-qt pytest-mock
+  - ./conda.exe create -p $HOME/miniconda -c defaults -c conda-forge python=$PYENV conda conda-build pytest pytest-qt pytest-mock pytest-cov python-coveralls
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   # Useful for debugging any issues with conda
@@ -31,13 +31,7 @@ install:
 
   # Build source into local package for testing
   - conda build ./ci/travis/recipe --no-test
-
-  # Include coverage packages for linux distro
-  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$PYENV" == "3.7" ]; then
-      conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev pytest-cov python-coveralls;
-    else
-      conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev;
-    fi
+  - conda install -q -c defaults -c conda-forge -c cmutel -c haasad --use-local activity-browser-dev
 
 before_script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -48,14 +42,10 @@ before_script:
 
 script:
   # Run tests on the installed package, also do code coverage in linux.
-  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$PYENV" == "3.7" ]; then
-      py.test --cov=activity_browser;
-    else
-      py.test;
-    fi
+  - py.test --cov=activity_browser;
 
 after_success:
-  # Only upload the code coverage if tests were successful
+  # Only upload the code coverage from linux py37 machine
   - if [ "$TRAVIS_OS_NAME" == "linux" -a "$PYENV" == "3.7" ]; then coveralls; fi
 
 # https://docs.travis-ci.com/user/deployment/script/


### PR DESCRIPTION
With the [recent issue of `conda update conda` failing](https://github.com/conda/conda/issues/9337). A suggestion was made to not follow the official documentation but instead bootstrap the environment by using a prebuilt executable (https://github.com/conda/conda/issues/9337#issuecomment-542466141) as shown here https://github.com/conda/conda-prefix-replacement/blob/master/.travis.yml#L9-L14.

This pull request implements suggested changes and (together with simplifying some install steps) provides clearer and faster (~1 minute faster) automated tests.