### PR TITLE
Refactor settings

### DIFF
--- a/activity_browser/app/bwutils/commontasks.py
+++ b/activity_browser/app/bwutils/commontasks.py
@@ -5,8 +5,6 @@ import brightway2 as bw
 from bw2data import databases
 from bw2data.utils import natural_sort
 
-from ..settings import ab_settings, project_settings
-
 """
 bwutils is a collection of methods that build upon brightway2 and are generic enough to provide here so that we avoid 
 re-typing the same code in different parts of the Activity Browser.
@@ -72,20 +70,6 @@ def get_databases_data(databases):
     for row, name in enumerate(natural_sort(databases)):
         data.append(get_database_metadata(name))
     yield data
-
-
-def get_editable_databases():
-    editable_dbs = []
-    databases_read_only_settings = project_settings.settings.get('read-only-databases', {})
-    for db_name, read_only in databases_read_only_settings.items():
-        if not read_only and db_name != 'biosphere3':
-            editable_dbs.append(db_name)
-    return editable_dbs
-
-
-def is_database_read_only(db_name):
-    if "read-only-databases" in project_settings.settings:
-        return project_settings.settings["read-only-databases"].get(db_name, True)
 
 
 def is_technosphere_db(db_name):
@@ -177,42 +161,6 @@ def get_exchanges_data(exchanges):
         results.append(exc)
     for r in results:
         print(r)
-
-
-# Settings (directory, project, etc.)
-def get_startup_bw_dir():
-    """Returns the brightway directory as defined in the settings file.
-    If it has not been defined here, it returns the brightway default directory."""
-    return ab_settings.settings.get('custom_bw_dir', get_default_bw_dir())
-
-
-def get_default_bw_dir():
-    """Returns the default brightway directory."""
-    return bw.projects._get_base_directories()[0]
-
-
-def get_current_bw_dir():
-    """Returns the current used brightway directory."""
-    return bw.projects._base_data_dir
-
-
-def get_startup_project_name():
-    """Returns the startup or default project name."""
-    custom_startup = ab_settings.settings.get('startup_project')
-    if custom_startup in bw.projects:
-        return ab_settings.settings['startup_project']
-    else:
-        return get_default_project_name()
-
-
-def get_default_project_name():
-    """Returns the default project name."""
-    if "default" in bw.projects:
-        return "default"
-    elif len(bw.projects):
-        return next(iter(bw.projects)).name
-    else:
-        return None
 
 
 # LCIA

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -11,7 +11,6 @@ from bw2data.project import ProjectDataset, SubstitutableDatabase
 from activity_browser.app.ui.wizards.db_import_wizard import (
     DatabaseImportWizard, DefaultBiosphereDialog, CopyDatabaseDialog
 )
-from .bwutils import commontasks as bc
 from .settings import ab_settings, project_settings
 from .signals import signals
 
@@ -73,10 +72,8 @@ class Controller(object):
     def load_settings(self):
         if ab_settings.settings:
             print("Loading user settings:")
-            if ab_settings.settings.get('custom_bw_dir'):
-                self.switch_brightway2_dir_path(dirpath=ab_settings.settings['custom_bw_dir'])
-            if ab_settings.settings.get('startup_project'):
-                self.change_project(ab_settings.settings['startup_project'])
+            self.switch_brightway2_dir_path(dirpath=ab_settings.custom_bw_dir)
+            self.change_project(ab_settings.startup_project)
 
     def import_database_wizard(self):
         try:
@@ -107,7 +104,7 @@ class Controller(object):
                 [ProjectDataset]
             )
             print('Loaded brightway2 data directory: {}'.format(bw.projects._base_data_dir))
-            self.change_project(bc.get_startup_project_name(), reload=True)
+            self.change_project(ab_settings.startup_project, reload=True)
             signals.databases_changed.emit()
 
         except AssertionError:
@@ -202,7 +199,7 @@ class Controller(object):
         #     "Do you also want to delete the files on your hard drive?")
         if buttonReply == QtWidgets.QMessageBox.Yes:
             bw.projects.delete_project(bw.projects.current, delete_dir=False)
-            self.change_project(bc.get_startup_project_name(), reload=True)
+            self.change_project(ab_settings.startup_project, reload=True)
             # if delete_dir:  # also purging does not work (PermissionError)
             #     bw.projects.purge_deleted_directories()
             signals.projects_changed.emit()
@@ -385,7 +382,7 @@ class Controller(object):
         origin_db = activity_key[0]
         activity = bw.get_activity(activity_key)
 
-        available_target_dbs = bc.get_editable_databases()
+        available_target_dbs = project_settings.get_editable_databases()
 
         if origin_db in available_target_dbs:
             available_target_dbs.remove(origin_db)

--- a/activity_browser/app/settings.py
+++ b/activity_browser/app/settings.py
@@ -2,6 +2,7 @@
 import json
 import os
 import shutil
+from typing import Optional
 
 import appdirs
 import brightway2 as bw
@@ -10,43 +11,128 @@ from activity_browser.app.signals import signals
 from .. import PACKAGE_DIRECTORY
 
 
-class ABSettings():
+class BaseSettings(object):
+    """ Base Class for handling JSON settings files.
+    """
+    def __init__(self, directory: str, filename: str = None):
+        self.data_dir = directory
+        self.filename = filename or "default_settings.json"
+        self.settings_file = os.path.join(self.data_dir, self.filename)
+        self.settings: Optional[dict] = None
+        self.initialize_settings()
+
+    @classmethod
+    def get_default_settings(cls) -> dict:
+        """ Returns dictionary containing the default settings for the file
+        """
+        raise NotImplementedError
+
+    def restore_default_settings(self) -> None:
+        """ Undo all user settings and return to original state.
+        """
+        self.settings = self.get_default_settings()
+        self.write_settings()
+
+    def initialize_settings(self) -> None:
+        """ Attempt to find and read the settings_file, creates a default
+        if not found
+        """
+        if os.path.isfile(self.settings_file):
+            self.load_settings()
+        else:
+            self.settings = self.get_default_settings()
+            self.write_settings()
+
+    def load_settings(self) -> None:
+        with open(self.settings_file, "r") as infile:
+            self.settings = json.load(infile)
+
+    def write_settings(self) -> None:
+        with open(self.settings_file, "w") as outfile:
+            json.dump(self.settings, outfile, indent=4, sort_keys=True)
+
+
+class ABSettings(BaseSettings):
     """
     Interface to the json settings file. Will create a userdata directory via appdirs if not
     already present.
     """
-    def __init__(self):
-        ab_dir = appdirs.AppDirs('ActivityBrowser', 'ActivityBrowser')
-        self.data_dir = ab_dir.user_data_dir
-        if not os.path.isdir(self.data_dir):
-            os.makedirs(self.data_dir, exist_ok=True)
-        self.settings_file = os.path.join(self.data_dir, 'ABsettings.json')
-        self.move_old_settings()
-        if os.path.isfile(self.settings_file):
-            self.load_settings()
-        else:
-            self.settings = {}
+    def __init__(self, filename: str):
+        ab_dir = appdirs.AppDirs("ActivityBrowser", "ActivityBrowser")
+        if not os.path.isdir(ab_dir.user_data_dir):
+            os.makedirs(ab_dir.user_data_dir, exist_ok=True)
+        self.move_old_settings(ab_dir.user_data_dir, filename)
 
-    def move_old_settings(self):
+        super().__init__(ab_dir.user_data_dir, filename)
+
+    @staticmethod
+    def move_old_settings(directory: str, filename: str) -> None:
+        """ legacy code: This function is only required for compatibility
+        with the old settings file and can be removed in a future release
         """
-        legacy code: This function is only required for compatibility with the old settings file and
-        can be removed in a future release
-        """
-        if not os.path.exists(self.settings_file):
-            old_settings = os.path.join(PACKAGE_DIRECTORY, 'ABsettings.json')
+        file = os.path.join(directory, filename)
+        if not os.path.exists(file):
+            old_settings = os.path.join(PACKAGE_DIRECTORY, "ABsettings.json")
             if os.path.exists(old_settings):
