### PR TITLE
Fix empty formula rebuild

### DIFF
--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -496,7 +496,7 @@ class Controller(object):
         else:
             exchange[field] = value
         exchange.save()
-        if field == "formula" and value:
-            # If a formula was set or changed, recalculate exchanges
+        if field == "formula":
+            # If a formula was set, removed or changed, recalculate exchanges
             signals.exchange_formula_changed.emit(exchange["output"])
         signals.database_changed.emit(exchange['output'][0])

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -126,8 +126,6 @@ class BaseExchangeTable(ABDataFrameEdit):
         # Clear out all ParameterizedExchanges before recalculating
         param = ActivityParameter.get_or_none(database=self.key[0], code=self.key[1])
         if param:
-            activity = bw.get_activity(self.key)
-            bw.parameters.remove_exchanges_from_group(param.group, activity)
             signals.exchange_formula_changed.emit(self.key)
 
     def contextMenuEvent(self, a0) -> None:

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -638,6 +638,7 @@ class ExchangesTable(ABDictTreeView):
 
         param = ActivityParameter.get(database=key[0], code=key[1])
         act = bw.get_activity(key)
+        bw.parameters.remove_exchanges_from_group(param.group, act)
         bw.parameters.add_exchanges_to_group(param.group, act)
         ActivityParameter.recalculate_exchanges(param.group)
         signals.parameters_changed.emit()

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -226,7 +226,7 @@ class ProjectParameterTable(BaseParameterTable):
                    DatabaseParameter.select().count())
         try:
             bw.parameters.new_project_parameters([
-                {"name": "param_{}".format(counter + 1), "amount": 0.0}
+                {"name": "param_{}".format(counter + 1), "amount": 1.0}
             ], False)
             signals.parameters_changed.emit()
         except ValueError as e:
@@ -295,7 +295,7 @@ class DataBaseParameterTable(BaseParameterTable):
         database = next(iter(bw.databases))
         try:
             bw.parameters.new_database_parameters([
-                {"name": "param_{}".format(counter + 1), "amount": 0.0}
+                {"name": "param_{}".format(counter + 1), "amount": 1.0}
             ], database, False)
             signals.parameters_changed.emit()
         except ValueError as e:
@@ -466,7 +466,7 @@ class ActivityParameterTable(BaseParameterTable):
                  .where(ActivityParameter.group == group).count())
         row = {
             "name": "{}_{}".format(prep_name, count + 1),
-            "amount": act.get("amount", 0.0),
+            "amount": act.get("amount", 1.0),
             "formula": act.get("formula", ""),
             "database": key[0],
             "code": key[1],

--- a/activity_browser/app/ui/wizards/parameter_wizard.py
+++ b/activity_browser/app/ui/wizards/parameter_wizard.py
@@ -146,7 +146,7 @@ class CompleteParameterPage(QtWidgets.QWizardPage):
             self.field("btn_activity")
         ].index(True)
 
-        self.amount.setText("0.0")
+        self.amount.setText("1.0")
         if selected == 0:
             self.name.clear()
             self.database.setHidden(True)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -86,7 +86,7 @@ def test_edit_project_param(qtbot):
     # Now edit the formula of the 3rd param to use the 2nd param
     with qtbot.waitSignal(signals.parameters_changed, timeout=1000):
         table.model.setData(table.model.index(2, 2), "param_2 + 3")
-    assert ProjectParameter.get(name="param_3").amount == 3
+    assert ProjectParameter.get(name="param_3").amount == 4
 
 
 def test_delete_project_param(qtbot):


### PR DESCRIPTION
Ensure that ParameterizedExchange objects are all removed and (re)added to a group on any kind of change to an exchange formula in that group.

This makes sure that both the right-click 'clear formula' actions as well as emptying the formula field in the delegate work the same way.