### PR TITLE
Always include default biosphere in MLCA all_databases call

### DIFF
--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -194,13 +194,17 @@ class MLCA(object):
         return {key: 1 for func_unit in self.func_units for key in func_unit}
 
     @property
-    def all_databases(self):
-        """Get all databases linked to the functional units."""
-        databases = list()
-        for f in self.fu_activity_keys:
-            databases.append(f[0])
-            databases.extend(bw.databases[f[0]].get('depends', []))
-        return set(databases)
+    def all_databases(self) -> set:
+        """ Get all databases linked to the functional units.
+        """
+        databases = set(f[0] for f in self.fu_activity_keys)
+        for dep in (bw.databases[db].get('depends', []) for db in databases):
+            databases = databases.union(dep)
+        # In rare cases, the default biosphere is not found as a dependency, see:
+        # https://github.com/LCA-ActivityBrowser/activity-browser/issues/298
+        # Always include it.
+        databases.add(bw.config.biosphere)
+        return databases
 
     @property
     def lca_scores_normalized(self):

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -383,7 +383,7 @@ class Controller(object):
         origin_db = activity_key[0]
         activity = bw.get_activity(activity_key)
 
-        available_target_dbs = project_settings.get_editable_databases()
+        available_target_dbs = list(project_settings.get_editable_databases())
 
         if origin_db in available_target_dbs:
             available_target_dbs.remove(origin_db)


### PR DESCRIPTION
Resolves #298.

Apart from patching that issue, this also ensures the copy command actually works again.

Also improve the speed of the copy call when copying multiple activities to a large database.