### PR TITLE
Various patches for database importing

### DIFF
--- a/activity_browser/app/ui/menu_bar.py
+++ b/activity_browser/app/ui/menu_bar.py
@@ -19,6 +19,9 @@ class MenuBar(object):
             "&Update biosphere...", None
         )
         self.biosphere_updater = None
+        self.import_db_action = QtWidgets.QAction(
+            qicons.import_db, '&Import database...', None
+        )
 
         self.menubar = QtWidgets.QMenuBar()
         self.menubar.addMenu(self.setup_file_menu())
@@ -35,15 +38,12 @@ class MenuBar(object):
         signals.project_selected.connect(self.biosphere_exists)
         signals.databases_changed.connect(self.biosphere_exists)
         self.update_biosphere_action.triggered.connect(self.update_biosphere)
+        self.import_db_action.triggered.connect(signals.import_database.emit)
 
     # FILE
     def setup_file_menu(self):
         menu = QtWidgets.QMenu('&File', self.window)
-        menu.addAction(
-            qicons.import_db,
-            '&Import database...',
-            signals.import_database.emit
-        )
+        menu.addAction(self.import_db_action)
         menu.addAction(
             self.window.style().standardIcon(QtWidgets.QStyle.SP_DriveHDIcon),
             "&Export database...",
@@ -153,6 +153,7 @@ You should have received a copy of the GNU Lesser General Public License along w
         """
         exists = True if bw.config.biosphere in bw.databases else False
         self.update_biosphere_action.setEnabled(exists)
+        self.import_db_action.setEnabled(exists)
 
     def update_biosphere(self):
         """ Open a popup with progression bar and run through the different

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -638,7 +638,7 @@ class EcoinventLoginPage(QtWidgets.QWizardPage):
         self.login_button.clicked.connect(self.login)
         self.login_button.setCheckable(True)
         self.password_edit.returnPressed.connect(self.login_button.click)
-        self.success_label = QtWidgets.QLabel('')
+        self.success_label = QtWidgets.QLabel()
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.description_label)
         layout.addWidget(self.username_edit)
@@ -675,8 +675,8 @@ class EcoinventLoginPage(QtWidgets.QWizardPage):
         self.login_thread.update(self.username, self.password)
         self.login_thread.start()
 
-    @Slot(bool)
-    def login_response(self, success):
+    @Slot(bool, name="handleLoginResponse")
+    def login_response(self, success: bool):
         if not success:
             self.success_label.setText('Login failed!')
             self.complete = False
@@ -731,7 +731,7 @@ class EcoinventVersionPage(QtWidgets.QWizardPage):
         self.setLayout(layout)
 
     def initializePage(self):
-        if getattr(self, "db_dict") is None:
+        if self.db_dict is None:
             self.wizard.downloader.db_dict = self.wizard.downloader.get_available_files()
             self.db_dict = self.wizard.downloader.db_dict
         self.system_models = {
@@ -745,9 +745,17 @@ class EcoinventVersionPage(QtWidgets.QWizardPage):
         self.version_combobox.clear()
         self.system_model_combobox.clear()
         self.version_combobox.addItems(list(self.system_models.keys()))
-        # Adding the items will cause system_model_combobox to update
-        # and show the correct list, this is just to be sure.
-        self.update_system_model_combobox(self.version_combobox.currentText())
+        if bool(self.version_combobox.count()):
+            # Adding the items will cause system_model_combobox to update
+            # and show the correct list, this is just to be sure.
+            self.update_system_model_combobox(self.version_combobox.currentText())
+        else:
+            # Raise an error if the version_combobox is empty
+            import_signals.connection_problem.emit((
+                "Cannot find files",
+                "Cannot find any valid data with the given login credentials"
+            ))
+            self.wizard.back()
 
     def nextId(self):
         return DatabaseImportWizard.DB_NAME


### PR DESCRIPTION
- Enforce importer wizard order with `nextId` methods on each page. Add enums to QWizard class.
- Disable file-menu import if biosphere3 was not imported yet.
- Catch 'Extracted...' spam and redirect to devnull when unpacking 7z archives.
- Clean up import wizard when switching projects and when starting an import.
- Subclass `BW2Package` class to allow for deeper testing of data before attempting to store it. This should give users a clearer reason for an import failing.