### PR TITLE
Prepwork pyside2 refactor

### DIFF
--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 import brightway2 as bw
 from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import pyqtSlot as Slot
 from bw2data.backends.peewee import sqlite3_lci_db
 from bw2data.project import ProjectDataset, SubstitutableDatabase
 
@@ -476,7 +477,7 @@ class Controller(object):
         signals.database_changed.emit(exchange['output'][0])
 
     @staticmethod
-    @QtCore.pyqtSlot(object, str, object)
+    @Slot(object, str, object)
     def modify_exchange(exchange, field, value):
         # The formula field needs special handling.
         if field == "formula":

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import pyqtSignal as Signal
 
 
 class Signals(QtCore.QObject):
@@ -9,85 +10,85 @@ class Signals(QtCore.QObject):
     # General Settings
 
     # bw2 directory
-    switch_bw2_dir_path = QtCore.pyqtSignal(str)
-    # directory_changed = QtCore.pyqtSignal()
+    switch_bw2_dir_path = Signal(str)
+    # directory_changed = Signal()
 
     # Project
-    change_project = QtCore.pyqtSignal(str)
-    # change_project_dialog = QtCore.pyqtSignal()
-    new_project = QtCore.pyqtSignal()
-    copy_project = QtCore.pyqtSignal()
-    delete_project = QtCore.pyqtSignal()
-    project_selected = QtCore.pyqtSignal()
-    projects_changed = QtCore.pyqtSignal()
+    change_project = Signal(str)
+    # change_project_dialog = Signal()
+    new_project = Signal()
+    copy_project = Signal()
+    delete_project = Signal()
+    project_selected = Signal()
+    projects_changed = Signal()
 
     # Database
-    add_database = QtCore.pyqtSignal()
-    delete_database = QtCore.pyqtSignal(str)
-    copy_database = QtCore.pyqtSignal(str)
-    install_default_data = QtCore.pyqtSignal()
-    import_database = QtCore.pyqtSignal()
+    add_database = Signal()
+    delete_database = Signal(str)
+    copy_database = Signal(str)
+    install_default_data = Signal()
+    import_database = Signal()
 
-    database_selected = QtCore.pyqtSignal(str)
-    databases_changed = QtCore.pyqtSignal()
-    database_changed = QtCore.pyqtSignal(str)
-    database_read_only_changed = QtCore.pyqtSignal(str, bool)
+    database_selected = Signal(str)
+    databases_changed = Signal()
+    database_changed = Signal(str)
+    database_read_only_changed = Signal(str, bool)
 
     # Activity (key, field, new value)
-    new_activity = QtCore.pyqtSignal(str)
-    add_activity_to_history = QtCore.pyqtSignal(tuple)
-    duplicate_activity = QtCore.pyqtSignal(tuple)
-    duplicate_activity_to_db = QtCore.pyqtSignal(str, object)
-    show_duplicate_to_db_interface = QtCore.pyqtSignal(tuple)
-    open_activity_tab = QtCore.pyqtSignal(tuple)
-    open_activity_graph_tab = QtCore.pyqtSignal(tuple)
-    delete_activity = QtCore.pyqtSignal(tuple)
+    new_activity = Signal(str)
+    add_activity_to_history = Signal(tuple)
+    duplicate_activity = Signal(tuple)
+    duplicate_activity_to_db = Signal(str, object)
+    show_duplicate_to_db_interface = Signal(tuple)
+    open_activity_tab = Signal(tuple)
+    open_activity_graph_tab = Signal(tuple)
+    delete_activity = Signal(tuple)
 
     # Activity editing
-    edit_activity = QtCore.pyqtSignal(str)  # db_name
-    activity_modified = QtCore.pyqtSignal(tuple, str, object)
+    edit_activity = Signal(str)  # db_name
+    activity_modified = Signal(tuple, str, object)
 
     # Exchanges