-                shutil.copyfile(old_settings, self.settings_file)
+                shutil.copyfile(old_settings, file)
 
-    def load_settings(self):
-        with open(self.settings_file, 'r') as infile:
-            self.settings = json.load(infile)
+    @classmethod
+    def get_default_settings(cls) -> dict:
+        """ Using methods from the commontasks file to set default settings
+        """
+        return {
+            "custom_bw_dir": cls.get_default_directory(),
+            "startup_project": cls.get_default_project_name(),
+        }
 
-    def write_settings(self):
-        with open(self.settings_file, 'w') as outfile:
-            json.dump(self.settings, outfile, indent=4, sort_keys=True)
+    @property
+    def custom_bw_dir(self) -> str:
+        """ Returns the custom brightway directory, or the default
+        """
+        return self.settings.get("custom_bw_dir", self.get_default_directory())
+
+    @custom_bw_dir.setter
+    def custom_bw_dir(self, directory: str) -> None:
+        """ Sets the custom brightway directory to `directory`
+        """
+        self.settings.update({"custom_bw_dir": directory})
+
+    @property
+    def startup_project(self) -> str:
+        """ Get the startup project from the settings, or the default
+        """
+        project = self.settings.get(
+            "startup_project", self.get_default_project_name()
+        )
+        if project not in bw.projects:
+            project = self.get_default_project_name()
+        return project
+
+    @startup_project.setter
+    def startup_project(self, project: str) -> None:
+        """ Sets the startup project to `project`
+        """
+        self.settings.update({"startup_project": project})
+
+    @staticmethod
+    def get_default_directory() -> str:
+        """ Returns the default brightway application directory
+        """
+        return bw.projects._get_base_directories()[0]
+
+    @staticmethod
+    def get_default_project_name() -> Optional[str]:
+        """ Returns the default project name.
+        """
+        if "default" in bw.projects:
+            return "default"
+        elif len(bw.projects):
+            return next(iter(bw.projects)).name
+        else:
+            return None
 
 
-class ProjectSettings():
+class ProjectSettings(BaseSettings):
     """
     Handles user settings which are specific to projects. Created initially to handle read-only/writable database status
     Code based on ABSettings class, if more different types of settings are needed, could inherit from a base class
@@ -63,99 +149,80 @@ class ProjectSettings():
     This is currently not worth the effort but could be returned to later
 
     """
