### PR TITLE
Various fixes dec-2019

### DIFF
--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -482,10 +482,13 @@ class Contributions(object):
 
         """
         dfs = (
-            pd.DataFrame(v.values(), index=list(v.keys()), columns=pd.MultiIndex.from_tuples([k]))
+            pd.DataFrame(v.values(), index=list(v.keys()), columns=[k])
             for k, v in cont_dict.items()
         )
         df = pd.concat(dfs, sort=False, axis=1)
+        # If the cont_dict has tuples for keys, coerce df.columns into MultiIndex
+        if all(isinstance(k, tuple) for k in cont_dict.keys()):
+            df.columns = pd.MultiIndex.from_tuples(df.columns)
         special_keys = [('Total', ''), ('Rest', '')]
 
         if not mask:

--- a/activity_browser/app/ui/tabs/LCA_setup.py
+++ b/activity_browser/app/ui/tabs/LCA_setup.py
@@ -153,6 +153,7 @@ class LCASetupTab(QtWidgets.QWidget):
         signals.calculation_setup_selected.connect(lambda: self.show_details())
         signals.calculation_setup_selected.connect(self.enable_calculations)
         signals.calculation_setup_changed.connect(self.enable_calculations)
+        signals.calculation_setup_changed.connect(self.valid_presamples)
         signals.presample_package_created.connect(self.valid_presamples)
 
     def save_cs_changes(self):

--- a/activity_browser/app/ui/widgets/__init__.py
+++ b/activity_browser/app/ui/widgets/__init__.py
@@ -3,6 +3,7 @@ from .activity import ActivityDataGrid, DetailsGroupBox
 from .biosphere_update import BiosphereUpdater
 from .comparison_switch import SwitchComboBox
 from .cutoff_menu import CutoffMenu
+from .database_copy import CopyDatabaseDialog
 from .dialog import ForceInputDialog
 from .line_edit import (SignalledPlainTextEdit, SignalledComboEdit,
                         SignalledLineEdit)

--- a/activity_browser/app/ui/widgets/database_copy.py
+++ b/activity_browser/app/ui/widgets/database_copy.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import brightway2 as bw
+from PySide2 import QtCore, QtWidgets
+from PySide2.QtCore import Slot
+
+from ...signals import signals
+
+
+class CopyDatabaseDialog(QtWidgets.QProgressDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setWindowTitle('Copying database')
+        self.setRange(0, 0)
+        self.show()
+
+        self.thread = CopyDatabaseThread(self)
+        self.thread.finished.connect(self.complete)
+
+    def begin_copy(self, copy_from: str, copy_to: str) -> None:
+        if not all([copy_from, copy_to]):
+            raise ValueError("Copy information not configured")
+        if copy_from not in bw.databases:
+            raise ValueError("Database <strong>{}</strong> does not exist!".format(copy_from))
+        if copy_to in bw.databases:
+            raise ValueError("Database <strong>{}</strong> already exists!".format(copy_to))
+        self.setLabelText(
+            'Copying existing database <b>{}</b> to new database <b>{}</b>:'.format(
+                copy_from, copy_to)
+        )
+        self.thread.configure(copy_from, copy_to)
+        self.thread.start()
+
+    @Slot(name="threadComplete")
+    def complete(self) -> None:
+        self.setMaximum(1)
+        self.setValue(1)
+        signals.databases_changed.emit()
+
+
+class CopyDatabaseThread(QtCore.QThread):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.copy_from = None
+        self.copy_to = None
+        # https://doc.qt.io/qt-5/qthread.html#managing-threads
+        self.finished.connect(self.deleteLater)
+
+    def configure(self, copy_from: str, copy_to: str):
+        self.copy_from = copy_from
+        self.copy_to = copy_to
+
+    def run(self):
+        bw.Database(self.copy_from).copy(self.copy_to)

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -891,7 +891,6 @@ class ImportSignals(QtCore.QObject):
     download_complete = Signal()
     biosphere_finished = Signal()
     import_failure = Signal(tuple)
-    copydb_finished = Signal()
     cancel_sentinel = False
     login_success = Signal(bool)
     connection_problem = Signal(tuple)
@@ -931,39 +930,6 @@ class DefaultBiosphereThread(QtCore.QThread):
         import_signals.biosphere_finished.emit()
         signals.change_project.emit(bw.projects.current)
         signals.project_selected.emit()
-
-
-class CopyDatabaseDialog(QtWidgets.QProgressDialog):
-    def __init__(self, copy_from, copy_to):
-        super().__init__()
-        self.setWindowTitle('Copying database')
-        self.setLabelText(
-            'Copying existing database <b>{}</b> to new database <b>{}</b>:'.format(
-                copy_from, copy_to)
-        )
-        self.setRange(0, 0)
-        self.show()
-
-        self.copydb_thread = CopyDatabaseThread(copy_from, copy_to)
-        import_signals.copydb_finished.connect(self.finished)
-        import_signals.copydb_finished.connect(self.copydb_thread.exit)
-        self.copydb_thread.start()
-
-    def finished(self):
-        self.setMaximum(1)
-        self.setValue(1)
-
-
-class CopyDatabaseThread(QtCore.QThread):
-    def __init__(self, copy_from, copy_to):
-        super().__init__()
-        self.copy_from = copy_from
-        self.copy_to = copy_to
-
-    def run(self):
-        bw.Database(self.copy_from).copy(self.copy_to)
-        import_signals.copydb_finished.emit()
-        signals.databases_changed.emit()
 
 
 class ABEcoinventDownloader(eidl.EcoinventDownloader):

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -808,7 +808,16 @@ class LocalDatabaseImportPage(QtWidgets.QWizardPage):
             self.path.setText(path)
 
     def changed(self):
-        self.complete = True if os.path.isfile(self.path.text()) else False
+        exists = True if os.path.isfile(self.path.text()) else False
+        valid = False
+        if exists:
+            base, ext = os.path.splitext(self.path.text())
+            valid = True if ext.lower() == ".bw2package" else False
+            if not valid:
+                import_signals.import_failure.emit(
+                    ("Invalid extension", "Expecting 'local' import database file to have '.bw2package' extension")
+                )
+        self.complete = all([exists, valid])
         self.completeChanged.emit()
 
     def isComplete(self):


### PR DESCRIPTION
Fixed #331.

Fixed edge-case where presamples calculation button did not activate when the _first_ calculation setup for a project was created _after_ a presamples package was created.

Add checking for the correct file extension when importing a `local` database file to avoid possible confusion with the ecoinvent 7z archives.

Separate out `CopyDatabaseDialog` and `CopyDatabaseThread` from the `db_import_wizard.py` script into its own `database_copy.py` script in the widgets folder.