-    # exchanges_output_modified = QtCore.pyqtSignal(list, tuple)
-    exchanges_deleted = QtCore.pyqtSignal(list)
-    exchanges_add = QtCore.pyqtSignal(list, tuple)
-    exchange_amount_modified = QtCore.pyqtSignal(object, float)
-    exchange_modified = QtCore.pyqtSignal(object, str, object)
+    # exchanges_output_modified = Signal(list, tuple)
+    exchanges_deleted = Signal(list)
+    exchanges_add = Signal(list, tuple)
+    exchange_amount_modified = Signal(object, float)
+    exchange_modified = Signal(object, str, object)
 
     # Parameters
-    add_activity_parameter = QtCore.pyqtSignal(tuple)
-    parameters_changed = QtCore.pyqtSignal()
+    add_activity_parameter = Signal(tuple)
+    parameters_changed = Signal()
     # Pass the key of the activity holding the exchange
-    exchange_formula_changed = QtCore.pyqtSignal(tuple)
+    exchange_formula_changed = Signal(tuple)
 
     # Calculation Setups
-    new_calculation_setup = QtCore.pyqtSignal()
-    delete_calculation_setup = QtCore.pyqtSignal(str)
-    rename_calculation_setup = QtCore.pyqtSignal(str)
-    set_default_calculation_setup = QtCore.pyqtSignal()
+    new_calculation_setup = Signal()
+    delete_calculation_setup = Signal(str)
+    rename_calculation_setup = Signal(str)
+    set_default_calculation_setup = Signal()
 
-    calculation_setup_changed = QtCore.pyqtSignal()
-    calculation_setup_selected = QtCore.pyqtSignal(str)
+    calculation_setup_changed = Signal()
+    calculation_setup_selected = Signal(str)
 
     # LCA Results
-    lca_calculation = QtCore.pyqtSignal(str)
-    lca_results_tabs_changed = QtCore.pyqtSignal()
+    lca_calculation = Signal(str)
+    lca_results_tabs_changed = Signal()
 
-    method_selected = QtCore.pyqtSignal(tuple)
-    method_tabs_changed = QtCore.pyqtSignal()
+    method_selected = Signal(tuple)
+    method_tabs_changed = Signal()
 
     # Qt Windows
-    update_windows = QtCore.pyqtSignal()
-    new_statusbar_message = QtCore.pyqtSignal(str)
+    update_windows = Signal()
+    new_statusbar_message = Signal(str)
 
     # Tabs
-    toggle_show_or_hide_tab = QtCore.pyqtSignal(str)
-    show_tab = QtCore.pyqtSignal(str)
-    hide_tab = QtCore.pyqtSignal(str)
-    hide_when_empty = QtCore.pyqtSignal()
+    toggle_show_or_hide_tab = Signal(str)
+    show_tab = Signal(str)
+    hide_tab = Signal(str)
+    hide_when_empty = Signal()
 
     # Metadata
-    metadata_changed = QtCore.pyqtSignal(tuple)  # key
+    metadata_changed = Signal(tuple)  # key
 
 
 signals = Signals()

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -7,6 +7,7 @@ from bw2data.parameters import (ProjectParameter, DatabaseParameter, Group,
                                 ActivityParameter)
 import pandas as pd
 from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from .delegates import (FloatDelegate, FormulaDelegate, StringDelegate,
                         ViewOnlyDelegate)
@@ -19,7 +20,7 @@ from ...bwutils.commontasks import AB_names_to_bw_keys
 class BaseExchangeTable(ABDataFrameEdit):
     COLUMNS = []
     # Signal used to correctly control `DetailsGroupBox`
-    updated = QtCore.pyqtSignal()
+    updated = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -96,7 +97,7 @@ class BaseExchangeTable(ABDataFrameEdit):
             signals.open_activity_tab.emit(act)
             signals.add_activity_to_history.emit(act)
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def delete_exchanges(self) -> None:
         """ Remove all of the selected exchanges from the activity.
         """

--- a/activity_browser/app/ui/tables/delegates/formula.py
+++ b/activity_browser/app/ui/tables/delegates/formula.py
@@ -3,6 +3,7 @@ from os import devnull
 
 from asteval import Interpreter
 from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from ...icons import qicons
 from ...wizards import ParameterWizard
