### PR TITLE
Improve ecoinvent dataset import

### DIFF
--- a/activity_browser/app/ui/widgets/__init__.py
+++ b/activity_browser/app/ui/widgets/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .activity import ActivityDataGrid, DetailsGroupBox
+from .biosphere_update import BiosphereUpdater
 from .cutoff_menu import CutoffMenu
 from .line_edit import (SignalledPlainTextEdit, SignalledComboEdit,
                         SignalledLineEdit)

--- a/activity_browser/app/ui/widgets/biosphere_update.py
+++ b/activity_browser/app/ui/widgets/biosphere_update.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import brightway2 as bw
+from bw2data.errors import ValidityError
+from bw2io.data import (
+    add_ecoinvent_33_biosphere_flows, add_ecoinvent_34_biosphere_flows,
+    add_ecoinvent_35_biosphere_flows, add_ecoinvent_36_biosphere_flows,
+)
+from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
+
+from ...signals import signals
+
+
+class BiosphereUpdater(QtWidgets.QProgressDialog):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Updating '{}' database".format(bw.config.biosphere))
+        self.setLabelText("Adding new flows to biosphere database")
+        self.setRange(0, 0)
+        self.show()
+
+        self.thread = UpdateBiosphereThread(self)
+        self.setMaximum(self.thread.total_patches)
+        self.thread.progress.connect(self.update_progress)
+        self.thread.finished.connect(self.finished)
+        self.thread.start()
+
+    def finished(self, result: int = None) -> None:
+        outcome = result or 0
+        self.thread.exit(outcome)
+        self.setMaximum(1)
+        self.setValue(1)
+        signals.database_changed.emit(bw.config.biosphere)
+        signals.databases_changed.emit()
+
+    @Slot(int)
+    def update_progress(self, current: int):
+        self.setValue(current)
+
+
+class UpdateBiosphereThread(QtCore.QThread):
+    PATCHES = (
+        add_ecoinvent_33_biosphere_flows,
+        add_ecoinvent_34_biosphere_flows,
+        add_ecoinvent_35_biosphere_flows,
+        add_ecoinvent_36_biosphere_flows,
+    )
+    progress = Signal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.total_patches = len(self.PATCHES)
+
+    def run(self):
+        try:
+            for i, patch in enumerate(self.PATCHES):
+                self.progress.emit(i)
+                patch()
+        except ValidityError as e:
+            print("Could not patch biosphere: {}".format(str(e)))
+            self.exit(1)


### PR DESCRIPTION
Fixes #213, fixes #292.

Catches the `InvalidExchange` exception and handles it by removing the empty database and pointing the user to a new biosphere update functionality.

Adds a new action to the `File` menu which uses brightway2-io functions to update older versions of the default biosphere database (`biosphere3`).