-    def __init__(self):
+    def __init__(self, filename: str):
         # on selection of a project (signal?), find the settings file for that project if it exists
         # it can be a custom location, based on ABsettings. So check that, and if not, use default?
         # once found, load the settings or just an empty dict.
         self.connect_signals()
-
-        self.project_dir = bw.projects.dir
-        # print("project_dir:", self.project_dir)
-        # self.project_name = bw.projects._project_name
-
-        self.settings_file = os.path.join(self.project_dir, 'AB_project_settings.json')
-
-        if os.path.isfile(self.settings_file):
-            self.load_settings()
-        else:
-            # make empty dict for settings
-            self.settings = self.get_default_settings()
-            # save to ensure it's always accessible after first project select
-            self.write_settings()
+        super().__init__(bw.projects.dir, filename)
 
         # https://github.com/LCA-ActivityBrowser/activity-browser/issues/235
         # Fix empty settings file and populate with currently active databases
-        if 'read-only-databases' not in self.settings:
+        if "read-only-databases" not in self.settings:
             self.settings.update(self.process_brightway_databases())
             self.write_settings()
 
     def connect_signals(self):
+        """ Reload the project settings whenever a project switch occurs.
+        """
         signals.project_selected.connect(self.reset_for_project_selection)
         signals.delete_project.connect(self.reset_for_project_selection)
 
-    def get_default_settings(self):
+    @classmethod
+    def get_default_settings(cls) -> dict:
         """ Return default empty settings dictionary.
         """
-        default = {
-            'read-only-databases': {}
-        }
-        return default
+        return cls.process_brightway_databases()
 
-    def process_brightway_databases(self):
+    @staticmethod
+    def process_brightway_databases() -> dict:
         """ Process brightway database list and return new settings dictionary.
 
         NOTE: This ignores the existing database read-only settings.
         """
