### PR TITLE
Separate bwutils from qt

### DIFF
--- a/activity_browser/app/bwutils/metadata.py
+++ b/activity_browser/app/bwutils/metadata.py
@@ -3,14 +3,12 @@ import brightway2 as bw
 from bw2data.errors import UnknownObject
 from bw2data.backends.peewee import ActivityDataset
 import pandas as pd
-from PySide2.QtCore import Slot, QObject
 import numpy as np
 
-from ..signals import signals
 # todo: extend store over several projects
 
 
-class MetaDataStore(QObject):
+class MetaDataStore(object):
     """A container for technosphere and biosphere metadata during an AB session.
 
     This is to prevent multiple time-expensive repetitions such as the code
@@ -30,17 +28,10 @@ class MetaDataStore(QObject):
     index
 
     """
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self):
         self.dataframe = pd.DataFrame()
         self.databases = set()
-        self._connect_signals()
         self.unpacked_columns = {}
-
-    def _connect_signals(self):
-        signals.project_selected.connect(self.reset_metadata)
-        signals.metadata_changed.connect(self.update_metadata)
-        signals.edit_activity.connect(self.print_convenience_information)
 
     def add_metadata(self, db_names_list: list) -> None:
         """"Include data from the brightway databases.
@@ -91,7 +82,6 @@ class MetaDataStore(QObject):
         self.dataframe.replace(np.nan, '', regex=True, inplace=True)  # replace 'nan' values with emtpy string
         # print('Dimensions of the Metadata:', self.dataframe.shape)
 
-    @Slot(tuple, name="updateMetadata")
     def update_metadata(self, key: tuple) -> None:
         """Update metadata when an activity has changed.
 
@@ -133,7 +123,6 @@ class MetaDataStore(QObject):
                 self.dataframe.replace(np.nan, '', regex=True, inplace=True)  # replace 'nan' values with emtpy string
             # print('Dimensions of the Metadata:', self.dataframe.shape)
 
-    @Slot(name="resetMetadata")
     def reset_metadata(self) -> None:
         """Deletes metadata when the project is changed."""
         # todo: metadata could be collected across projects...
@@ -199,7 +188,6 @@ class MetaDataStore(QObject):
         units = data["unit"].unique()
         return set(units[units != ""])
 
-    @Slot(str, name="printConvenienceInformation")
     def print_convenience_information(self, db_name: str) -> None:
         """ Reports how many unique locations and units the database has.
         """

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -70,6 +70,11 @@ class Controller(object):
         # Other
         signals.switch_bw2_dir_path.connect(self.switch_brightway2_dir_path)
 
+        # Metadata
+        signals.project_selected.connect(self.reset_metadata)
+        signals.metadata_changed.connect(self.update_metadata)
+        signals.edit_activity.connect(self.print_convenience_information)
+
 # SETTINGS
     def load_settings(self):
         if ab_settings.settings:
@@ -504,3 +509,18 @@ class Controller(object):
             # If a formula was set, removed or changed, recalculate exchanges
             signals.exchange_formula_changed.emit(exchange["output"])
         signals.database_changed.emit(exchange['output'][0])
+
+    @staticmethod
+    @Slot(name="triggerMetadataReset")
+    def reset_metadata() -> None:
+        AB_metadata.reset_metadata()
+
+    @staticmethod
+    @Slot(tuple, name="updateMetadataActivity")
+    def update_metadata(key: tuple) -> None:
+        AB_metadata.update_metadata(key)
+
+    @staticmethod
+    @Slot(str, name="printDatabaseInformation")
+    def print_convenience_information(db_name: str) -> None:
+        AB_metadata.print_convenience_information(db_name)


### PR DESCRIPTION
Revert Qt-related changes to the `MetaDataStore` and move the responsibility for updating it through signals to the `Controller` class.

This ensures that Qt 'stays out' of the bwutils folder and allows future separation of this code.