### PR TITLE
Uncertainty delegate

### DIFF
--- a/activity_browser/app/bwutils/__init__.py
+++ b/activity_browser/app/bwutils/__init__.py
@@ -7,7 +7,7 @@ import brightway2 as bw
 from .metadata import AB_metadata
 from .montecarlo import CSMonteCarloLCA
 from .multilca import MLCA, Contributions
-from .pedigree import PedigreeMatrix
+from .pedigree import DistributionGenerator, PedigreeMatrix, UncertainValues
 from .presamples import PresamplesContributions, PresamplesMLCA
 
 

--- a/activity_browser/app/bwutils/__init__.py
+++ b/activity_browser/app/bwutils/__init__.py
@@ -7,7 +7,7 @@ import brightway2 as bw
 from .metadata import AB_metadata
 from .montecarlo import CSMonteCarloLCA
 from .multilca import MLCA, Contributions
-from .pedigree import DistributionGenerator, PedigreeMatrix, UncertainValues
+from .pedigree import PedigreeMatrix
 from .presamples import PresamplesContributions, PresamplesMLCA
 
 

--- a/activity_browser/app/bwutils/__init__.py
+++ b/activity_browser/app/bwutils/__init__.py
@@ -7,6 +7,7 @@ import brightway2 as bw
 from .metadata import AB_metadata
 from .montecarlo import CSMonteCarloLCA
 from .multilca import MLCA, Contributions
+from .pedigree import PedigreeMatrix
 from .presamples import PresamplesContributions, PresamplesMLCA
 
 

--- a/activity_browser/app/bwutils/pedigree.py
+++ b/activity_browser/app/bwutils/pedigree.py
@@ -15,6 +15,9 @@ smoothly into the related uncertainty distributions.
 import math
 from pprint import pformat
 