-        settings = {
-            'read-only-databases': {
-                name: True for name in bw.databases.list
-            }
+        return {
+            "read-only-databases": {name: True for name in bw.databases.list}
         }
-        return settings
 
-    def load_settings(self):
-        with open(self.settings_file, 'r') as infile:
-            self.settings = json.load(infile)
+    def reset_for_project_selection(self) -> None:
+        """ On switching project, attempt to read the settings for the new
+        project.
+        """
+        print("Reset project settings directory to:", bw.projects.dir)
+        self.settings_file = os.path.join(bw.projects.dir, self.filename)
+        self.initialize_settings()
 
-    def write_settings(self):
-        with open(self.settings_file, 'w') as outfile:
-            json.dump(self.settings, outfile, indent=4, sort_keys=True)
-            # print("user settings written to", str(self.settings_file), "\n\t", str(self.settings))
-
-    def reset_for_project_selection(self):
-        # todo: better implementation? reinitialise settings object each time instead
-        # executes when new project selected
-        # same code as __init__ but without connect_signals()
-        self.project_dir = bw.projects.dir
-        print('Reset project settings directory to:', self.project_dir)
-        self.settings_file = os.path.join(self.project_dir, 'AB_project_settings.json')
-
-        # load if found, else make empty dict and save as new file
-        if os.path.isfile(self.settings_file):
-            self.load_settings()
-        else:
-            self.settings = self.get_default_settings()
-            self.write_settings()
-
-    def add_db(self, db_name, read_only=True):
+    def add_db(self, db_name: str, read_only: bool = True) -> None:
         """ Store new databases and relevant settings here when created/imported
         """
-        self.settings['read-only-databases'].setdefault(db_name, read_only)
+        self.settings["read-only-databases"].setdefault(db_name, read_only)
         self.write_settings()
 
-    def modify_db(self, db_name, read_only):
+    def modify_db(self, db_name: str, read_only: bool) -> None:
         """ Update write-rules for the given database
         """
-        self.settings['read-only-databases'].update({db_name: read_only})
+        self.settings["read-only-databases"].update({db_name: read_only})
         self.write_settings()
 
-    def remove_db(self, db_name):
+    def remove_db(self, db_name: str) -> None:
         """ When a database is deleted from a project, the settings are also deleted.
         """
-        self.settings['read-only-databases'].pop(db_name, None)
+        self.settings["read-only-databases"].pop(db_name, None)
         self.write_settings()
 
+    def db_is_readonly(self, db_name: str) -> bool:
+        """ Check if given database is read-only, defaults to yes.
+        """
+        return self.settings["read-only-databases"].get(db_name, True)
 
-ab_settings = ABSettings()
-project_settings = ProjectSettings()
+    def get_editable_databases(self):
+        """ Return list of database names where read-only is false
 
+        NOTE: discards the biosphere3 database based on name.
+        """
+        iterator = self.settings.get("read-only-databases", {}).items()
+        return (name for name, ro in iterator if not ro and name != "biosphere3")
+
+
+ab_settings = ABSettings("ABsettings.json")
+project_settings = ProjectSettings("AB_project_settings.json")

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -105,7 +105,6 @@ class DatabasesTable(ABDataFrameView):
 
     @dataframe_sync
     def sync(self):
-        databases_read_only_settings = project_settings.settings.get("read-only-databases", {})
         # code below is based on the assumption that bw uses utc timestamps
         tz = datetime.datetime.now(datetime.timezone.utc).astimezone()
         time_shift = - tz.utcoffset().total_seconds()
@@ -116,7 +115,7 @@ class DatabasesTable(ABDataFrameView):
             if dt:
                 dt = arrow.get(dt).shift(seconds=time_shift).humanize()
             # final column includes interactive checkbox which shows read-only state of db
-            database_read_only = databases_read_only_settings.get(name, True)
+            database_read_only = project_settings.db_is_readonly(name)
             data.append({
                 "Name": name,
                 "Depends": ", ".join(bw.databases[name].get("depends", [])),
@@ -236,7 +235,7 @@ class ActivitiesBiosphereTable(ABDataFrameView):
         # disable context menu (actions) if biosphere table and/or if db read-only
         if self.technosphere:
             self.setContextMenuPolicy(QtCore.Qt.DefaultContextMenu)
-            self.db_read_only = project_settings.settings.get('read-only-databases', {}).get(db_name, True)
+            self.db_read_only = project_settings.db_is_readonly(db_name)
             self.update_activity_table_read_only(self.database_name, self.db_read_only)
         else:
             self.setContextMenuPolicy(QtCore.Qt.NoContextMenu)

--- a/activity_browser/app/ui/tabs/activity.py
+++ b/activity_browser/app/ui/tabs/activity.py
@@ -9,6 +9,7 @@ from ..widgets import ActivityDataGrid, DetailsGroupBox, SignalledPlainTextEdit
 from ..panels import ABTab
 from ..icons import icons
 from ...bwutils import commontasks as bc
+from ...settings import project_settings
 from ...signals import signals
 
 
@@ -72,7 +73,7 @@ class ActivityTab(QtWidgets.QTabWidget):
         super(ActivityTab, self).__init__(parent)
         self.parent = parent
         self.read_only = read_only
-        self.db_read_only = bc.is_database_read_only(db_name=key[0])
+        self.db_read_only = project_settings.db_is_readonly(db_name=key[0])
         self.key = key
         self.db_name = self.key[0]
         self.activity = bw.get_activity(key)

--- a/activity_browser/app/ui/widgets/activity.py
+++ b/activity_browser/app/ui/widgets/activity.py
@@ -2,9 +2,9 @@
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtWidgets import QMessageBox
 
-from activity_browser.app.bwutils import commontasks as bc
 from .line_edit import SignalledLineEdit, SignalledComboEdit
 from ..icons import qicons
+from ...settings import project_settings
 from ...signals import signals
 from ...bwutils import AB_metadata
 
@@ -144,7 +144,7 @@ class ActivityDataGrid(QtWidgets.QWidget):
         self.database_combo.addItem(current_db)
 
         # other items are the dbs that the activity can be duplicated to: find them and add
-        available_target_dbs = bc.get_editable_databases()
+        available_target_dbs = project_settings.get_editable_databases()
         if current_db in available_target_dbs:
             available_target_dbs.remove(current_db)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+import os
+
+import brightway2 as bw
+import pytest
+
+from activity_browser.app.settings import (ABSettings, BaseSettings,
+                                           ProjectSettings)
+
+
+@pytest.fixture()
+def ab_settings(qtbot, ab_app):
+    """ Remove the test settings file after finishing the tests.
+    """
+    qtbot.waitForWindowShown(ab_app.main_window)
+    settings = ABSettings('test_ab.json')
+    yield settings
+    if os.path.isfile(settings.settings_file):
+        os.remove(settings.settings_file)
+
+
+@pytest.fixture()
+def project_settings(qtbot, ab_app):
+    """ No cleanup needed as the entire project is removed after testing.
+    """
+    qtbot.waitForWindowShown(ab_app.main_window)
+    settings = ProjectSettings('test_project.json')
+    yield settings
+
+
+def test_base_class():
+    """ Test that the base class raises an error on initialization
+    """
+    current_path = os.path.dirname(os.path.abspath(__file__))
+    with pytest.raises(NotImplementedError):
+        settings = BaseSettings(current_path)
+
+
+def test_ab_default_keys(ab_settings):
+    """ Test that default setting are only created for the given keys.
+    """
+    defaults = ab_settings.get_default_settings()
+    assert not {"custom_bw_dir", "startup_project"}.symmetric_difference(defaults)
+
+
+def test_ab_default_settings(ab_settings):
+    assert ABSettings.get_default_directory() == ab_settings.custom_bw_dir
+    assert ABSettings.get_default_project_name() == ab_settings.startup_project
+
+
+def test_ab_edit_settings(ab_settings):
+    current_path = os.path.dirname(os.path.abspath(__file__))
+    ab_settings.custom_bw_dir = current_path
+    assert ab_settings.custom_bw_dir != ABSettings.get_default_directory()
+
+
+@pytest.mark.skipif("pytest_project" not in bw.projects, reason="test project not created")
+def test_ab_existing_startup(ab_settings):
+    """ Alter the startup project and assert that it is correctly changed.
+
+    Will be skipped if test_settings.py is run in isolation because the test
+    project has not been created (results in duplicate of test below)
+    """
+    ab_settings.startup_project = "pytest_project"
+    assert ab_settings.startup_project != ABSettings.get_default_project_name()
+
+
+def test_ab_unknown_startup(ab_settings):
+    """ Alter the startup project with an unknown project, assert that it
+    was not altered because the project does not exist.
+    """
+    ab_settings.startup_project = "unknown_project"
+    assert ab_settings.startup_project == ABSettings.get_default_project_name()
+
+
+def test_project_default_keys(project_settings):
+    defaults = project_settings.get_default_settings()
+    assert not {"read-only-databases"}.symmetric_difference(defaults)
+
+
+def test_project_add_dbs(project_settings):
+    project_settings.add_db("fakedb")
+    project_settings.add_db("fake_readabledb", False)
+    assert project_settings.db_is_readonly("fakedb") is True
+    assert project_settings.db_is_readonly("fake_readabledb") is False
+
+
+def test_project_modify_db(project_settings):
+    assert project_settings.db_is_readonly("fakedb") is True
+    project_settings.modify_db("fakedb", False)
+    assert project_settings.db_is_readonly("fakedb") is False
+
+
+def test_project_editable_dbs(project_settings):
+    editable_dbs = {"fakedb", "fake_readabledb"}
+    assert all(db in editable_dbs for db in project_settings.get_editable_databases())
+
+
+def test_project_remove_db(project_settings):
+    project_settings.remove_db("fakedb")
+    # If db cannot be found, return True
+    assert project_settings.db_is_readonly("fakedb") is True


### PR DESCRIPTION
Shuffle settings-related code into the settings classes to keep logic in one place.

Add separate testing for the settings classes.

This is half of the [#249](https://github.com/LCA-ActivityBrowser/activity-browser/pull/249/) pull-request. Only refactoring the settings code.