@@ -12,8 +13,8 @@ class CalculatorButtons(QtWidgets.QWidget):
     """ A custom layout containing calculator buttons, emits a signal
     for each button pressed.
     """
-    button_press = QtCore.pyqtSignal(str)
-    clear = QtCore.pyqtSignal()
+    button_press = Signal(str)
+    clear = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -56,7 +57,7 @@ Keep in mind that the result of a formula must be a scalar value!
         layout.addStretch(1)
         self.setLayout(layout)
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def explanation(self):
         return QtWidgets.QMessageBox.question(
             self, "More...", self.explain_text, QtWidgets.QMessageBox.Ok,
@@ -122,7 +123,7 @@ class FormulaDialog(QtWidgets.QDialog):
                 model.setItem(x, y, model_item)
         self.parameters.resizeColumnsToContents()
 
-    @QtCore.pyqtSlot(str, str, str)
+    @Slot(str, str, str)
     def append_parameter(self, name: str, amount: str, p_type: str) -> None:
         """ Catch new parameters from the wizard and add them to the list.
         """
@@ -145,7 +146,7 @@ class FormulaDialog(QtWidgets.QDialog):
         """
         self.key = key
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def create_parameter(self):
         wizard = ParameterWizard(self.key, self)
         wizard.complete.connect(self.append_parameter)
@@ -165,7 +166,7 @@ class FormulaDialog(QtWidgets.QDialog):
         else:
             self.text_field.setText(str(value))
 
-    @QtCore.pyqtSlot(QtCore.QModelIndex)
+    @Slot(QtCore.QModelIndex)
     def append_parameter_name(self, index: QtCore.QModelIndex) -> None:
         """ Take the index from the parameters table and append the parameter
         name to the formula.
@@ -173,7 +174,7 @@ class FormulaDialog(QtWidgets.QDialog):
         param_name = self.parameters.model().index(index.row(), 0).data()
         self.text_field.insert(param_name)
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def validate_formula(self) -> None:
         """ Qt slot triggered whenever a change is detected in the text_field.
         """

--- a/activity_browser/app/ui/tables/history.py
+++ b/activity_browser/app/ui/tables/history.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 import pandas as pd
-from PyQt5.QtCore import pyqtSlot
+from PyQt5.QtCore import pyqtSlot as Slot
 from PyQt5.QtGui import QCursor
 from PyQt5.QtWidgets import QAbstractItemView, QMenu
 
@@ -47,7 +47,7 @@ class ActivitiesHistoryTable(ABDataFrameView):
         menu.popup(QCursor.pos())
         menu.exec()
 
-    @pyqtSlot()
+    @Slot()
     def open_tab(self):
         """ Only a single row can be selected for the history,
         trigger the open_tab_event.
@@ -61,7 +61,7 @@ class ActivitiesHistoryTable(ABDataFrameView):
         signals.open_activity_tab.emit(key)
         self.add_activity(key)
 
-    @pyqtSlot(tuple)
+    @Slot(tuple)
     def add_activity(self, key: tuple) -> None:
         row = self.dataframe.loc[self.dataframe["key"].isin([key])]
 

--- a/activity_browser/app/ui/tables/inventory.py
+++ b/activity_browser/app/ui/tables/inventory.py
@@ -6,6 +6,7 @@ import functools
 import arrow
 import brightway2 as bw
 from PyQt5 import QtWidgets, QtCore
+from PyQt5.QtCore import pyqtSlot as Slot
 from bw2data.utils import natural_sort
 import numpy as np
 import pandas as pd
@@ -94,7 +95,7 @@ class DatabasesTable(ABDataFrameView):
         signals.database_selected.emit(self.model.index(index.row(), 0).data())
 
     @staticmethod
-    @QtCore.pyqtSlot(str, bool)
+    @Slot(str, bool)
     def read_only_changed(db: str, read_only: bool):
         """ User has clicked to update a db to either read-only or not.
         """
@@ -204,13 +205,13 @@ class ActivitiesBiosphereTable(ABDataFrameView):
         key = self.model.index(index.row(), self.fields.index("key")).data()
         return literal_eval(key)
 
-    @QtCore.pyqtSlot(QtCore.QModelIndex)
+    @Slot(QtCore.QModelIndex)
     def open_activity_tab(self, proxy: QtCore.QModelIndex) -> None:
         key = self.get_key(proxy)
         signals.open_activity_tab.emit(key)
         signals.add_activity_to_history.emit(key)
 
-    @QtCore.pyqtSlot(str)
+    @Slot(str)
     def check_database_changed(self, db_name: str) -> None:
         """ Determine if we need to re-sync (did 'our' db change?).
         """

--- a/activity_browser/app/ui/tables/models.py
+++ b/activity_browser/app/ui/tables/models.py
@@ -2,7 +2,7 @@
 import numpy as np
 import brightway2 as bw
 from pandas import DataFrame
-from PyQt5.QtCore import QAbstractItemModel, QAbstractTableModel, QModelIndex, Qt, QVariant
+from PyQt5.QtCore import QAbstractItemModel, QAbstractTableModel, QModelIndex, Qt
 from PyQt5.QtGui import QBrush
 
 from ..style import style_item
@@ -25,7 +25,7 @@ class PandasModel(QAbstractTableModel):
 
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid():
-            return QVariant()
+            return None
 
         if role == Qt.DisplayRole:
             value = self._dataframe.iat[index.row(), index.column()]
@@ -37,7 +37,7 @@ class PandasModel(QAbstractTableModel):
                 value = value.item()
             elif isinstance(value, tuple):
                 value = str(value)
-            return QVariant() if value is None else QVariant(value)
+            return value
 
         if role == Qt.ForegroundRole:
             col_name = self._dataframe.columns[index.column()]
@@ -45,7 +45,7 @@ class PandasModel(QAbstractTableModel):
                 col_name = AB_names_to_bw_keys.get(col_name, "")
             return QBrush(style_item.brushes.get(col_name, style_item.brushes.get("default")))
 
-        return QVariant()
+        return None
 
     def flags(self, index):
         return Qt.ItemIsSelectable | Qt.ItemIsEnabled
@@ -228,11 +228,11 @@ class BaseTreeModel(QAbstractItemModel):
 
     def data(self, index, role: int = Qt.DisplayRole):
         if not index.isValid():
-            return QVariant()
+            return None
 
         item = index.internalPointer()
         if role == Qt.DisplayRole:
-            return QVariant(item.data(index.column()))
+            return item.data(index.column())
 
         if role == Qt.ForegroundRole:
             col_name = self.root.COLUMNS[index.column()]
@@ -243,10 +243,10 @@ class BaseTreeModel(QAbstractItemModel):
     def headerData(self, column, orientation, role: int = Qt.DisplayRole):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
             try:
-                return QVariant(self.root.COLUMNS[column])
+                return self.root.COLUMNS[column]
             except IndexError:
                 pass
-        return QVariant()
+        return None
 
     def index(self, row, column, parent=None):
         if not self.hasIndex(row, column, parent):

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -7,7 +7,7 @@ import brightway2 as bw
 import pandas as pd
 from bw2data.parameters import (ActivityParameter, DatabaseParameter, Group,
                                 ProjectParameter)
-from PyQt5.QtCore import pyqtSlot, Qt
+from PyQt5.QtCore import pyqtSlot as Slot, Qt
 from PyQt5.QtGui import QContextMenuEvent, QDragMoveEvent, QDropEvent
 from PyQt5.QtWidgets import QAction, QInputDialog, QMenu
 
@@ -452,7 +452,7 @@ class ActivityParameterTable(BaseParameterTable):
         signals.blockSignals(False)
         signals.parameters_changed.emit()
 
-    @pyqtSlot(tuple)
+    @Slot(tuple)
     def add_parameter(self, key: tuple) -> None:
         """ Given the activity key, generate a new row with data from
         the activity and immediately call `new_activity_parameters`.
@@ -497,7 +497,7 @@ class ActivityParameterTable(BaseParameterTable):
                 self.delete_action.setEnabled(False)
             menu.exec(event.globalPos())
 
-    @pyqtSlot()
+    @Slot()
     def open_activity_tab(self):
         """ Triggers the activity tab to open one or more activities.
         """
@@ -522,7 +522,7 @@ class ActivityParameterTable(BaseParameterTable):
         group.order = order
         group.expire()
 
-    @pyqtSlot()
+    @Slot()
     def delete_parameter(self, proxy) -> None:
         """ Override the base method to include additional logic.
 
@@ -624,7 +624,7 @@ class ExchangesTable(ABDictTreeView):
     def _select_model(self):
         return ParameterTreeModel(self.data)
 
-    @pyqtSlot(tuple)
+    @Slot(tuple)
     def parameterize_exchanges(self, key: tuple) -> None:
         """ Used whenever a formula is set on an exchange in an activity.
 
@@ -640,7 +640,7 @@ class ExchangesTable(ABDictTreeView):
         signals.parameters_changed.emit()
 
     @staticmethod
-    @pyqtSlot()
+    @Slot()
     def recalculate_exchanges():
         """ Will iterate through all activity parameters and rerun the
         formula interpretation for all exchanges.

--- a/activity_browser/app/ui/tables/views.py
+++ b/activity_browser/app/ui/tables/views.py
@@ -4,7 +4,7 @@ from functools import wraps
 from typing import Optional
 
 from PyQt5.QtCore import (QAbstractTableModel, QModelIndex, QSize,
-                          QSortFilterProxyModel, Qt, pyqtSlot)
+                          QSortFilterProxyModel, Qt, pyqtSlot as Slot)
 from PyQt5.QtWidgets import QFileDialog, QTableView, QTreeView
 
 from activity_browser.app.settings import ab_settings
@@ -133,7 +133,7 @@ class ABDataFrameView(QTableView):
                 filepath += '.xlsx'
             self.dataframe.to_excel(filepath)
 
-    @pyqtSlot()
+    @Slot()
     def keyPressEvent(self, e):
         """ Allow user to copy selected data from the table
 
@@ -201,7 +201,7 @@ class ABDictTreeView(QTreeView):
         """
         raise NotImplementedError
 
-    @pyqtSlot()
+    @Slot()
     def _resize(self) -> None:
         """ Resize the first column (usually 'name') whenever an item is
         expanded or collapsed.

--- a/activity_browser/app/ui/tabs/activity.py
+++ b/activity_browser/app/ui/tabs/activity.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 from PyQt5 import QtCore, QtWidgets, QtGui
+from PyQt5.QtCore import pyqtSlot as Slot
 
 from ..style import style_activity_tab
 from ..tables import (BiosphereExchangeTable, DownstreamExchangeTable,
@@ -27,7 +28,7 @@ class ActivitiesTab(ABTab):
         signals.delete_activity.connect(self.close_tab_by_tab_name)
         signals.project_selected.connect(self.close_all)
 
-    @QtCore.pyqtSlot(tuple)
+    @Slot(tuple)
     def open_activity_tab(self, key: tuple) -> None:
         """Opens new tab or focuses on already open one."""
         if key not in self.tabs:
@@ -151,7 +152,7 @@ class ActivityTab(QtWidgets.QWidget):
         signals.parameters_changed.connect(self.populate)
         # signals.activity_modified.connect(self.update_activity_values)
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def open_graph(self):
         signals.open_activity_graph_tab.emit(self.key)
 

--- a/activity_browser/app/ui/tabs/base.py
+++ b/activity_browser/app/ui/tabs/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PyQt5.QtCore import pyqtSlot
+from PyQt5.QtCore import pyqtSlot as Slot
 from PyQt5.QtWidgets import QMessageBox, QWidget
 
 
@@ -28,7 +28,7 @@ class BaseRightTab(QWidget):
         """
         raise NotImplementedError
 
-    @pyqtSlot()
+    @Slot()
     def explanation(self):
         """ Builds and shows a message box containing whatever text is set
         on self.explain_text

--- a/activity_browser/app/ui/tabs/parameters.py
+++ b/activity_browser/app/ui/tabs/parameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PyQt5.QtCore import pyqtSlot, QSize
+from PyQt5.QtCore import pyqtSlot as Slot, QSize
 from PyQt5.QtWidgets import (QCheckBox, QHBoxLayout, QPushButton, QToolBar,
                              QVBoxLayout, QTabWidget)
 
@@ -41,7 +41,7 @@ class ParametersTab(QTabWidget):
         # signals.add_activity_parameter.connect(self.activity_parameter_added)
         pass
 
-    @pyqtSlot()
+    @Slot()
     def activity_parameter_added(self) -> None:
         """ Selects the correct sub-tab to show and trigger a switch to
         the Parameters tab.
@@ -178,13 +178,13 @@ can be used within the formula!</p>
         else:
             self.new_database_param.setEnabled(True)
 
-    @pyqtSlot()
+    @Slot()
     def hide_uncertainty_columns(self):
         show = self.uncertainty_columns.isChecked()
         for table in self.tables.values():
             table.uncertainty_columns(show)
 
-    @pyqtSlot()
+    @Slot()
     def activity_order_column(self) -> None:
         col = self.activity_table.combine_columns().index("order")
         state = self.show_order.isChecked()
@@ -194,7 +194,7 @@ can be used within the formula!</p>
             self.activity_table.setColumnHidden(col, False)
             self.activity_table.resizeColumnToContents(col)
 
-    @pyqtSlot()
+    @Slot()
     def hide_database_parameter(self) -> None:
         hide = not self.show_database_params.isChecked()
         self.database_header.setHidden(hide)

--- a/activity_browser/app/ui/web/graphnav/navigator.py
+++ b/activity_browser/app/ui/web/graphnav/navigator.py
@@ -6,7 +6,7 @@ import networkx as nx
 
 import brightway2 as bw
 from PyQt5 import QtWidgets, QtCore, QtWebEngineWidgets, QtWebChannel
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import pyqtSignal as Signal, pyqtSlot as Slot, Qt
 
 from .signals import graphsignals
 from ...icons import qicons
@@ -84,7 +84,7 @@ class GraphNavigatorWidget(QtWidgets.QWidget):
             self.selected_db = key[0]
             self.new_graph(key)
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def loadFinishedHandler(self):
         """Executed when webpage has been loaded for the first time or refreshed.
         This is needed to resend the json data the first time after the page has completely loaded."""
@@ -263,9 +263,9 @@ class GraphNavigatorWidget(QtWidgets.QWidget):
 
 
 class Bridge(QtCore.QObject):
-    graph_ready = QtCore.pyqtSignal(str)
+    graph_ready = Signal(str)
 
-    @QtCore.pyqtSlot(str)
+    @Slot(str)
     def node_clicked(self, click_text):
         """ Is called when a node is clicked in Javascript.
         Args:

--- a/activity_browser/app/ui/web/graphnav/sankey_navigator.py
+++ b/activity_browser/app/ui/web/graphnav/sankey_navigator.py
@@ -6,7 +6,7 @@ import time
 
 import brightway2 as bw
 from PyQt5 import QtWidgets, QtCore, QtWebEngineWidgets, QtWebChannel
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import pyqtSignal as Signal, pyqtSlot as Slot, Qt
 
 from .signals import graphsignals
 from ...icons import qicons
@@ -63,7 +63,7 @@ class SankeyNavigatorWidget(QtWidgets.QWidget):
 
         self.connect_signals()
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def loadFinishedHandler(self):
         """Executed when webpage has been loaded for the first time or refreshed.
         Can be used to trigger a calculation after the webpage has been completely loaded."""
@@ -277,9 +277,9 @@ class SankeyNavigatorWidget(QtWidgets.QWidget):
 
 
 class Bridge(QtCore.QObject):
-    graph_ready = QtCore.pyqtSignal(str)
+    graph_ready = Signal(str)
 
-    @QtCore.pyqtSlot(str)
+    @Slot(str)
     def node_clicked(self, click_text):
         """ Is called when a node is clicked in Javascript.
         Args:

--- a/activity_browser/app/ui/web/graphnav/signals.py
+++ b/activity_browser/app/ui/web/graphnav/signals.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtCore
+from PyQt5.QtCore import pyqtSignal as Signal
 
 
 class GraphSignals(QtCore.QObject):
-    update_graph = QtCore.pyqtSignal(dict)
+    update_graph = Signal(dict)
 
 graphsignals = GraphSignals()

--- a/activity_browser/app/ui/web/sankey/sankey.py
+++ b/activity_browser/app/ui/web/sankey/sankey.py
@@ -7,6 +7,7 @@ import numpy as np
 import brightway2 as bw
 import matplotlib.pyplot as plt
 from PyQt5 import QtWidgets, QtCore, QtWebEngineWidgets, QtWebChannel
+from PyQt5.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from .. import wait_html
 from .signals import sankeysignals
@@ -130,19 +131,19 @@ class SankeyWidget(QtWidgets.QWidget):
 
 
 class Bridge(QtCore.QObject):
-    link_clicked = QtCore.pyqtSignal(int)
-    lca_calc_finished = QtCore.pyqtSignal(str)
-    viewer_waiting = QtCore.pyqtSignal()
-    sankey_ready = QtCore.pyqtSignal(str)
+    link_clicked = Signal(int)
+    lca_calc_finished = Signal(str)
+    viewer_waiting = Signal()
+    sankey_ready = Signal(str)
 
-    @QtCore.pyqtSlot(str)
+    @Slot(str)
     def link_selected(self, link):
         target_key = link.split('-')[-2]
         if target_key.startswith('__'):
             target_key = target_key.split('_')[-2]
         self.link_clicked.emit(int(target_key))
 
-    @QtCore.pyqtSlot()
+    @Slot()
     def viewer_ready(self):
         # print("Viewer ready!")
         self.viewer_waiting.emit()

--- a/activity_browser/app/ui/web/sankey/signals.py
+++ b/activity_browser/app/ui/web/sankey/signals.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtCore
+from PyQt5.QtCore import pyqtSignal as Signal
 
 
 class SankeySignals(QtCore.QObject):
-    gt_ready = QtCore.pyqtSignal(dict)
-    calculating_gt = QtCore.pyqtSignal()
-    initial_sankey_ready = QtCore.pyqtSignal()
+    gt_ready = Signal(dict)
+    calculating_gt = Signal()
+    initial_sankey_ready = Signal()
 
 
 sankeysignals = SankeySignals()

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -11,8 +11,8 @@ from bw2io.extractors import Ecospold2DataExtractor
 from bw2io import SingleOutputEcospold2Importer
 from bw2data import config
 from bw2data.backends import SQLiteBackend
-from bw2data.errors import InvalidExchange
 from PyQt5 import QtWidgets, QtCore
+from PyQt5.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from activity_browser.app.signals import signals
 
@@ -401,17 +401,17 @@ class ImportPage(QtWidgets.QWizardPage):
             self.main_worker_thread.update(db_name=self.field('db_name'))
         self.main_worker_thread.start()
 
-    @QtCore.pyqtSlot(int, int)
+    @Slot(int, int)
     def update_extraction_progress(self, i, tot):
         self.extraction_progressbar.setMaximum(tot)
         self.extraction_progressbar.setValue(i)
 
-    @QtCore.pyqtSlot(int, int)
+    @Slot(int, int)
     def update_strategy_progress(self, i, tot):
         self.strategy_progressbar.setMaximum(tot)
         self.strategy_progressbar.setValue(i)
 
-    @QtCore.pyqtSlot(int, int)
+    @Slot(int, int)
     def update_db_progress(self, i, tot):
         self.db_progressbar.setMaximum(tot)
         self.db_progressbar.setValue(i)
@@ -596,7 +596,7 @@ class EcoinventLoginPage(QtWidgets.QWizardPage):
         self.login_thread.update(self.username, self.password)
         self.login_thread.start()
 
-    @QtCore.pyqtSlot(bool)
+    @Slot(bool)
     def login_response(self, success):
         if not success:
             self.success_label.setText('Login failed!')
@@ -670,7 +670,7 @@ class EcoinventVersionPage(QtWidgets.QWizardPage):
     def nextId(self):
         return self.wizard.pages.index(self.wizard.db_name_page)
 
-    @QtCore.pyqtSlot(str)
+    @Slot(str)
     def update_system_model_combobox(self, version: str) -> None:
         """ Updates the `system_model_combobox` whenever the user selects a
         different ecoinvent version.
@@ -737,19 +737,19 @@ class ImportCanceledError(Exception):
 
 
 class ImportSignals(QtCore.QObject):
-    extraction_progress = QtCore.pyqtSignal(int, int)
-    strategy_progress = QtCore.pyqtSignal(int, int)
-    db_progress = QtCore.pyqtSignal(int, int)
-    finalizing = QtCore.pyqtSignal()
-    finished = QtCore.pyqtSignal()
-    unarchive_finished = QtCore.pyqtSignal()
-    download_complete = QtCore.pyqtSignal()
-    biosphere_finished = QtCore.pyqtSignal()
-    biosphere_incomplete = QtCore.pyqtSignal(tuple)
-    copydb_finished = QtCore.pyqtSignal()
+    extraction_progress = Signal(int, int)
+    strategy_progress = Signal(int, int)
+    db_progress = Signal(int, int)
+    finalizing = Signal()
+    finished = Signal()
+    unarchive_finished = Signal()
+    download_complete = Signal()
+    biosphere_finished = Signal()
+    biosphere_incomplete = Signal(tuple)
+    copydb_finished = Signal()
     cancel_sentinel = False
-    login_success = QtCore.pyqtSignal(bool)
-    connection_problem = QtCore.pyqtSignal(tuple)
+    login_success = Signal(bool)
+    connection_problem = Signal(tuple)
 
 
 import_signals = ImportSignals()

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -267,7 +267,7 @@ class ConfirmationPage(QtWidgets.QWizardPage):
         super().__init__(parent)
         self.wizard = self.parent()
         self.setCommitPage(True)
-        self.setButtonText(2, 'Import Database')
+        self.setButtonText(QtWidgets.QWizard.CommitButton, 'Import Database')
         self.current_project_label = QtWidgets.QLabel('empty')
         self.db_name_label = QtWidgets.QLabel('empty')
         self.path_label = QtWidgets.QLabel('empty')

--- a/activity_browser/app/ui/wizards/parameter_wizard.py
+++ b/activity_browser/app/ui/wizards/parameter_wizard.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtCore import pyqtSignal as Signal
 
 from activity_browser.app.bwutils import commontasks as bc
 
@@ -18,7 +19,7 @@ PARAMETER_FIELDS_ENUM = {
 
 
 class ParameterWizard(QtWidgets.QWizard):
-    complete = QtCore.pyqtSignal(str, str, str)
+    complete = Signal(str, str, str)
 
     def __init__(self, key: tuple, parent=None):
         super().__init__(parent)

--- a/activity_browser/app/ui/wizards/settings_wizard.py
+++ b/activity_browser/app/ui/wizards/settings_wizard.py
@@ -82,7 +82,7 @@ class SettingsPage(QtWidgets.QWizardPage):
         self.setLayout(self.layout)
 
         self.setFinalPage(True)
-        self.setButtonText(3, 'Save')
+        self.setButtonText(QtWidgets.QWizard.FinishButton, 'Save')
 
         # signals
         self.startup_project_combobox.currentIndexChanged.connect(self.changed)


### PR DESCRIPTION
Prepare code for refactoring to pyside2 (#184).

These changes clear up PyQt specific naming and drops the use of QVariant.

No functional changes are made.