+from bw2data.parameters import ParameterBase
+from bw2data.proxies import ExchangeProxyBase
+
 VERSION_2 = {
     "reliability": (1., 1.54, 1.61, 1.69, 1.69),
     "completeness": (1., 1.03, 1.04, 1.08, 1.08),
@@ -59,9 +62,9 @@ class PedigreeMatrix(object):
 
     @classmethod
     def from_bw_object(cls, obj) -> 'PedigreeMatrix':
-        if hasattr(obj, "pedigree"):
+        if isinstance(obj, ExchangeProxyBase):
             return cls.from_dict(obj.get("pedigree"))
-        elif hasattr(obj, "data") and "pedigree" in obj.data:
+        elif isinstance(obj, ParameterBase) and "pedigree" in obj.data:
             return cls.from_dict(obj.data.get("pedigree"))
         else:
             raise AssertionError("Could not find pedigree in object")

--- a/activity_browser/app/bwutils/pedigree.py
+++ b/activity_browser/app/bwutils/pedigree.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*
+"""
+Code in `pedigree.py` is taken wholesale from the https://bitbucket.org/cmutel/pedigree-matrix/src repository,
+which is published by Chris Mutel under an MIT license (2012).
+
+FUTURE WORK?
+'The application of the pedigree approach to the distributions foreseen in ecoinvent v3'
+(doi: 10.1007/s11367-014-0759-5) reveals the formulas used to convert the calculated sigma
+(+ geometric standard deviation) into the coefficient of variation ('CV').
+In turn, this CV can then be used to generate required values for a number of other uncertainty distributions.
+
+Any additions made should improve the transition of the calculated sigma (or Geometric Standard Deviation/GSD)
+smoothly into the related uncertainty distributions.
+"""
+import math
+from pprint import pformat
+from typing import Tuple
+
+
+VERSION_2 = {
+    "reliability": (1., 1.54, 1.61, 1.69, 1.69),
+    "completeness": (1., 1.03, 1.04, 1.08, 1.08),
+    "temporal correlation": (1., 1.03, 1.1, 1.19, 1.29),
+    "geographical correlation": (1., 1.04, 1.08, 1.11, 1.11),
+    "further technological correlation": (1., 1.18, 1.65, 2.08, 2.8),
+    "sample size": (1., 1., 1., 1., 1.)
+}
+
+
+class PedigreeMatrix(object):
+    __slots__ = ["factors"]
+    labels = (
+        "reliability",
+        "completeness",
+        "temporal correlation",
+        "geographical correlation",
+        "further technological correlation",
+        "sample size"
+    )
+
+    def __init__(self):
+        self.factors = {}
+
+    @classmethod
+    def from_numbers(cls, data: Tuple[int]) -> 'PedigreeMatrix':
+        """Takes a tuple of integers and construct a PedigreeMatrix.
+        """
+        assert len(data) in (5, 6), "Must provide either 5 or 6 factors"
+        if len(data) == 5:
+            data = data + (1,)
+        matrix = cls()
+        for index, factor in enumerate(data):
+            matrix.factors[cls.labels[index]] = factor
+        return matrix
+
+    def calculate(self, basic_uncertainty: float = 1.,
+                  as_geometric_sigma: bool = False) -> float:
+        """ Calculates the sigma or geometric standard deviation from the factors.
+        """
+        values = [basic_uncertainty] + self.get_values()
+        sigma = math.sqrt(sum([math.log(x) ** 2 for x in values])) / 2
+        return sigma if not as_geometric_sigma else math.exp(2 * sigma)
+
+    def get_values(self) -> list:
+        assert self.factors, "Must provide Pedigree Matrix factors"
+        return [VERSION_2[key][index - 1] for key, index in self.factors.items()]
+
+    def __repr__(self) -> str:
+        return "Empty Pedigree Matrix" if not self.factors else pformat(self.factors)

--- a/activity_browser/app/bwutils/pedigree.py
+++ b/activity_browser/app/bwutils/pedigree.py
@@ -12,9 +12,12 @@ In turn, this CV can then be used to generate required values for a number of ot
 Any additions made should improve the transition of the calculated sigma (or Geometric Standard Deviation/GSD)
 smoothly into the related uncertainty distributions.
 """
+from collections import namedtuple
 import math
 from pprint import pformat
-from typing import Tuple
+
+import numpy as np
+from stats_arrays import uncertainty_choices as uc
 
 
 VERSION_2 = {
@@ -42,7 +45,7 @@ class PedigreeMatrix(object):
         self.factors = {}
 
     @classmethod
-    def from_numbers(cls, data: Tuple[int]) -> 'PedigreeMatrix':
+    def from_numbers(cls, data: tuple) -> 'PedigreeMatrix':
         """Takes a tuple of integers and construct a PedigreeMatrix.
         """
         assert len(data) in (5, 6), "Must provide either 5 or 6 factors"
@@ -67,3 +70,41 @@ class PedigreeMatrix(object):
 
     def __repr__(self) -> str:
         return "Empty Pedigree Matrix" if not self.factors else pformat(self.factors)
+
+
+UncertainValues = namedtuple("values", ("loc", "scale", "shape", "min", "max"))
+
+
+class DistributionGenerator(object):
+    """Generator class that is mostly here to have a central place to store
+    logic on which values are used in which distributions.
+
+    TODO: finish this at a later date.
+    """
+    @staticmethod
+    def generate_distribution(data: UncertainValues, dist_id: int, size: int = 1000) -> np.ndarray:
+        assert dist_id in uc.id_dict
+        if dist_id == 2:
+            return DistributionGenerator._log_normal(data, size)
+        elif dist_id == 3:
+            return DistributionGenerator._normal(data, size)
+
+    @staticmethod
+    def _log_normal(data: UncertainValues, size: int) -> np.ndarray:
+        assert not any(np.isnan([data.loc, data.scale]))
+        return np.random.lognormal(mean=data.loc, sigma=data.scale, size=size)
+
+    @staticmethod
+    def _normal(data: UncertainValues, size: int) -> np.ndarray:
+        assert not any(np.isnan([data.loc, data.scale]))
+        return np.random.normal(loc=data.loc, scale=data.scale, size=size)
+
+    @staticmethod
+    def _uniform(data: UncertainValues, size: int) -> np.ndarray:
+        assert not any(np.isnan([data.min, data.max]))
+        return np.random.uniform(low=data.min, high=data.max, size=size)
+
+    @staticmethod
+    def _triangular(data: UncertainValues, size: int) -> np.ndarray:
+        pass
+

--- a/activity_browser/app/bwutils/pedigree.py
+++ b/activity_browser/app/bwutils/pedigree.py
@@ -12,13 +12,8 @@ In turn, this CV can then be used to generate required values for a number of ot
 Any additions made should improve the transition of the calculated sigma (or Geometric Standard Deviation/GSD)
 smoothly into the related uncertainty distributions.
 """
-from collections import namedtuple
 import math
 from pprint import pformat
-
-import numpy as np
-from stats_arrays import uncertainty_choices as uc
-
 
 VERSION_2 = {
     "reliability": (1., 1.54, 1.61, 1.69, 1.69),
@@ -70,41 +65,3 @@ class PedigreeMatrix(object):
 
     def __repr__(self) -> str:
         return "Empty Pedigree Matrix" if not self.factors else pformat(self.factors)
-
-
-UncertainValues = namedtuple("values", ("loc", "scale", "shape", "min", "max"))
-
-
-class DistributionGenerator(object):
-    """Generator class that is mostly here to have a central place to store
-    logic on which values are used in which distributions.
-
-    TODO: finish this at a later date.
-    """
-    @staticmethod
-    def generate_distribution(data: UncertainValues, dist_id: int, size: int = 1000) -> np.ndarray:
-        assert dist_id in uc.id_dict
-        if dist_id == 2:
-            return DistributionGenerator._log_normal(data, size)
-        elif dist_id == 3:
-            return DistributionGenerator._normal(data, size)
-
-    @staticmethod
-    def _log_normal(data: UncertainValues, size: int) -> np.ndarray:
-        assert not any(np.isnan([data.loc, data.scale]))
-        return np.random.lognormal(mean=data.loc, sigma=data.scale, size=size)
-
-    @staticmethod
-    def _normal(data: UncertainValues, size: int) -> np.ndarray:
-        assert not any(np.isnan([data.loc, data.scale]))
-        return np.random.normal(loc=data.loc, scale=data.scale, size=size)
-
-    @staticmethod
-    def _uniform(data: UncertainValues, size: int) -> np.ndarray:
-        assert not any(np.isnan([data.min, data.max]))
-        return np.random.uniform(low=data.min, high=data.max, size=size)
-
-    @staticmethod
-    def _triangular(data: UncertainValues, size: int) -> np.ndarray:
-        pass
-

--- a/activity_browser/app/bwutils/pedigree.py
+++ b/activity_browser/app/bwutils/pedigree.py
@@ -78,5 +78,8 @@ class PedigreeMatrix(object):
         assert self.factors, "Must provide Pedigree Matrix factors"
         return [VERSION_2[key][index - 1] for key, index in self.factors.items()]
 
+    def factors_as_tuple(self):
+        return tuple(self.factors[k] for k in self.labels if k in self.factors)
+
     def __repr__(self) -> str:
         return "Empty Pedigree Matrix" if not self.factors else pformat(self.factors)

--- a/activity_browser/app/bwutils/pedigree.py
+++ b/activity_browser/app/bwutils/pedigree.py
@@ -51,6 +51,21 @@ class PedigreeMatrix(object):
             matrix.factors[cls.labels[index]] = factor
         return matrix
 
+    @classmethod
+    def from_dict(cls, data: dict) -> 'PedigreeMatrix':
+        return cls.from_numbers(
+            tuple(data.get(k) for k in cls.labels if k in data)
+        )
+
+    @classmethod
+    def from_bw_object(cls, obj) -> 'PedigreeMatrix':
+        if hasattr(obj, "pedigree"):
+            return cls.from_dict(obj.get("pedigree"))
+        elif hasattr(obj, "data") and "pedigree" in obj.data:
+            return cls.from_dict(obj.data.get("pedigree"))
+        else:
+            raise AssertionError("Could not find pedigree in object")
+
     def calculate(self, basic_uncertainty: float = 1.,
                   as_geometric_sigma: bool = False) -> float:
         """ Calculates the sigma or geometric standard deviation from the factors.

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -74,6 +74,7 @@ class Controller(object):
         signals.exchange_uncertainty_modified.connect(self.modify_exchange_uncertainty)
         signals.exchange_pedigree_modified.connect(self.modify_exchange_pedigree)
         # Parameters
+        signals.parameter_modified.connect(self.modify_parameter)
         signals.parameter_uncertainty_modified.connect(self.modify_parameter_uncertainty)
         signals.parameter_pedigree_modified.connect(self.modify_parameter_pedigree)
         # Calculation Setups
@@ -544,6 +545,16 @@ class Controller(object):
         signals.database_changed.emit(exc['output'][0])
 
 # PARAMETERS
+    @staticmethod
+    @Slot(object, str, object, name="modifyParameter")
+    def modify_parameter(param: ParameterBase, field: str, value: object) -> None:
+        if hasattr(param, field):
+            setattr(param, field, value)
+        else:
+            param.data[field] = value
+        param.save()
+        signals.parameters_changed.emit()
+
     @staticmethod
     @Slot(object, object, name="modifyParameterUncertainty")
     def modify_parameter_uncertainty(param: ParameterBase, uncertain: dict) -> None:

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -72,8 +72,10 @@ class Controller(object):
         signals.exchange_amount_modified.connect(self.modify_exchange_amount)
         signals.exchange_modified.connect(self.modify_exchange)
         signals.exchange_uncertainty_modified.connect(self.modify_exchange_uncertainty)
+        signals.exchange_pedigree_modified.connect(self.modify_exchange_pedigree)
         # Parameters
         signals.parameter_uncertainty_modified.connect(self.modify_parameter_uncertainty)
+        signals.parameter_pedigree_modified.connect(self.modify_parameter_pedigree)
         # Calculation Setups
         signals.new_calculation_setup.connect(self.new_calculation_setup)
         signals.rename_calculation_setup.connect(self.rename_calculation_setup)
@@ -534,6 +536,13 @@ class Controller(object):
         exc.save()
         signals.database_changed.emit(exc['output'][0])
 
+    @staticmethod
+    @Slot(object, object, name="modifyExchangePedigree")
+    def modify_exchange_pedigree(exc: ExchangeProxyBase, pedigree: dict) -> None:
+        exc["pedigree"] = pedigree
+        exc.save()
+        signals.database_changed.emit(exc['output'][0])
+
 # PARAMETERS
     @staticmethod
     @Slot(object, object, name="modifyParameterUncertainty")
@@ -544,6 +553,13 @@ class Controller(object):
                 # Convert empty values into nan, accepted by stats_arrays
                 v = float("nan") if not v else float(v)
             param.data[k] = v
+        param.save()
+        signals.parameters_changed.emit()
+
+    @staticmethod
+    @Slot(object, object, name="modifyParameterPedigree")
+    def modify_parameter_pedigree(param: ParameterBase, pedigree: dict) -> None:
+        param.data["pedigree"] = pedigree
         param.save()
         signals.parameters_changed.emit()
 

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -63,6 +63,8 @@ class Signals(QObject):
     parameter_renamed = Signal(str, str, str)  # old, group, new
     # Pass the key of the activity holding the exchange
     exchange_formula_changed = Signal(tuple)
+    # Parameter, field, value for field
+    parameter_modified = Signal(object, str, object)
     # Parameter object and uncertainty dictionary
     parameter_uncertainty_modified = Signal(object, object)
     parameter_pedigree_modified = Signal(object, object)

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -53,6 +53,8 @@ class Signals(QObject):
     exchanges_add = Signal(list, tuple)
     exchange_amount_modified = Signal(object, float)
     exchange_modified = Signal(object, str, object)
+    # Exchange object and uncertainty dictionary
+    exchange_uncertainty_modified = Signal(object, object)
 
     # Parameters
     add_activity_parameter = Signal(tuple)
@@ -60,6 +62,8 @@ class Signals(QObject):
     parameter_renamed = Signal(str, str, str)  # old, group, new
     # Pass the key of the activity holding the exchange
     exchange_formula_changed = Signal(tuple)
+    # Parameter object and uncertainty dictionary
+    parameter_uncertainty_modified = Signal(object, object)
 
     # Presamples
     presample_package_created = Signal(str)

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -55,6 +55,7 @@ class Signals(QObject):
     exchange_modified = Signal(object, str, object)
     # Exchange object and uncertainty dictionary
     exchange_uncertainty_modified = Signal(object, object)
+    exchange_pedigree_modified = Signal(object, object)
 
     # Parameters
     add_activity_parameter = Signal(tuple)
@@ -64,6 +65,7 @@ class Signals(QObject):
     exchange_formula_changed = Signal(tuple)
     # Parameter object and uncertainty dictionary
     parameter_uncertainty_modified = Signal(object, object)
+    parameter_pedigree_modified = Signal(object, object)
 
     # Presamples
     presample_package_created = Signal(str)

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -274,9 +274,10 @@ class MonteCarloPlot(Plot):
 
 
 class SimpleDistributionPlot(Plot):
-    def plot(self, data: np.ndarray):
+    def plot(self, data: np.ndarray, label: str = "Mean of amount"):
         self.reset_plot()
-        sns.distplot(data, ax=self.ax)
+        sns.distplot(data, axlabel=label, ax=self.ax)
+        self.ax.set_ylabel("Probability density")
         _, height = self.canvas.get_width_height()
         self.setMinimumHeight(height / 2)
         self.canvas.draw()

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -271,3 +271,9 @@ class MonteCarloPlot(Plot):
         # lconfi, upconfi =mc['statistics']['interval'][0], mc['statistics']['interval'][1]
 
         self.canvas.draw()
+
+
+class SimpleDistributionPlot(Plot):
+    def plot(self, data: np.ndarray):
+        self.reset_plot()
+        sns.distplot(data, ax=self.ax)

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -274,7 +274,7 @@ class MonteCarloPlot(Plot):
 
 
 class SimpleDistributionPlot(Plot):
-    def plot(self, data: np.ndarray, label: str = "Mean of amount"):
+    def plot(self, data: np.ndarray, label: str = "Mean"):
         self.reset_plot()
         sns.distplot(data, axlabel=label, ax=self.ax)
         self.ax.set_ylabel("Probability density")

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -277,3 +277,6 @@ class SimpleDistributionPlot(Plot):
     def plot(self, data: np.ndarray):
         self.reset_plot()
         sns.distplot(data, ax=self.ax)
+        _, height = self.canvas.get_width_height()
+        self.setMinimumHeight(height / 2)
+        self.canvas.draw()

--- a/activity_browser/app/ui/style.py
+++ b/activity_browser/app/ui/style.py
@@ -87,7 +87,19 @@ class TableItemStyle:
             })
 
 
+class GroupBoxStyle:
+    __slots__ = []
+    border_title = """
+    QGroupBox {
+        border: 1px solid gray; border-radius: 5px; margin-top: 7px; margin-bottom: 7px; padding: 0px
+    }
+    QGroupBox::title {top:-7 ex;left: 10px; subcontrol-origin: border}
+    """
+
+
 style_activity_panel = ActivitiesPanel
 style_activity_tab = ActivitiesTab
 style_table = TableStyle()
 style_item = TableItemStyle()
+style_group_box = GroupBoxStyle
+

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -155,9 +155,8 @@ class BaseExchangeTable(ABDataFrameEdit):
         # A single cell was edited.
         if topLeft == bottomRight and topLeft.isValid():
             index = self.get_source_index(topLeft)
-            field = AB_names_to_bw_keys.get(
-                self.model.headerData(index.column(), QtCore.Qt.Horizontal)
-            )
+            header = self.model.headerData(index.column(), QtCore.Qt.Horizontal)
+            field = AB_names_to_bw_keys.get(header, header)
             exchange = self.model.index(index.row(), self.exchange_column).data()
             if field in self.VALID_FIELDS:
                 value = topLeft.data() if topLeft.data() is not None else ""

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -15,6 +15,7 @@ from .views import ABDataFrameEdit, dataframe_sync
 from ..icons import qicons
 from ..wizards import UncertaintyWizard
 from ...signals import signals
+from ...bwutils import PedigreeMatrix
 from ...bwutils.commontasks import AB_names_to_bw_keys
 
 
@@ -307,12 +308,13 @@ class TechnosphereExchangeTable(BaseExchangeTable):
         self.setItemDelegateForColumn(4, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(5, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(6, UncertaintyDelegate(self))
-        self.setItemDelegateForColumn(7, FloatDelegate(self))
+        self.setItemDelegateForColumn(7, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(8, FloatDelegate(self))
         self.setItemDelegateForColumn(9, FloatDelegate(self))
         self.setItemDelegateForColumn(10, FloatDelegate(self))
         self.setItemDelegateForColumn(11, FloatDelegate(self))
-        self.setItemDelegateForColumn(12, FormulaDelegate(self))
+        self.setItemDelegateForColumn(12, FloatDelegate(self))
+        self.setItemDelegateForColumn(13, FormulaDelegate(self))
         self.setDragDropMode(QtWidgets.QTableView.DragDrop)
         self.table_name = "technosphere"
         self.drag_model = True
@@ -322,7 +324,7 @@ class TechnosphereExchangeTable(BaseExchangeTable):
         columns = super().df_columns
         start = columns[:columns.index("Formula")]
         end = columns[columns.index("Formula"):]
-        return start + self.UNCERTAINTY + end
+        return start + ["pedigree"] + self.UNCERTAINTY + end
 
     def create_row(self, exchange: ExchangeProxyBase) -> (dict, object):
         row, adj_act = super().create_row(exchange)
@@ -334,6 +336,11 @@ class TechnosphereExchangeTable(BaseExchangeTable):
             "Uncertainty": exchange.get("uncertainty type", 0),
             "Formula": exchange.get("formula"),
         })
+        try:
+            matrix = PedigreeMatrix.from_dict(exchange.get("pedigree", {}))
+            row.update({"pedigree": matrix.factors_as_tuple()})
+        except AssertionError:
+            row.update({"pedigree": None})
         row.update({
             k: v for k, v in exchange.uncertainty.items() if k in self.UNCERTAINTY
         })
@@ -349,6 +356,8 @@ class TechnosphereExchangeTable(BaseExchangeTable):
         """Show or hide the uncertainty columns, 'Uncertainty Type' is always shown.
         """
         cols = self.df_columns
+        self.setColumnHidden(cols.index("Uncertainty"), not show)
+        self.setColumnHidden(cols.index("pedigree"), not show)
         for c in self.UNCERTAINTY:
             self.setColumnHidden(cols.index(c), not show)
 
@@ -387,12 +396,13 @@ class BiosphereExchangeTable(BaseExchangeTable):
         self.setItemDelegateForColumn(3, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(4, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(5, UncertaintyDelegate(self))
-        self.setItemDelegateForColumn(6, FloatDelegate(self))
+        self.setItemDelegateForColumn(6, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(7, FloatDelegate(self))
         self.setItemDelegateForColumn(8, FloatDelegate(self))
         self.setItemDelegateForColumn(9, FloatDelegate(self))
         self.setItemDelegateForColumn(10, FloatDelegate(self))
-        self.setItemDelegateForColumn(11, FormulaDelegate(self))
+        self.setItemDelegateForColumn(11, FloatDelegate(self))
+        self.setItemDelegateForColumn(12, FormulaDelegate(self))
         self.table_name = "biosphere"
         self.setDragDropMode(QtWidgets.QTableView.DropOnly)
 
@@ -401,7 +411,7 @@ class BiosphereExchangeTable(BaseExchangeTable):
         columns = super().df_columns
         start = columns[:columns.index("Formula")]
         end = columns[columns.index("Formula"):]
-        return start + self.UNCERTAINTY + end
+        return start + ["pedigree"] + self.UNCERTAINTY + end
 
     def create_row(self, exchange) -> (dict, object):
         row, adj_act = super().create_row(exchange)
@@ -412,6 +422,11 @@ class BiosphereExchangeTable(BaseExchangeTable):
             "Uncertainty": exchange.get("uncertainty type", 0),
             "Formula": exchange.get("formula"),
         })
+        try:
+            matrix = PedigreeMatrix.from_dict(exchange.get("pedigree", {}))
+            row.update({"pedigree": matrix.factors_as_tuple()})
+        except AssertionError:
+            row.update({"pedigree": None})
         row.update({
             k: v for k, v in exchange.uncertainty.items() if k in self.UNCERTAINTY
         })
@@ -425,6 +440,8 @@ class BiosphereExchangeTable(BaseExchangeTable):
         """Show or hide the uncertainty columns, 'Uncertainty Type' is always shown.
         """
         cols = self.df_columns
+        self.setColumnHidden(cols.index("Uncertainty"), not show)
+        self.setColumnHidden(cols.index("pedigree"), not show)
         for c in self.UNCERTAINTY:
             self.setColumnHidden(cols.index(c), not show)
 

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -2,7 +2,6 @@
 import itertools
 
 from asteval import Interpreter
-import brightway2 as bw
 from bw2data.parameters import (ProjectParameter, DatabaseParameter, Group,
                                 ActivityParameter)
 import pandas as pd
@@ -21,6 +20,11 @@ class BaseExchangeTable(ABDataFrameEdit):
     COLUMNS = []
     # Signal used to correctly control `DetailsGroupBox`
     updated = Signal()
+    # Fields accepted by brightway to be stored in exchange objects.
+    VALID_FIELDS = {
+        "amount", "formula", "uncertainty type", "loc", "scale", "shape",
+        "minimum", "maximum"
+    }
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -154,11 +158,8 @@ class BaseExchangeTable(ABDataFrameEdit):
                 self.model.headerData(index.column(), QtCore.Qt.Horizontal)
             )
             exchange = self.model.index(index.row(), self.exchange_column).data()
-            if field in {"amount", "formula"}:
-                if field == "amount":
-                    value = float(topLeft.data())
-                else:
-                    value = str(topLeft.data()) if topLeft.data() is not None else ""
+            if field in self.VALID_FIELDS:
+                value = topLeft.data() if topLeft.data() is not None else ""
                 signals.exchange_modified.emit(exchange, field, value)
             else:
                 value = str(topLeft.data())

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -56,12 +56,16 @@ class BaseExchangeTable(ABDataFrameEdit):
             self.exchanges = exchanges
         self.dataframe = self.build_df()
 
+    @property
+    def df_columns(self) -> list:
+        return self.COLUMNS + ["exchange"]
+
     def build_df(self) -> pd.DataFrame:
         """ Use the Exchanges Iterable to construct a dataframe.
 
         Make sure to store the Exchange object itself in the dataframe as well.
         """
-        columns = self.COLUMNS + ["exchange"]
+        columns = self.df_columns
         df = pd.DataFrame([
             self.create_row(exchange=exc)[0] for exc in self.exchanges
         ], columns=columns)
@@ -101,7 +105,7 @@ class BaseExchangeTable(ABDataFrameEdit):
     def delete_exchanges(self) -> None:
         """ Remove all of the selected exchanges from the activity.
         """
-        indexes = [self.get_source_index(p) for p in self.selectedIndexes()]
+        indexes = (self.get_source_index(p) for p in self.selectedIndexes())
         exchanges = [
             self.model.index(index.row(), self.exchange_column).data()
             for index in indexes
@@ -115,7 +119,7 @@ class BaseExchangeTable(ABDataFrameEdit):
         attempt to overwrite the `amount` with that value after removing the
         `formula` field.
         """
-        indexes = [self.get_source_index(p) for p in self.selectedIndexes()]
+        indexes = (self.get_source_index(p) for p in self.selectedIndexes())
         exchanges = [
             self.model.index(index.row(), self.exchange_column).data()
             for index in indexes
@@ -254,7 +258,7 @@ class ProductExchangeTable(BaseExchangeTable):
     def _resize(self) -> None:
         """ Ensure the `exchange` column is hidden whenever the table is shown.
         """
-        self.setColumnHidden(4, True)
+        self.setColumnHidden(self.exchange_column, True)
 
     def contextMenuEvent(self, a0) -> None:
         menu = QtWidgets.QMenu()
@@ -306,7 +310,7 @@ class TechnosphereExchangeTable(BaseExchangeTable):
     def _resize(self) -> None:
         """ Ensure the `exchange` column is hidden whenever the table is shown.
         """
-        self.setColumnHidden(8, True)
+        self.setColumnHidden(self.exchange_column, True)
 
     def contextMenuEvent(self, a0) -> None:
         menu = QtWidgets.QMenu()
@@ -355,7 +359,7 @@ class BiosphereExchangeTable(BaseExchangeTable):
         return row, adj_act
 
     def _resize(self) -> None:
-        self.setColumnHidden(7, True)
+        self.setColumnHidden(self.exchange_column, True)
 
     def dragEnterEvent(self, event):
         """ Only accept exchanges from a technosphere database table
@@ -399,7 +403,7 @@ class DownstreamExchangeTable(BaseExchangeTable):
     def _resize(self) -> None:
         """ Next to `exchange`, also hide the `formula` column.
         """
-        self.setColumnHidden(6, True)
+        self.setColumnHidden(self.exchange_column, True)
 
     def contextMenuEvent(self, a0) -> None:
         menu = QtWidgets.QMenu()

--- a/activity_browser/app/ui/tables/delegates/float.py
+++ b/activity_browser/app/ui/tables/delegates/float.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import math
+
 from PySide2 import QtCore, QtGui, QtWidgets
 
 
@@ -7,6 +9,11 @@ class FloatDelegate(QtWidgets.QStyledItemDelegate):
     """
     def __init__(self, parent=None):
         super().__init__(parent)
+
+    def displayText(self, value, locale):
+        if math.isnan(value):
+            return ""
+        return str(value)
 
     def createEditor(self, parent, option, index):
         editor = QtWidgets.QLineEdit(parent)
@@ -21,7 +28,7 @@ class FloatDelegate(QtWidgets.QStyledItemDelegate):
         """ Populate the editor with data if editing an existing field.
         """
         data = index.data(QtCore.Qt.DisplayRole)
-        value = float(data) if data else 0
+        value = float(data) if data and not math.isnan(data) else 0
         editor.setText(str(value))
 
     def setModelData(self, editor: QtWidgets.QLineEdit, model: QtCore.QAbstractItemModel,

--- a/activity_browser/app/ui/tables/delegates/uncertainty.py
+++ b/activity_browser/app/ui/tables/delegates/uncertainty.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import math
-
 from PySide2 import QtCore, QtWidgets
 from stats_arrays import uncertainty_choices as uc
 
@@ -48,7 +46,12 @@ class UncertaintyDelegate(QtWidgets.QStyledItemDelegate):
         take the value and set the index in that way.
         """
         value = index.data(QtCore.Qt.DisplayRole)
-        value = value if not math.isnan(value) else 0
+        if isinstance(value, (str, float)):
+            try:
+                value = int(value)
+            except ValueError as e:
+                print("{}, using 0 instead".format(str(e)))
+                value = 0
         editor.setCurrentIndex(uc.choices.index(uc[value]))
 
     def setModelData(self, editor: QtWidgets.QComboBox, model: QtCore.QAbstractItemModel,

--- a/activity_browser/app/ui/tables/delegates/uncertainty.py
+++ b/activity_browser/app/ui/tables/delegates/uncertainty.py
@@ -1,21 +1,36 @@
 # -*- coding: utf-8 -*-
+import math
+
 from PySide2 import QtCore, QtWidgets
-from stats_arrays import uncertainty_choices
+from stats_arrays import uncertainty_choices as uc
 
 
 class UncertaintyDelegate(QtWidgets.QStyledItemDelegate):
-    """ A combobox containing the sorted list of possible uncertainties
+    """A combobox containing the sorted list of possible uncertainties
     `setModelData` stores the integer id of the selected uncertainty
     distribution.
     """
     def __init__(self, parent=None):
         super().__init__(parent)
+        uc.check_id_uniqueness()
         self.choices = {
-            u.description: u.id for u in uncertainty_choices.choices
+            u.description: u.id for u in uc.choices
         }
 
+    def displayText(self, value, locale):
+        """Take the given integer id and return the description.
+
+        Will return the 'Unknown' uncertainty description if the given id
+        either cannot be found or the value is 'nan' (when id is not set)
+        """
+        try:
+            return uc[int(value)].description
+        except (IndexError, ValueError):
+            return uc[0].description
+
     def createEditor(self, parent, option, index):
-        """ Create a list of descriptions of the uncertainties we have.
+        """Create a list of descriptions of the uncertainties we have.
+
         Note that the `choices` attribute of uncertainty_choices is already
         sorted by id.
         """
@@ -25,7 +40,7 @@ class UncertaintyDelegate(QtWidgets.QStyledItemDelegate):
         return editor
 
     def setEditorData(self, editor: QtWidgets.QComboBox, index: QtCore.QModelIndex):
-        """ Lookup the description text set in the model using the reverse
+        """Lookup the description text set in the model using the reverse
         dictionary for the uncertainty choices.
 
         Note that the model presents the integer value as a string (the
@@ -33,11 +48,12 @@ class UncertaintyDelegate(QtWidgets.QStyledItemDelegate):
         take the value and set the index in that way.
         """
         value = index.data(QtCore.Qt.DisplayRole)
-        editor.setCurrentIndex(self.choices.get(value, 0))
+        value = value if not math.isnan(value) else 0
+        editor.setCurrentIndex(uc.choices.index(uc[value]))
 
     def setModelData(self, editor: QtWidgets.QComboBox, model: QtCore.QAbstractItemModel,
                      index: QtCore.QModelIndex):
-        """ Read the current index of the combobox and return that to the model.
+        """ Read the current text and look up the actual ID of that uncertainty type.
         """
-        value = editor.currentIndex()
-        model.setData(index, value, QtCore.Qt.EditRole)
+        uc_id = self.choices.get(editor.currentText(), 0)
+        model.setData(index, uc_id, QtCore.Qt.EditRole)

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -128,7 +128,11 @@ class BaseParameterTable(ABDataFrameEdit):
         with bw.parameters.db.atomic() as transaction:
             try:
                 field = self.model.headerData(proxy.column(), Qt.Horizontal)
-                setattr(param, field, proxy.data())
+                if field not in self.COLUMNS:
+                    # Must store value inside 'data' field.
+                    param.data[field] = proxy.data()
+                else:
+                    setattr(param, field, proxy.data())
                 param.save()
                 # Saving the parameter expires the related group, so recalculate.
                 bw.parameters.recalculate()

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -17,6 +17,7 @@ from activity_browser.app.signals import signals
 
 from ..icons import qicons
 from ..widgets import simple_warning_box
+from ..wizards import UncertaintyWizard
 from .delegates import (DatabaseDelegate, FloatDelegate, FormulaDelegate,
                         ListDelegate, StringDelegate, UncertaintyDelegate,
                         ViewOnlyDelegate)
@@ -43,6 +44,10 @@ class BaseParameterTable(ABDataFrameEdit):
         self.rename_action.triggered.connect(
             lambda: self.handle_parameter_rename(self.currentIndex())
         )
+        self.modify_uncertainty_action = QAction(
+            qicons.edit, "Modify uncertainty", None
+        )
+        self.modify_uncertainty_action.triggered.connect(self.modify_uncertainty)
 
     def dataChanged(self, topLeft, bottomRight, roles=None) -> None:
         """ Handle updating the parameters whenever the user changes a value.
@@ -66,6 +71,7 @@ class BaseParameterTable(ABDataFrameEdit):
         menu = QMenu(self)
         menu.addAction(self.rename_action)
         menu.addAction(self.delete_action)
+        menu.addAction(self.modify_uncertainty_action)
         proxy = self.indexAt(event.pos())
         if proxy.isValid():
             param = self.get_parameter(proxy)
@@ -171,6 +177,13 @@ class BaseParameterTable(ABDataFrameEdit):
         with bw.parameters.db.atomic():
             param.delete_instance()
         signals.parameters_changed.emit()
+
+    @Slot(name="modifyParameterUncertainty")
+    def modify_uncertainty(self) -> None:
+        proxy = next(p for p in self.selectedIndexes())
+        param = self.get_parameter(proxy)
+        wizard = UncertaintyWizard(param, self)
+        wizard.show()
 
     def uncertainty_columns(self, show: bool):
         """ Given a boolean, iterates over the uncertainty columns and either
@@ -495,6 +508,7 @@ class ActivityParameterTable(BaseParameterTable):
         )
         menu.addAction(self.rename_action)
         menu.addAction(self.delete_action)
+        menu.addAction(self.modify_uncertainty_action)
         proxy = self.indexAt(event.pos())
         if proxy.isValid():
             param = self.get_parameter(proxy)

--- a/activity_browser/app/ui/tabs/activity.py
+++ b/activity_browser/app/ui/tabs/activity.py
@@ -100,10 +100,16 @@ class ActivityTab(QtWidgets.QWidget):
 
         self.db_read_only_changed(db_name=self.db_name, db_read_only=self.db_read_only)
 
+        # Reveal/hide uncertainty columns
+        self.show_uncertainty = QtWidgets.QCheckBox("Show Uncertainty", self)
+        self.show_uncertainty.setChecked(False)
+        self.show_uncertainty.toggled.connect(self.show_exchange_uncertainty)
+
         # Toolbar Layout
         toolbar = QtWidgets.QToolBar()
         toolbar.addWidget(self.checkbox_edit_act)
         toolbar.addWidget(self.checkbox_activity_description)
+        toolbar.addWidget(self.show_uncertainty)
         self.graph_action = toolbar.addAction(
             qicons.graph_explorer, "Show graph", self.open_graph
         )
@@ -169,6 +175,7 @@ class ActivityTab(QtWidgets.QWidget):
             table.updated.emit()
 
         self.populate_description_box()
+        self.show_exchange_uncertainty(self.show_uncertainty.isChecked())
 
     def populate_description_box(self):
         # activity description
@@ -187,6 +194,11 @@ class ActivityTab(QtWidgets.QWidget):
     def toggle_activity_description_visibility(self):
         """Show only if checkbox is checked."""
         self.activity_description.setVisible(self.checkbox_activity_description.isChecked())
+
+    @QtCore.Slot(bool, name="toggleUncertaintyColumns")
+    def show_exchange_uncertainty(self, toggled: bool) -> None:
+        self.technosphere.show_uncertainty(toggled)
+        self.biosphere.show_uncertainty(toggled)
 
     def act_read_only_changed(self, read_only):
         """ When read_only=False specific data fields in the tables below become user-editable

--- a/activity_browser/app/ui/tabs/activity.py
+++ b/activity_browser/app/ui/tabs/activity.py
@@ -227,10 +227,12 @@ class ActivityTab(QtWidgets.QWidget):
                 table.setAcceptDrops(False)
                 table.delete_exchange_action.setEnabled(False)
                 table.remove_formula_action.setEnabled(False)
+                table.modify_uncertainty_action.setEnabled(False)
             else:
                 table.setEditTriggers(QtWidgets.QTableView.DoubleClicked)
                 table.delete_exchange_action.setEnabled(True)
                 table.remove_formula_action.setEnabled(True)
+                table.modify_uncertainty_action.setEnabled(True)
                 if not table.downstream:  # downstream consumers table never accepts drops
                     table.setAcceptDrops(True)
 

--- a/activity_browser/app/ui/wizards/__init__.py
+++ b/activity_browser/app/ui/wizards/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from .parameter_wizard import ParameterWizard
+from .uncertainty import UncertaintyWizard

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -499,6 +499,7 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
         loc_val = str(np.log(float(self.mean.text())))
         self.loc.setText(loc_val)
         self.setField("loc", loc_val)
+        self.check_complete()
 
     @Slot(name="constructPedigreeMatrix")
     def check_complete(self) -> None:

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -376,8 +376,9 @@ class UncertaintyValuesPage(QtWidgets.QWizardPage):
     @QtCore.Slot(name="regenPlot")
     def generate_plot(self) -> None:
         """ Called whenever a value changes, regenerate the plot based on """
-        data = DistributionGenerator.generate_distribution(
-            self.extract_values(), self.field("distribution")
-        )
+        # data = DistributionGenerator.generate_distribution(
+        #     self.extract_values(), self.field("distribution")
+        # )
+        data = None
         if data is not None and not any(np.isnan(data)):
             self.plot.plot(data)

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -388,7 +388,7 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
         self.loc.setValidator(self.validator)
         self.loc.textEdited.connect(self.balance_mean_with_loc)
         self.loc.textEdited.connect(self.check_negative)
-        self.loc.textChanged.connect(self.check_complete)
+        self.loc.textEdited.connect(self.check_complete)
         self.mean = QtWidgets.QLineEdit()
         self.mean.setValidator(self.validator)
         self.mean.textEdited.connect(self.balance_loc_with_mean)

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -65,10 +65,17 @@ class UncertaintyWizard(QtWidgets.QWizard):
 
     @Slot(name="modifyUncertainty")
     def update_uncertainty(self):
+        """ Update the uncertainty information of the relevant object, optionally
+        including a pedigree update.
+        """
         if isinstance(self.obj, ExchangeProxyBase):
             signals.exchange_uncertainty_modified.emit(self.obj, self.uncertainty_info)
+            if self.using_pedigree:
+                signals.exchange_pedigree_modified.emit(self.obj, self.pedigree.matrix.factors)
         elif isinstance(self.obj, ParameterBase):
             signals.parameter_uncertainty_modified.emit(self.obj, self.uncertainty_info)
+            if self.using_pedigree:
+                signals.parameter_pedigree_modified.emit(self.obj, self.pedigree.matrix.factors)
 
     def extract_uncertainty(self) -> None:
         """Used to extract possibly existing uncertainty information from the

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -233,9 +233,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
 
     def special_lognormal_handling(self):
         """Special kansas city shuffling for this distribution."""
-        if self.dist is None:
-            return
-        if self.dist.id == LognormalUncertainty.id:
+        if self.is_lognormal_uncertainty:
             self.mean.setHidden(False)
             self.mean_label.setHidden(False)
             self.loc_label.setText("Loc (ln(mean)):")
@@ -285,6 +283,10 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
         self.generate_plot()
 
     @property
+    def is_lognormal_uncertainty(self) -> bool:
+        return self.dist.id == LognormalUncertainty.id
+
+    @property
     def active_fields(self) -> tuple:
         """Returns anywhere from 0 to 3 fields"""
         if self.dist.id in {0, 1}:
@@ -316,7 +318,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
 
         Another special edge-case for the lognormal distribution.
         """
-        if self.dist.id == LognormalUncertainty.id and self.mean.text().startswith("-"):
+        if self.is_lognormal_uncertainty and self.mean.text().startswith("-"):
             self.setField("negative", True)
         else:
             self.setField("negative", False)

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -5,7 +5,7 @@ from bw2data.parameters import ParameterBase
 from bw2data.proxies import ExchangeProxyBase
 from PySide2 import QtCore, QtGui, QtWidgets
 import numpy as np
-from stats_arrays import uncertainty_choices as uc
+from stats_arrays import LognormalUncertainty, uncertainty_choices as uc
 
 from ..figures import SimpleDistributionPlot
 from ..style import style_group_box
@@ -19,41 +19,42 @@ class UncertaintyWizard(QtWidgets.QWizard):
 
     Note that this can also be used for setting uncertainties on parameters
     """
-    CHOICE = 0
+    KEYS = {
+        "uncertainty type", "loc", "scale", "shape", "minimum", "maximum",
+        "negative"
+    }
+
+    TYPE = 0
     PEDIGREE = 1
-    TYPE = 2
-    VALUES = 3
 
     def __init__(self, unc_object: Union[ExchangeProxyBase, ParameterBase], parent=None):
         super().__init__(parent)
 
         self.obj = unc_object
 
-        self.choice = ChoicePage(self)
         self.pedigree = PedigreeMatrixPage(self)
         self.type = UncertaintyTypePage(self)
-        self.values = UncertaintyValuesPage(self)
-        self.pages = (
-            self.choice, self.pedigree, self.type, self.values
-        )
+        self.pages = (self.type, self.pedigree)
 
         for i, p in enumerate(self.pages):
             self.setPage(i, p)
-        self.setStartId(self.CHOICE)
+        self.setStartId(self.TYPE)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setOption(QtWidgets.QWizard.IndependentPages, True)
 
         self.button(QtWidgets.QWizard.FinishButton).clicked.connect(self.update_uncertainty)
+        self.extract_uncertainty()
 
     @property
     def uncertainty_info(self):
         return {
-            "uncertainty type": self.field("distribution"),
+            "uncertainty type": self.field("uncertainty type"),
             "loc": float(self.field("loc")) if self.field("loc") else float("nan"),
             "scale": float(self.field("scale")) if self.field("scale") else float("nan"),
             "shape": float(self.field("shape")) if self.field("shape") else float("nan"),
             "minimum": float(self.field("minimum")) if self.field("minimum") else float("nan"),
             "maximum": float(self.field("maximum")) if self.field("maximum") else float("nan"),
-            "negative": False,
+            "negative": bool(self.field("negative")),
         }
 
     @QtCore.Slot(name="modifyUncertainty")
@@ -63,47 +64,206 @@ class UncertaintyWizard(QtWidgets.QWizard):
         elif isinstance(self.obj, ParameterBase):
             signals.parameter_uncertainty_modified.emit(self.obj, self.uncertainty_info)
 
+    def extract_uncertainty(self) -> None:
+        """Used to extract possibly existing uncertainty information from the
+        given exchange/parameter
+        """
+        if self.obj is None:
+            return
+        # If we start from an exchange, we can use a shortcut.
+        if isinstance(self.obj, ExchangeProxyBase):
+            for k, v in self.obj.uncertainty.items():
+                self.setField(k, v)
+        # Otherwise, try and get something from the parameter.
+        elif isinstance(self.obj, ParameterBase):
+            for key in (k for k in self.KEYS if k in self.obj.data):
+                self.setField(key, self.obj.data[key])
 
-class ChoicePage(QtWidgets.QWizardPage):
-    """Present three choices to the user:
+        # If no loc/mean value is set yet, convert the amount.
+        loc = self.field("loc")
+        if (loc is None or loc == "nan") and hasattr(self.obj, "amount"):
+            self.setField("loc", str(np.log(self.obj.amount)))
 
-    - No uncertainty
-    - Pedigree matrix
-    - (Manual) distribution selection and value editing.
+
+class UncertaintyTypePage(QtWidgets.QWizardPage):
+    """Present a list of uncertainty types directly retrieved from the `stats_arrays` package.
     """
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.setFinalPage(True)
+        self.dist = None
+        self.complete = False
+        self.goto_pedigree = False
 
-        self.choice = QtWidgets.QComboBox(self)
-        # Set three options, the first is the 'No uncertainty' option.
-        # Possibly allows users to quick click through, is this good or bad?
-        self.choice.addItems(
-            ["No uncertainty", "Pedigree matrix", "Manual selection"]
-        )
-        self.registerField("uncertain_choice", self.choice, "currentIndex")
-
-        # Startup options
-        group = QtWidgets.QGroupBox("How to set uncertainty")
-        # Explicitly set the stylesheet to avoid parent classes overriding
-        group.setStyleSheet(style_group_box.border_title)
+        # Selection of uncertainty distribution.
+        box1 = QtWidgets.QGroupBox("Select the uncertainty distribution")
+        box1.setStyleSheet(style_group_box.border_title)
+        self.distribution = QtWidgets.QComboBox(box1)
+        self.distribution.addItems([ud.description for ud in uc.choices])
+        self.distribution.currentIndexChanged.connect(self.distribution_selection)
+        self.registerField("uncertainty type", self.distribution, "currentIndex")
+        self.pedigree = QtWidgets.QPushButton("Use pedigree")
+        self.pedigree.clicked.connect(self.pedigree_page)
         box_layout = QtWidgets.QGridLayout()
-        box_layout.addWidget(QtWidgets.QLabel("Define by:"), 0, 0, 1, 1)
-        box_layout.addWidget(self.choice, 0, 1, 1, 2)
-        group.setLayout(box_layout)
+        box_layout.addWidget(QtWidgets.QLabel("Distribution:"), 0, 0, 2, 1)
+        box_layout.addWidget(self.distribution, 0, 1, 2, 2)
+        box_layout.addWidget(self.pedigree, 0, 3, 2, 1)
+        box1.setLayout(box_layout)
+
+        # Set values for selected uncertainty distribution.
+        box2 = QtWidgets.QGroupBox("Fill out or change required parameters")
+        box2.setStyleSheet(style_group_box.border_title)
+        self.locale = QtCore.QLocale(QtCore.QLocale.English, QtCore.QLocale.UnitedStates)
+        self.locale.setNumberOptions(QtCore.QLocale.RejectGroupSeparator)
+        self.validator = QtGui.QDoubleValidator()
+        self.validator.setLocale(self.locale)
+        self.loc = QtWidgets.QLineEdit()
+        self.loc.setValidator(self.validator)
+        self.loc.textEdited.connect(self.generate_plot)
+        self.loc_label = QtWidgets.QLabel("Mean/loc:")
+        self.scale = QtWidgets.QLineEdit()
+        self.scale.setValidator(self.validator)
+        self.scale.textEdited.connect(self.generate_plot)
+        self.scale_label = QtWidgets.QLabel("Sigma/scale:")
+        self.shape = QtWidgets.QLineEdit()
+        self.shape.setValidator(self.validator)
+        self.shape.textEdited.connect(self.generate_plot)
+        self.shape_label = QtWidgets.QLabel("Shape:")
+        self.minimum = QtWidgets.QLineEdit()
+        self.minimum.setValidator(self.validator)
+        self.minimum.textEdited.connect(self.generate_plot)
+        self.min_label = QtWidgets.QLabel("Minimum:")
+        self.maximum = QtWidgets.QLineEdit()
+        self.maximum.setValidator(self.validator)
+        self.maximum.textEdited.connect(self.generate_plot)
+        self.max_label = QtWidgets.QLabel("Maximum:")
+        self.negative = QtWidgets.QRadioButton(self)
+        self.negative.setChecked(False)
+        self.negative.setHidden(True)
+        box_layout = QtWidgets.QGridLayout()
+        box_layout.addWidget(self.loc_label, 0, 0, 2, 1)
+        box_layout.addWidget(self.loc, 0, 1, 2, 2)
+        box_layout.addWidget(self.scale_label, 2, 0, 2, 1)
+        box_layout.addWidget(self.scale, 2, 1, 2, 2)
+        box_layout.addWidget(self.shape_label, 4, 0, 2, 1)
+        box_layout.addWidget(self.shape, 4, 1, 2, 2)
+        box_layout.addWidget(self.min_label, 6, 0, 2, 1)
+        box_layout.addWidget(self.minimum, 6, 1, 2, 2)
+        box_layout.addWidget(self.max_label, 8, 0, 2, 1)
+        box_layout.addWidget(self.maximum, 8, 1, 2, 2)
+        box2.setLayout(box_layout)
+
+        self.registerField("loc", self.loc, "text")
+        self.registerField("scale", self.scale, "text")
+        self.registerField("shape", self.shape, "text")
+        self.registerField("minimum", self.minimum, "text")
+        self.registerField("maximum", self.maximum, "text")
+        self.registerField("negative", self.negative, "checked")
+
+        self.plot = SimpleDistributionPlot(self)
 
         layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(group)
+        layout.addWidget(box1)
+        layout.addWidget(box2)
+        layout.addWidget(self.plot)
         self.setLayout(layout)
 
+    def hide_param(self, *params, hide: bool = True):
+        if "loc" in params:
+            self.loc_label.setHidden(hide)
+            self.loc.setHidden(hide)
+        if "scale" in params:
+            self.scale_label.setHidden(hide)
+            self.scale.setHidden(hide)
+        if "shape" in params:
+            self.shape_label.setHidden(hide)
+            self.shape.setHidden(hide)
+        if "min" in params:
+            self.min_label.setHidden(hide)
+            self.minimum.setHidden(hide)
+        if "max" in params:
+            self.max_label.setHidden(hide)
+            self.maximum.setHidden(hide)
+
+    @QtCore.Slot(name="changeDistribution")
+    def distribution_selection(self):
+        """Selected distribution and present the correct uncertainty parameters.
+
+        See https://stats-arrays.readthedocs.io/en/latest/index.html for which
+        fields to show and hide.
+        """
+        self.dist = uc.id_dict[self.distribution.currentIndex()]
+
+        # Huge if/elif tree to ensure the correct fields are shown.
+        if self.dist.id in {0, 1}:
+            self.hide_param("loc", "scale", "shape", "min", "max")
+        elif self.dist.id in {2, 3}:
+            self.hide_param("shape", "min", "max")
+            self.hide_param("loc", "scale", hide=False)
+        elif self.dist.id in {4, 7}:
+            self.hide_param("loc", "scale", "shape")
+            self.hide_param("min", "max", hide=False)
+        elif self.dist.id in {5, 6}:
+            self.hide_param("scale", "shape")
+            self.hide_param("loc", "min", "max", hide=False)
+        elif self.dist.id in {8, 9, 10, 11, 12}:
+            self.hide_param("min", "max")
+            self.hide_param("loc", "scale", "shape", hide=False)
+        self.generate_plot()
+
+    @property
+    def active_fields(self) -> tuple:
+        """Returns anywhere from 0 to 3 fields"""
+        if self.dist.id in {0, 1}:
+            return ()
+        elif self.dist.id in {2, 3}:
+            return self.loc, self.scale
+        elif self.dist.id in {4, 7}:
+            return self.minimum, self.maximum
+        elif self.dist.id in {5, 6}:
+            return self.loc, self.minimum, self.maximum
+        elif self.dist.id in {8, 9, 10, 11, 12}:
+            return self.loc, self.scale, self.shape
+
+    def cleanupPage(self):
+        """Remove values from fields and reset the plot."""
+        super().cleanupPage()
+        self.plot.reset_plot()
+        self.plot.canvas.draw()
+
+    def initializePage(self):
+        self.distribution_selection()
+
     def nextId(self):
-        """Read out the uncertain_choice field and proceed to related page."""
-        choice = self.field("uncertain_choice")
-        if choice == 0:
-            return UncertaintyWizard.VALUES
-        if choice == 1:
+        if self.goto_pedigree:
             return UncertaintyWizard.PEDIGREE
-        if choice == 2:
-            return UncertaintyWizard.TYPE
+        return -1
+
+    def isComplete(self):
+        return self.complete
+
+    @QtCore.Slot(name="gotoPedigreePage")
+    def pedigree_page(self) -> None:
+        self.goto_pedigree = True
+        self.wizard().next()
+
+    @QtCore.Slot(name="regenPlot")
+    def generate_plot(self) -> None:
+        """Called whenever a value changes, (re)generate the plot.
+
+        Also tests if all of the visible QLineEdit fields have valid values.
+        """
+        self.complete = all(
+            (field.hasAcceptableInput() and field.text())
+            for field in self.active_fields
+        )
+        if self.complete:
+            data = self.dist.random_variables(
+                self.dist.from_dicts(self.wizard().uncertainty_info), 1000
+            )
+            if not np.any(np.isnan(data)):
+                self.plot.plot(data)
+        self.completeChanged.emit()
 
 
 class PedigreeMatrixPage(QtWidgets.QWizardPage):
@@ -120,6 +280,7 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
     """
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.setFinalPage(True)
 
         box = QtWidgets.QGroupBox("Fill out pedigree matrix")
         box.setStyleSheet(style_group_box.border_title)
@@ -164,11 +325,6 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
             "4) Data on related processes and materials",
             "5) Data on related processes on lab scale OR from different technology",
         ])
-        self.registerField("reliable", self.reliable, "currentIndex")
-        self.registerField("complete", self.complete, "currentIndex")
-        self.registerField("temporal", self.temporal, "currentIndex")
-        self.registerField("geographical", self.geographical, "currentIndex")
-        self.registerField("technological", self.technological, "currentIndex")
         self.reliable.currentIndexChanged.connect(self.check_complete)
         self.complete.currentIndexChanged.connect(self.check_complete)
         self.temporal.currentIndexChanged.connect(self.check_complete)
@@ -188,120 +344,6 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
         box_layout.addWidget(self.technological, 8, 2, 2, 3)
         box.setLayout(box_layout)
 
-        layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(box)
-        self.setLayout(layout)
-
-    def initializePage(self):
-        self.check_complete()
-
-    @QtCore.Slot(name="constructPedigreeMatrix")
-    def check_complete(self) -> None:
-        self.setField("distribution", 2)
-        matrix = PedigreeMatrix.from_numbers((
-            int(self.field("reliable")) + 1,
-            int(self.field("complete")) + 1,
-            int(self.field("temporal")) + 1,
-            int(self.field("geographical")) + 1,
-            int(self.field("technological")) + 1,
-        ))
-        self.setField("loc", 1)
-        self.setField("scale", matrix.calculate())
-
-    def nextId(self):
-        """ Calculate and set values for fields before moving to next page.
-        """
-        return UncertaintyWizard.VALUES
-
-
-class UncertaintyTypePage(QtWidgets.QWizardPage):
-    """Present a list of uncertainty types directly retrieved from the `stats_arrays` package.
-    """
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-        box = QtWidgets.QGroupBox("Select the uncertainty distribution")
-        box.setStyleSheet(style_group_box.border_title)
-
-        self.distribution = QtWidgets.QComboBox(box)
-        self.distribution.addItems([ud.description for ud in uc.choices])
-        self.registerField("distribution", self.distribution, "currentIndex")
-        box_layout = QtWidgets.QGridLayout()
-        box_layout.addWidget(QtWidgets.QLabel("Distribution:"), 0, 0, 2, 1)
-        box_layout.addWidget(self.distribution, 0, 1, 2, 2)
-        box.setLayout(box_layout)
-
-        layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(box)
-        self.setLayout(layout)
-
-    def nextId(self):
-        return UncertaintyWizard.VALUES
-
-
-class UncertaintyValuesPage(QtWidgets.QWizardPage):
-    """Show values for specific fields and allow user to edit.
-
-    Also, show a graph of the distribution that is updated as
-    the values change.
-    """
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.wizard = parent
-        self.setFinalPage(True)
-        self.complete = False
-        self.dist = None
-
-        self.locale = QtCore.QLocale(QtCore.QLocale.English, QtCore.QLocale.UnitedStates)
-        self.locale.setNumberOptions(QtCore.QLocale.RejectGroupSeparator)
-        self.validator = QtGui.QDoubleValidator()
-        self.validator.setLocale(self.locale)
-
-        box = QtWidgets.QGroupBox("Fill out or change required parameters")
-        box.setStyleSheet(style_group_box.border_title)
-
-        self.distribution = QtWidgets.QLabel("")
-        self.loc = QtWidgets.QLineEdit()
-        self.loc.setValidator(self.validator)
-        self.loc.textEdited.connect(self.generate_plot)
-        self.loc_label = QtWidgets.QLabel("Mean/loc:")
-        self.scale = QtWidgets.QLineEdit()
-        self.scale.setValidator(self.validator)
-        self.scale.textEdited.connect(self.generate_plot)
-        self.scale_label = QtWidgets.QLabel("Sigma/scale:")
-        self.shape = QtWidgets.QLineEdit()
-        self.shape.setValidator(self.validator)
-        self.shape.textEdited.connect(self.generate_plot)
-        self.shape_label = QtWidgets.QLabel("Shape:")
-        self.minimum = QtWidgets.QLineEdit()
-        self.minimum.setValidator(self.validator)
-        self.minimum.textEdited.connect(self.generate_plot)
-        self.min_label = QtWidgets.QLabel("Minimum:")
-        self.maximum = QtWidgets.QLineEdit()
-        self.maximum.setValidator(self.validator)
-        self.maximum.textEdited.connect(self.generate_plot)
-        self.max_label = QtWidgets.QLabel("Maximum:")
-        box_layout = QtWidgets.QGridLayout()
-        box_layout.addWidget(QtWidgets.QLabel("Distribution:"), 0, 0, 2, 1)
-        box_layout.addWidget(self.distribution, 0, 1, 2, 2)
-        box_layout.addWidget(self.loc_label, 2, 0, 2, 1)
-        box_layout.addWidget(self.loc, 2, 1, 2, 2)
-        box_layout.addWidget(self.scale_label, 4, 0, 2, 1)
-        box_layout.addWidget(self.scale, 4, 1, 2, 2)
-        box_layout.addWidget(self.shape_label, 6, 0, 2, 1)
-        box_layout.addWidget(self.shape, 6, 1, 2, 2)
-        box_layout.addWidget(self.min_label, 8, 0, 2, 1)
-        box_layout.addWidget(self.minimum, 8, 1, 2, 2)
-        box_layout.addWidget(self.max_label, 10, 0, 2, 1)
-        box_layout.addWidget(self.maximum, 10, 1, 2, 2)
-        box.setLayout(box_layout)
-
-        self.registerField("loc", self.loc, "text")
-        self.registerField("scale", self.scale, "text")
-        self.registerField("shape", self.shape, "text")
-        self.registerField("minimum", self.minimum, "text")
-        self.registerField("maximum", self.maximum, "text")
-
         self.plot = SimpleDistributionPlot(self)
 
         layout = QtWidgets.QVBoxLayout()
@@ -309,72 +351,44 @@ class UncertaintyValuesPage(QtWidgets.QWizardPage):
         layout.addWidget(self.plot)
         self.setLayout(layout)
 
-    def hide_param(self, *params, hide: bool = True):
-        if "loc" in params:
-            self.loc_label.setHidden(hide)
-            self.loc.setHidden(hide)
-        if "scale" in params:
-            self.scale_label.setHidden(hide)
-            self.scale.setHidden(hide)
-        if "shape" in params:
-            self.shape_label.setHidden(hide)
-            self.shape.setHidden(hide)
-        if "min" in params:
-            self.min_label.setHidden(hide)
-            self.minimum.setHidden(hide)
-        if "max" in params:
-            self.max_label.setHidden(hide)
-            self.maximum.setHidden(hide)
-
     def initializePage(self):
-        """Take the information from the previous pages and present the correct
-        uncertainty parameters.
+        # if the parent contains an 'obj' with uncertainty, extract data
+        self.setField("uncertainty type", 2)
+        obj = getattr(self.wizard(), "obj")
+        if isinstance(obj, ExchangeProxyBase) and "pedigree" in obj:
+            self.pedigree = obj.get("pedigree", {})
+        # Otherwise, try and get something from the parameter.
+        elif isinstance(obj, ParameterBase) and "pedigree" in obj.data:
+            self.pedigree = obj.data.get("pedigree", {})
+        self.check_complete()
 
-        See https://stats-arrays.readthedocs.io/en/latest/index.html for which
-        fields to show and hide.
-        """
-        self.dist = uc.id_dict[self.field("distribution")]
-        self.distribution.setText("<strong>{}</strong>".format(self.dist.description))
-
-        # Huge if/elif tree to ensure the correct fields are shown.
-        if self.dist.id in {0, 1}:
-            self.hide_param("loc", "scale", "shape", "min", "max")
-        elif self.dist.id in {2, 3}:
-            self.hide_param("shape", "min", "max")
-            self.hide_param("loc", "scale", hide=False)
-        elif self.dist.id in {4, 7}:
-            self.hide_param("loc", "scale", "shape")
-            self.hide_param("min", "max", hide=False)
-        elif self.dist.id in {5, 6}:
-            self.hide_param("scale", "shape")
-            self.hide_param("loc", "min", "max", hide=False)
-        elif self.dist.id in {8, 9, 10, 11}:
-            self.hide_param("min", "max")
-            self.hide_param("loc", "scale", "shape", hide=False)
-        self.generate_plot()
-
-    def cleanupPage(self):
-        """Remove values from fields and reset the plot."""
-        super().cleanupPage()
-        self.plot.reset_plot()
-        self.plot.canvas.draw()
+    def nextId(self):
+        """Ensures that 'Next' button does not show."""
+        return -1
 
     @property
-    def active_fields(self) -> tuple:
-        """Returns anywhere from 0 to 3 fields"""
-        if self.dist.id in {0, 1}:
-            return ()
-        elif self.dist.id in {2, 3}:
-            return self.loc, self.scale
-        elif self.dist.id in {4, 7}:
-            return self.minimum, self.maximum
-        elif self.dist.id in {5, 6}:
-            return self.loc, self.minimum, self.maximum
-        elif self.dist.id in {8, 9, 10, 11}:
-            return self.loc, self.scale, self.shape
+    def pedigree(self) -> tuple:
+        return (
+            self.reliable.currentIndex() + 1,
+            self.complete.currentIndex() + 1,
+            self.temporal.currentIndex() + 1,
+            self.geographical.currentIndex() + 1,
+            self.technological.currentIndex() + 1,
+        )
 
-    def isComplete(self):
-        return self.complete
+    @pedigree.setter
+    def pedigree(self, data: dict) -> None:
+        self.reliable.setCurrentIndex(data.get("reliability", 1) - 1)
+        self.complete.setCurrentIndex(data.get("completeness", 1) - 1)
+        self.temporal.setCurrentIndex(data.get("temporal correlation", 1) - 1)
+        self.geographical.setCurrentIndex(data.get("geographical correlation", 1) - 1)
+        self.technological.setCurrentIndex(data.get("further technological correlation", 1) - 1)
+
+    @QtCore.Slot(name="constructPedigreeMatrix")
+    def check_complete(self) -> None:
+        matrix = PedigreeMatrix.from_numbers(self.pedigree)
+        self.setField("scale", matrix.calculate())
+        self.generate_plot()
 
     @QtCore.Slot(name="regenPlot")
     def generate_plot(self) -> None:
@@ -382,14 +396,8 @@ class UncertaintyValuesPage(QtWidgets.QWizardPage):
 
         Also tests if all of the visible QLineEdit fields have valid values.
         """
-        self.complete = all(
-            (field.hasAcceptableInput() and field.text())
-            for field in self.active_fields
+        data = LognormalUncertainty.random_variables(
+            LognormalUncertainty.from_dicts(self.wizard().uncertainty_info), 1000
         )
-        if self.complete:
-            data = self.dist.random_variables(
-                self.dist.from_dicts(self.wizard.uncertainty_info), 1000
-            )
-            if not np.any(np.isnan(data)):
-                self.plot.plot(data)
-        self.completeChanged.emit()
+        if not np.any(np.isnan(data)):
+            self.plot.plot(data)

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+from typing import Union
+
+from bw2data.parameters import ParameterBase
+from bw2data.proxies import ExchangeProxyBase
+from PySide2 import QtCore, QtGui, QtWidgets
+import numpy as np
+from stats_arrays import uncertainty_choices as uc
+
+from ..figures import SimpleDistributionPlot
+from ..style import style_group_box
+from ...bwutils import DistributionGenerator, PedigreeMatrix, UncertainValues
+from ...signals import signals
+
+
+class UncertaintyWizard(QtWidgets.QWizard):
+    """Using this wizard, guide the user through selecting an 'uncertainty'
+    distribution (and related values) for their activity/process exchanges.
+
+    Note that this can also be used for setting uncertainties on parameters
+    """
+    CHOICE = 0
+    PEDIGREE = 1
+    TYPE = 2
+    VALUES = 3
+
+    def __init__(self, unc_object: Union[ExchangeProxyBase, ParameterBase], parent=None):
+        super().__init__(parent)
+
+        self.obj = unc_object
+
+        self.choice = ChoicePage(self)
+        self.pedigree = PedigreeMatrixPage(self)
+        self.type = UncertaintyTypePage(self)
+        self.values = UncertaintyValuesPage(self)
+        self.pages = (
+            self.choice, self.pedigree, self.type, self.values
+        )
+
+        for i, p in enumerate(self.pages):
+            self.setPage(i, p)
+        self.setStartId(self.CHOICE)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+
+        self.button(QtWidgets.QWizard.FinishButton).clicked.connect(self.update_uncertainty)
+
+    @property
+    def uncertainty_info(self):
+        return {
+            "uncertainty type": self.field("distribution"),
+            "loc": self.field("loc"),
+            "scale": self.field("scale"),
+            "shape": self.field("shape"),
+            "minimum": self.field("minimum"),
+            "maximum": self.field("maximum"),
+            "negative": False,
+        }
+
+    @QtCore.Slot(name="modifyUncertainty")
+    def update_uncertainty(self):
+        if isinstance(self.obj, ExchangeProxyBase):
+            signals.exchange_uncertainty_modified.emit(self.obj, self.uncertainty_info)
+        elif isinstance(self.obj, ParameterBase):
+            signals.parameter_uncertainty_modified.emit(self.obj, self.uncertainty_info)
+
+
+class ChoicePage(QtWidgets.QWizardPage):
+    """Present three choices to the user:
+
+    - No uncertainty
+    - Pedigree matrix
+    - (Manual) distribution selection and value editing.
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.choice = QtWidgets.QComboBox(self)
+        # Set three options, the first is the 'No uncertainty' option.
+        # Possibly allows users to quick click through, is this good or bad?
+        self.choice.addItems(
+            ["No uncertainty", "Pedigree matrix", "Manual selection"]
+        )
+        self.registerField("uncertain_choice", self.choice, "currentIndex")
+
+        # Startup options
+        group = QtWidgets.QGroupBox("How to set uncertainty")
+        # Explicitly set the stylesheet to avoid parent classes overriding
+        group.setStyleSheet(style_group_box.border_title)
+        box_layout = QtWidgets.QGridLayout()
+        box_layout.addWidget(QtWidgets.QLabel("Define by:"), 0, 0, 1, 1)
+        box_layout.addWidget(self.choice, 0, 1, 1, 2)
+        group.setLayout(box_layout)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(group)
+        self.setLayout(layout)
+
+    def nextId(self):
+        """Read out the uncertain_choice field and proceed to related page."""
+        choice = self.field("uncertain_choice")
+        if choice == 0:
+            return UncertaintyWizard.VALUES
+        if choice == 1:
+            return UncertaintyWizard.PEDIGREE
+        if choice == 2:
+            return UncertaintyWizard.TYPE
+
+
+class PedigreeMatrixPage(QtWidgets.QWizardPage):
+    """Guide the user through filling out a pedigree matrix.
+
+    There are 5 indicators used, each carrying a score from 1 to 5
+    with 1 indicating 'less uncertain' and 5 'more uncertain'.
+
+    NOTE: Currently, the pedigree matrix will always default to a lognormal distribution.
+
+    NOTE: using terms and quoting from the paper:
+    'Empirically based uncertainty factors for the pedigree matrix in ecoinvent' (2016)
+    doi: 10.1007/s11367-013-0670-5
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.is_complete = False
+
+        box = QtWidgets.QGroupBox("Fill out pedigree matrix")
+        box.setStyleSheet(style_group_box.border_title)
+
+        self.reliable = QtWidgets.QComboBox(box)
+        self.reliable.addItems([
+            "1) Verified data based on measurements",
+            "2) Verified data partly based on assumptions",
+            "3) Non-verified data partly based on qualified measurements",
+            "4) Qualified estimate",
+            "5) Non-qualified estimate",
+        ])
+        self.complete = QtWidgets.QComboBox(box)
+        self.complete.addItems([
+            "1) Representative relevant data from all sites, over an adequate period",
+            "2) Representative relevant data from >50% sites, over an adequate period",
+            "3) Representative relevant data from <50% sites OR >50%, but over shorter period",
+            "4) Representative relevant data from one site OR some sites but over shorter period",
+            "5) Representativeness unknown",
+        ])
+        self.temporal = QtWidgets.QComboBox(box)
+        self.temporal.addItems([
+            "1) Data less than 3 years old",
+            "2) Data less than 6 years old",
+            "3) Data less than 10 years old",
+            "4) Data less than 15 years old",
+            "5) Data age unknown or more than 15 years old",
+        ])
+        self.geographical = QtWidgets.QComboBox(box)
+        self.geographical.addItems([
+            "1) Data from area under study",
+            "2) Average data from larger area in which area under study is included",
+            "3) Data from area with similar production conditions",
+            "4) Data from area with slightly similar production conditions",
+            "5) Data from unknown OR distinctly different area",
+        ])
+        self.technological = QtWidgets.QComboBox(box)
+        self.technological.addItems([
+            "1) Data from enterprises, processes and materials under study",
+            "2) Data from processes and materials under study, different enterprise",
+            "3) Data from processes and materials under study from different technology",
+            "4) Data on related processes and materials",
+            "5) Data on related processes on lab scale OR from different technology",
+        ])
+        self.registerField("reliable", self.reliable, "currentIndex")
+        self.registerField("complete", self.complete, "currentIndex")
+        self.registerField("temporal", self.temporal, "currentIndex")
+        self.registerField("geographical", self.geographical, "currentIndex")
+        self.registerField("technological", self.technological, "currentIndex")
+        self.reliable.currentIndexChanged.connect(self.check_complete)
+        self.complete.currentIndexChanged.connect(self.check_complete)
+        self.temporal.currentIndexChanged.connect(self.check_complete)
+        self.geographical.currentIndexChanged.connect(self.check_complete)
+        self.technological.currentIndexChanged.connect(self.check_complete)
+
+
+        box_layout = QtWidgets.QGridLayout()
+        box_layout.addWidget(QtWidgets.QLabel("Reliability"), 0, 0, 2, 2)
+        box_layout.addWidget(self.reliable, 0, 2, 2, 3)
+        box_layout.addWidget(QtWidgets.QLabel("Completeness"), 2, 0, 2, 2)
+        box_layout.addWidget(self.complete, 2, 2, 2, 3)
+        box_layout.addWidget(QtWidgets.QLabel("Temporal correlation"), 4, 0, 2, 2)
+        box_layout.addWidget(self.temporal, 4, 2, 2, 3)
+        box_layout.addWidget(QtWidgets.QLabel("Geographical correlation"), 6, 0, 2, 2)
+        box_layout.addWidget(self.geographical, 6, 2, 2, 3)
+        box_layout.addWidget(QtWidgets.QLabel("Further technological correlation"), 8, 0, 2, 2)
+        box_layout.addWidget(self.technological, 8, 2, 2, 3)
+        box.setLayout(box_layout)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(box)
+        self.setLayout(layout)
+
+    def initializePage(self):
+        self.check_complete()
+
+    @QtCore.Slot(name="constructPedigreeMatrix")
+    def check_complete(self) -> None:
+        self.setField("distribution", 2)
+        matrix = PedigreeMatrix.from_numbers((
+            int(self.field("reliable")) + 1,
+            int(self.field("complete")) + 1,
+            int(self.field("temporal")) + 1,
+            int(self.field("geographical")) + 1,
+            int(self.field("technological")) + 1,
+        ))
+        self.setField("loc", 1)
+        self.setField("scale", matrix.calculate())
+        self.is_complete = True
+
+    def isComplete(self):
+        return self.is_complete
+
+    def nextId(self):
+        """ Calculate and set values for fields before moving to next page.
+        """
+        return UncertaintyWizard.VALUES
+
+
+class UncertaintyTypePage(QtWidgets.QWizardPage):
+    """Present a list of uncertainty types directly retrieved from the `stats_arrays` package.
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        box = QtWidgets.QGroupBox("Select the uncertainty distribution")
+        box.setStyleSheet(style_group_box.border_title)
+
+        self.distribution = QtWidgets.QComboBox(box)
+        self.distribution.addItems([ud.description for ud in uc.choices])
+        self.registerField("distribution", self.distribution, "currentIndex")
+        box_layout = QtWidgets.QGridLayout()
+        box_layout.addWidget(QtWidgets.QLabel("Distribution:"), 0, 0, 2, 1)
+        box_layout.addWidget(self.distribution, 0, 1, 2, 2)
+        box.setLayout(box_layout)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(box)
+        self.setLayout(layout)
+
+    def nextId(self):
+        return UncertaintyWizard.VALUES
+
+
+class UncertaintyValuesPage(QtWidgets.QWizardPage):
+    """Show values for specific fields and allow user to edit.
+
+    Also, possibly show a graph of the distribution that is updated as
+    the values change.
+
+    ('loc', np.NaN),
+    ('scale', np.NaN),
+    ('shape', np.NaN),
+    ('minimum', np.NaN),
+    ('maximum', np.NaN),
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setFinalPage(True)
+
+        self.locale = QtCore.QLocale(QtCore.QLocale.English, QtCore.QLocale.UnitedStates)
+        self.locale.setNumberOptions(QtCore.QLocale.RejectGroupSeparator)
+        self.validator = QtGui.QDoubleValidator()
+        self.validator.setLocale(self.locale)
+
+        box = QtWidgets.QGroupBox("Fill out or change required parameters")
+        box.setStyleSheet(style_group_box.border_title)
+
+        self.distribution = QtWidgets.QLabel("")
+        self.loc = QtWidgets.QLineEdit()
+        self.loc.setValidator(self.validator)
+        self.loc.textEdited.connect(self.generate_plot)
+        self.loc_label = QtWidgets.QLabel("Mean:")
+        self.scale = QtWidgets.QLineEdit()
+        self.scale.setValidator(self.validator)
+        self.scale.textEdited.connect(self.generate_plot)
+        self.scale_label = QtWidgets.QLabel("Scale:")
+        self.shape = QtWidgets.QLineEdit()
+        self.shape.setValidator(self.validator)
+        self.shape.textEdited.connect(self.generate_plot)
+        self.shape_label = QtWidgets.QLabel("Shape:")
+        self.minimum = QtWidgets.QLineEdit()
+        self.minimum.setValidator(self.validator)
+        self.minimum.textEdited.connect(self.generate_plot)
+        self.min_label = QtWidgets.QLabel("Minimum:")
+        self.maximum = QtWidgets.QLineEdit()
+        self.maximum.setValidator(self.validator)
+        self.maximum.textEdited.connect(self.generate_plot)
+        self.max_label = QtWidgets.QLabel("Maximum:")
+        box_layout = QtWidgets.QGridLayout()
+        box_layout.addWidget(QtWidgets.QLabel("Distribution:"), 0, 0, 2, 1)
+        box_layout.addWidget(self.distribution, 0, 1, 2, 2)
+        box_layout.addWidget(self.loc_label, 2, 0, 2, 1)
+        box_layout.addWidget(self.loc, 2, 1, 2, 2)
+        box_layout.addWidget(self.scale_label, 4, 0, 2, 1)
+        box_layout.addWidget(self.scale, 4, 1, 2, 2)
+        box_layout.addWidget(self.shape_label, 6, 0, 2, 1)
+        box_layout.addWidget(self.shape, 6, 1, 2, 2)
+        box_layout.addWidget(self.min_label, 8, 0, 2, 1)
+        box_layout.addWidget(self.minimum, 8, 1, 2, 2)
+        box_layout.addWidget(self.max_label, 10, 0, 2, 1)
+        box_layout.addWidget(self.maximum, 10, 1, 2, 2)
+        box.setLayout(box_layout)
+
+        self.registerField("loc", self.loc, "text")
+        self.registerField("scale", self.scale, "text")
+        self.registerField("shape", self.shape, "text")
+        self.registerField("minimum", self.minimum, "text")
+        self.registerField("maximum", self.maximum, "text")
+
+        self.plot = SimpleDistributionPlot(self)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(box)
+        layout.addWidget(self.plot)
+        self.setLayout(layout)
+
+    def hide_param(self, *params, hide: bool = True):
+        if "loc" in params:
+            self.loc_label.setHidden(hide)
+            self.loc.setHidden(hide)
+        if "scale" in params:
+            self.scale_label.setHidden(hide)
+            self.scale.setHidden(hide)
+        if "shape" in params:
+            self.shape_label.setHidden(hide)
+            self.shape.setHidden(hide)
+        if "min" in params:
+            self.min_label.setHidden(hide)
+            self.minimum.setHidden(hide)
+        if "max" in params:
+            self.max_label.setHidden(hide)
+            self.maximum.setHidden(hide)
+
+    def initializePage(self):
+        """Take the information from the previous pages and present the correct
+        uncertainty parameters.
+
+        See https://stats-arrays.readthedocs.io/en/latest/index.html for which
+        fields to show and hide.
+        """
+        ud = uc.id_dict[self.field("distribution")]
+        self.distribution.setText("<strong>{}</strong>".format(ud.description))
+
+        # Huge if/elif tree to ensure the correct fields are shown.
+        if ud.id in {0, 1}:
+            self.hide_param("loc", "scale", "shape", "min", "max")
+        elif ud.id in {2, 3}:
+            self.hide_param("shape", "min", "max")
+            self.hide_param("loc", "scale", hide=False)
+        elif ud.id in {4, 7}:
+            self.hide_param("loc", "scale", "shape")
+            self.hide_param("min", "max", hide=False)
+        elif ud.id in {5, 6}:
+            self.hide_param("scale", "shape")
+            self.hide_param("loc", "min", "max", hide=False)
+        elif ud.id in {8, 9, 10, 11}:
+            self.hide_param("min", "max")
+            self.hide_param("loc", "scale", "shape", hide=False)
+
+    def extract_values(self) -> UncertainValues:
+        """Return a namedtuple containing values for all of the registered
+        fields on this page.
+        """
+        return UncertainValues(
+            loc=float(self.field("loc")) if self.field("loc") else np.nan,
+            scale=float(self.field("scale")) if self.field("scale") else np.nan,
+            shape=float(self.field("shape")) if self.field("shape") else np.nan,
+            min=float(self.field("minimum")) if self.field("minimum") else np.nan,
+            max=float(self.field("maximum")) if self.field("maximum") else np.nan
+        )
+
+    @QtCore.Slot(name="regenPlot")
+    def generate_plot(self) -> None:
+        """ Called whenever a value changes, regenerate the plot based on """
+        data = DistributionGenerator.generate_distribution(
+            self.extract_values(), self.field("distribution")
+        )
+        if data is not None and not any(np.isnan(data)):
+            self.plot.plot(data)

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -353,6 +353,12 @@ class UncertaintyValuesPage(QtWidgets.QWizardPage):
             self.hide_param("loc", "scale", "shape", hide=False)
         self.generate_plot()
 
+    def cleanupPage(self):
+        """Remove values from fields and reset the plot."""
+        super().cleanupPage()
+        self.plot.reset_plot()
+        self.plot.canvas.draw()
+
     @property
     def active_fields(self) -> tuple:
         """Returns anywhere from 0 to 3 fields"""

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -247,7 +247,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
             self.loc_label.setText("Loc (ln(mean)):")
             self.loc_label.setToolTip("Natural logarithm of mean")
             # Convert 'mean' to lognormal mean
-            if self.previous and self.previous != LognormalUncertainty.id:
+            if self.previous is not None and self.previous != LognormalUncertainty.id:
                 self.wizard().extract_lognormal_loc()
                 self.balance_mean_with_loc()
         else:

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -323,9 +323,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
 
     def initializePage(self) -> None:
         self.distribution_selection()
-        # Set the mean field if the loc field is not empty.
-        if self.loc.text():
-            self.mean.setText(str(np.exp(float(self.loc.text()))))
+        self.balance_mean_with_loc()
 
     def nextId(self) -> int:
         if self.goto_pedigree:
@@ -512,6 +510,7 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
 
     @Slot(name="locToMean")
     def balance_mean_with_loc(self):
+        self.setField("loc", self.loc.text())
         if self.loc.text():
             self.mean.setText(str(np.exp(float(self.loc.text()))))
 

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -120,7 +120,6 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
     """
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.is_complete = False
 
         box = QtWidgets.QGroupBox("Fill out pedigree matrix")
         box.setStyleSheet(style_group_box.border_title)
@@ -176,7 +175,6 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
         self.geographical.currentIndexChanged.connect(self.check_complete)
         self.technological.currentIndexChanged.connect(self.check_complete)
 
-
         box_layout = QtWidgets.QGridLayout()
         box_layout.addWidget(QtWidgets.QLabel("Reliability"), 0, 0, 2, 2)
         box_layout.addWidget(self.reliable, 0, 2, 2, 3)
@@ -209,10 +207,6 @@ class PedigreeMatrixPage(QtWidgets.QWizardPage):
         ))
         self.setField("loc", 1)
         self.setField("scale", matrix.calculate())
-        self.is_complete = True
-
-    def isComplete(self):
-        return self.is_complete
 
     def nextId(self):
         """ Calculate and set values for fields before moving to next page.

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -48,11 +48,11 @@ class UncertaintyWizard(QtWidgets.QWizard):
     def uncertainty_info(self):
         return {
             "uncertainty type": self.field("distribution"),
-            "loc": self.field("loc"),
-            "scale": self.field("scale"),
-            "shape": self.field("shape"),
-            "minimum": self.field("minimum"),
-            "maximum": self.field("maximum"),
+            "loc": float(self.field("loc")) if self.field("loc") else float("nan"),
+            "scale": float(self.field("scale")) if self.field("scale") else float("nan"),
+            "shape": float(self.field("shape")) if self.field("shape") else float("nan"),
+            "minimum": float(self.field("minimum")) if self.field("minimum") else float("nan"),
+            "maximum": float(self.field("maximum")) if self.field("maximum") else float("nan"),
             "negative": False,
         }
 

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -9,7 +9,7 @@ from stats_arrays import uncertainty_choices as uc
 
 from ..figures import SimpleDistributionPlot
 from ..style import style_group_box
-from ...bwutils import DistributionGenerator, PedigreeMatrix, UncertainValues
+from ...bwutils import PedigreeMatrix
 from ...signals import signals
 
 
@@ -361,17 +361,6 @@ class UncertaintyValuesPage(QtWidgets.QWizardPage):
             self.hide_param("min", "max")
             self.hide_param("loc", "scale", "shape", hide=False)
 
-    def extract_values(self) -> UncertainValues:
-        """Return a namedtuple containing values for all of the registered
-        fields on this page.
-        """
-        return UncertainValues(
-            loc=float(self.field("loc")) if self.field("loc") else np.nan,
-            scale=float(self.field("scale")) if self.field("scale") else np.nan,
-            shape=float(self.field("shape")) if self.field("shape") else np.nan,
-            min=float(self.field("minimum")) if self.field("minimum") else np.nan,
-            max=float(self.field("maximum")) if self.field("maximum") else np.nan
-        )
 
     @QtCore.Slot(name="regenPlot")
     def generate_plot(self) -> None:


### PR DESCRIPTION
Resolves #328.

Implements a new list-type delegate for the uncertainty type, showing the actual description of the type instead of the integer.

Also, adds handling for exchange and parameter uncertainty through signals and controller methods.

A new `UncertaintyWizard` is added which can be accessed through right-clicking the relevant exchange/parameter and selecting 'modify uncertainty'. It will allow users to choose from some defaults as well as allowing manual selection of uncertainty. Included is a simple plot which shows the distribution for the selected type and values.