### PR TITLE
Add CF uncertainty modifying

### DIFF
--- a/activity_browser/app/bwutils/__init__.py
+++ b/activity_browser/app/bwutils/__init__.py
@@ -9,6 +9,10 @@ from .montecarlo import CSMonteCarloLCA
 from .multilca import MLCA, Contributions
 from .pedigree import PedigreeMatrix
 from .presamples import PresamplesContributions, PresamplesMLCA
+from .uncertainty import (
+    CFUncertaintyInterface, ExchangeUncertaintyInterface,
+    ParameterUncertaintyInterface, get_uncertainty_interface
+)
 
 
 def cleanup():

--- a/activity_browser/app/bwutils/uncertainty.py
+++ b/activity_browser/app/bwutils/uncertainty.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*
+import abc
+
+from bw2data.parameters import ParameterBase
+from bw2data.proxies import ExchangeProxyBase
+from stats_arrays import (
+    UncertaintyBase, UndefinedUncertainty, uncertainty_choices as uc
+)
+
+
+class BaseUncertaintyInterface(abc.ABC):
+    __slots__ = ["_data"]
+    KEYS = {
+        "uncertainty type", "loc", "scale", "shape", "minimum", "maximum",
+        "negative"
+    }
+    data_type = ""
+
+    def __init__(self, unc_obj):
+        self._data = unc_obj
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    @abc.abstractmethod
+    def amount(self) -> float:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def uncertainty_type(self) -> UncertaintyBase:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def uncertainty(self) -> dict:
+        pass
+
+
+class ExchangeUncertaintyInterface(BaseUncertaintyInterface):
+    """Many kinds of exchanges use uncertainty to describe how 'correct' the
+    data is which makes up the amount of the exchange.
+    """
+    _data: ExchangeProxyBase
+    data_type = "exchange"
+
+    @property
+    def amount(self) -> float:
+        return self._data.amount
+
+    @property
+    def uncertainty_type(self) -> UncertaintyBase:
+        return self._data.uncertainty_type
+
+    @property
+    def uncertainty(self) -> dict:
+        return self._data.uncertainty
+
+
+class ParameterUncertaintyInterface(BaseUncertaintyInterface):
+    """All levels of parameters can describe their amounts with uncertainty."""
+    _data: ParameterBase
+    data_type = "parameter"
+
+    @property
+    def amount(self) -> float:
+        return self._data.amount
+
+    @property
+    def uncertainty_type(self) -> UncertaintyBase:
+        if "uncertainty type" not in self._data.data:
+            return UndefinedUncertainty
+        return uc[self._data.data.get("uncertainty type", 0)]
+
+    @property
+    def uncertainty(self) -> dict:
+        return {k: self._data.data.get(k) for k in self.KEYS if k in self._data.data}
+
+
+class CFUncertaintyInterface(BaseUncertaintyInterface):
+    """The characterization factors (CFs) of an impact assessment method can also
+    contain uncertainty.
+
+    This is however not certain (ha), as the CF is made up out of a flow key
+    and either an amount (float) or the uncertainty values + an amount (dict).
+
+    See the ``Method`` and ``ProcessedDataStore`` classes in the bw2data library.
+    """
+    _data: tuple
+    data_type = "cf"
+
+    @property
+    def is_uncertain(self) -> bool:
+        return isinstance(self._data[1], dict)
+
+    @property
+    def amount(self) -> float:
+        return self._data[1]["amount"] if self.is_uncertain else self._data[1]
+
+    @property
+    def uncertainty_type(self) -> UncertaintyBase:
+        if not self.is_uncertain:
+            return UndefinedUncertainty
+        return uc[self._data[1].get("uncertainty type", 0)]
+
+    @property
+    def uncertainty(self) -> dict:
+        if not self.is_uncertain:
+            return {}
+        return {k: self._data[1].get(k) for k in self.KEYS if k in self._data[1]}
+
+
+def get_uncertainty_interface(data: object) -> BaseUncertaintyInterface:
+    if isinstance(data, ExchangeProxyBase):
+        return ExchangeUncertaintyInterface(data)
+    elif isinstance(data, ParameterBase):
+        return ParameterUncertaintyInterface(data)
+    elif isinstance(data, tuple):
+        return CFUncertaintyInterface(data)
+    else:
+        raise TypeError(
+            "No uncertainty interface exists for object type {}".format(type(data))
+        )

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -274,10 +274,13 @@ class MonteCarloPlot(Plot):
 
 
 class SimpleDistributionPlot(Plot):
-    def plot(self, data: np.ndarray, label: str = "Mean"):
+    def plot(self, data: np.ndarray, mean: float, label: str = "Value"):
         self.reset_plot()
         sns.distplot(data, axlabel=label, ax=self.ax)
         self.ax.set_ylabel("Probability density")
+        # Add vertical line at given mean of x-axis
+        self.ax.axvline(mean, label="Mean / amount", c="r", ymax=0.98)
+        self.ax.legend(loc="upper right")
         _, height = self.canvas.get_width_height()
         self.setMinimumHeight(height / 2)
         self.canvas.draw()

--- a/activity_browser/app/ui/tables/LCA_setup.py
+++ b/activity_browser/app/ui/tables/LCA_setup.py
@@ -207,7 +207,7 @@ class CSMethodsTable(ABDataFrameView):
 
     def dropEvent(self, event):
         event.accept()
-        new_methods = [row["method"] for row in event.source().selectedItems()]
+        new_methods = event.source().selected_methods()
         old_methods = set(m for m in self.dataframe["method"])
         data = [self.build_row(m) for m in new_methods if m not in old_methods]
         if data:

--- a/activity_browser/app/ui/tables/impact_categories.py
+++ b/activity_browser/app/ui/tables/impact_categories.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import numbers
-from typing import Optional
+from typing import Iterable, Optional
 
 import brightway2 as bw
 from pandas import DataFrame
@@ -38,20 +38,11 @@ class MethodsTable(ABDataFrameView):
 
     @Slot(QModelIndex, name="methodSelection")
     def method_selected(self, proxy):
-        index = self.get_source_index(proxy)
-        method = self.dataframe.iloc[index.row(), ]["method"]
-        signals.method_selected.emit(method)
+        signals.method_selected.emit(self.get_method(proxy))
 
-    def selectedItems(self) -> list:
-        """ Use to retrieve the method objects for the selected rows.
-
-        TODO: Shadows the `selectedItems` method in QTableWidget as it is used
-         by `CSMethodsTable`. Possibly remove or improve in the future.
-        """
-        indexes = (self.get_source_index(p) for p in self.selectedIndexes())
-        return [
-            self.dataframe.iloc[index.row(), ] for index in indexes
-        ]
+    def selected_methods(self) -> Iterable:
+        """Returns a generator which yields the 'method' for each row."""
+        return (self.get_method(p) for p in self.selectedIndexes())
 
     @dataframe_sync
     @Slot(name="syncTable")
@@ -76,7 +67,7 @@ class MethodsTable(ABDataFrameView):
         }
 
     def _resize(self) -> None:
-        self.setColumnHidden(self.dataframe.columns.get_loc("method"), True)
+        self.setColumnHidden(self.method_col, True)
         self.setSizePolicy(QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
         ))

--- a/activity_browser/app/ui/tables/impact_categories.py
+++ b/activity_browser/app/ui/tables/impact_categories.py
@@ -165,17 +165,16 @@ class CFTable(ABDataFrameView):
 
     @Slot(tuple, object, name="modifyCf")
     def modify_cf(self, cf: tuple, uncertainty: dict) -> None:
+        """Update the CF with new uncertainty information, possibly converting
+        the second item in the tuple to a dictionary without losing information.
         """
-        acidification potential
-        """
-        key, maybe_uc = cf
-        if isinstance(maybe_uc, dict):
-            maybe_uc.update(uncertainty)
-            new_cf = (key, maybe_uc)
+        data = [*cf]
+        if isinstance(data[1], dict):
+            data[1].update(uncertainty)
         else:
-            uncertainty["amount"] = maybe_uc
-            new_cf = (key, uncertainty)
-        self.modify_method_with_cf(new_cf)
+            uncertainty["amount"] = data[1]
+            data[1] = uncertainty
+        self.modify_method_with_cf(tuple(data))
 
     @Slot(tuple, name="modifyMethodWithCf")
     def modify_method_with_cf(self, cf: tuple) -> None:

--- a/activity_browser/app/ui/tables/impact_categories.py
+++ b/activity_browser/app/ui/tables/impact_categories.py
@@ -87,7 +87,7 @@ class CFTable(ABDataFrameView):
         method_data = method.load()
         self.dataframe = DataFrame([
             self.build_row(obj) for obj in method_data
-        ], columns=self.HEADERS)
+        ], columns=self.HEADERS + self.UNCERTAINTY)
 
     def build_row(self, method_cf) -> dict:
         key, amount = method_cf[:2]
@@ -112,5 +112,5 @@ class CFTable(ABDataFrameView):
 
     @Slot(bool, name="toggleUncertainColumns")
     def hide_uncertain(self, hide: bool = True) -> None:
-        for i in (c for c in self.dataframe.columns if c in self.UNCERTAINTY):
-            self.setColumnHidden(self.dataframe.columns.get_loc(i), hide)
+        for c in self.UNCERTAINTY:
+            self.setColumnHidden(self.dataframe.columns.get_loc(c), hide)

--- a/activity_browser/app/ui/tables/impact_categories.py
+++ b/activity_browser/app/ui/tables/impact_categories.py
@@ -4,9 +4,9 @@ import numbers
 import brightway2 as bw
 from pandas import DataFrame
 from PySide2 import QtWidgets
+from PySide2.QtCore import QModelIndex, Slot
 
-from activity_browser.app.signals import signals
-
+from ...signals import signals
 from .views import ABDataFrameView, dataframe_sync
 
 
@@ -25,6 +25,7 @@ class MethodsTable(ABDataFrameView):
         self.doubleClicked.connect(self.method_selected)
         signals.project_selected.connect(self.sync)
 
+    @Slot(QModelIndex, name="methodSelection")
     def method_selected(self, proxy):
         index = self.get_source_index(proxy)
         method = self.dataframe.iloc[index.row(), ]["method"]
@@ -33,51 +34,48 @@ class MethodsTable(ABDataFrameView):
     def selectedItems(self) -> list:
         """ Use to retrieve the method objects for the selected rows.
 
-        NOTE: Shadows the `selectedItems` method in QTableWidget as it is used
-        by `CSMethodsTable`. Possibly remove or improve in the future.
+        TODO: Shadows the `selectedItems` method in QTableWidget as it is used
+         by `CSMethodsTable`. Possibly remove or improve in the future.
         """
-        indexes = [self.get_source_index(p) for p in self.selectedIndexes()]
+        indexes = (self.get_source_index(p) for p in self.selectedIndexes())
         return [
             self.dataframe.iloc[index.row(), ] for index in indexes
         ]
 
     @dataframe_sync
-    def sync(self, query=None):
+    @Slot(name="syncTable")
+    def sync(self, query=None) -> None:
         sorted_names = sorted([(", ".join(method), method) for method in bw.methods])
-
         if query:
             sorted_names = filter(
                 lambda obj: query.lower() in obj[0].lower(), sorted_names
             )
+        self.dataframe = DataFrame([
+            self.build_row(method_obj) for method_obj in sorted_names
+        ], columns=self.HEADERS)
 
-        data = []
-        for method_obj in sorted_names:
-            method = bw.methods[method_obj[1]]
-            row =  {
-                "Name": method_obj[0],
-                "Unit": method.get("unit", "Unknown"),
-                "# CFs": str(method.get("num_cfs", 0)),
-                "method": method_obj[1],
-            }
-            data.append(row)
-        self.dataframe = DataFrame(data, columns=self.HEADERS)
+    def build_row(self, method_obj) -> dict:
+        method = bw.methods[method_obj[1]]
+        return {
+            "Name": method_obj[0],
+            "Unit": method.get("unit", "Unknown"),
+            "# CFs": str(method.get("num_cfs", 0)),
+            "method": method_obj[1],
+        }
 
-    def _resize(self):
-        self.setColumnHidden(3, True)
+    def _resize(self) -> None:
+        self.setColumnHidden(self.dataframe.columns.get_loc("method"), True)
         self.setSizePolicy(QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
         ))
 
 
 class CFTable(ABDataFrameView):
-    COLUMNS = [
-        "name",
-        "categories",
-        "amount",
-        "unit",
-        "uncertain",
-    ]
+    COLUMNS = ["name", "categories", "amount", "unit", "uncertain"]
     HEADERS = ["Name", "Category", "Amount", "Unit", "Uncertain"] + ["key"]
+    UNCERTAINTY = [
+        "uncertainty type", "loc", "scale", "shape", "minimum", "maximum"
+    ]
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -87,25 +85,32 @@ class CFTable(ABDataFrameView):
     def sync(self, method: tuple) -> None:
         method = bw.Method(method)
         method_data = method.load()
-        data = []
-        for obj in method_data:
-            key, amount = obj[:2]
-            flow = bw.get_activity(key)
-            if isinstance(amount, numbers.Number):
-                uncertain = "False"
-            else:
-                uncertain = "True"
-                amount = amount['amount']
-            row = {
-                self.HEADERS[i]: flow.get(self.COLUMNS[i])
-                for i in range(len(self.COLUMNS))
-            }
-            row.update({"Amount": amount, "Uncertain": uncertain, "key": key})
-            data.append(row)
-        self.dataframe = DataFrame(data, columns=self.HEADERS)
+        self.dataframe = DataFrame([
+            self.build_row(obj) for obj in method_data
+        ], columns=self.HEADERS)
 
-    def _resize(self):
+    def build_row(self, method_cf) -> dict:
+        key, amount = method_cf[:2]
+        flow = bw.get_activity(key)
+        row = {
+            self.HEADERS[i]: flow.get(c) for i, c in enumerate(self.COLUMNS)
+        }
+        # If uncertain, unpack the uncertainty dictionary
+        uncertain = not isinstance(amount, numbers.Number)
+        if uncertain:
+            row.update({k: amount.get(k, "nan") for k in self.UNCERTAINTY})
+            amount = amount["amount"]
+        row.update({"Amount": amount, "Uncertain": uncertain, "key": key})
+        return row
+
+    def _resize(self) -> None:
         self.setColumnHidden(5, True)
+        self.hide_uncertain()
         self.setSizePolicy(QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
         ))
+
+    @Slot(bool, name="toggleUncertainColumns")
+    def hide_uncertain(self, hide: bool = True) -> None:
+        for i in (c for c in self.dataframe.columns if c in self.UNCERTAINTY):
+            self.setColumnHidden(self.dataframe.columns.get_loc(i), hide)

--- a/activity_browser/app/ui/tables/impact_categories.py
+++ b/activity_browser/app/ui/tables/impact_categories.py
@@ -101,6 +101,7 @@ class CFTable(ABDataFrameView):
     UNCERTAINTY = [
         "uncertainty type", "loc", "scale", "shape", "minimum", "maximum"
     ]
+    modified = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -191,4 +192,4 @@ class CFTable(ABDataFrameView):
         else:
             cfs[idx] = cf
         self.method.write(cfs)
-        self.sync(self.method.name)
+        self.modified.emit()

--- a/activity_browser/app/ui/tabs/impact_categories.py
+++ b/activity_browser/app/ui/tabs/impact_categories.py
@@ -36,7 +36,7 @@ class MethodsTab(QtWidgets.QWidget):
     def __init__(self, parent):
         super(MethodsTab, self).__init__(parent)
 
-        self.table = MethodsTable()
+        self.table = MethodsTable(self)
         self.search_box = QtWidgets.QLineEdit()
         self.search_box.setPlaceholderText("Filter impact categories")
         reset_search_button = QtWidgets.QPushButton("Reset")
@@ -61,6 +61,14 @@ class MethodsTab(QtWidgets.QWidget):
         reset_search_button.clicked.connect(self.search_box.clear)
         self.search_box.returnPressed.connect(lambda: self.table.sync(query=self.search_box.text()))
         signals.project_selected.connect(self.search_box.clear)
+        self.table.new_method.connect(self.method_copied)
+
+    @QtCore.Slot(tuple, name="searchCopiedMethod")
+    def method_copied(self, method: tuple) -> None:
+        """If a method is successfully copied, sync and filter for new name."""
+        query = ", ".join(method)
+        self.search_box.setText(query)
+        self.table.sync(query)
 
 
 class CharacterizationFactorsTab(ABTab):

--- a/activity_browser/app/ui/tabs/impact_categories.py
+++ b/activity_browser/app/ui/tabs/impact_categories.py
@@ -16,7 +16,6 @@ class CFsTab(QtWidgets.QWidget):
         self.cf_table = CFTable()
         self.hide_uncertainty = QtWidgets.QCheckBox("Hide uncertainty columns")
         self.hide_uncertainty.setChecked(True)
-        self.hide_uncertainty.toggled.connect(self.cf_table.hide_uncertain)
         toolbar = QtWidgets.QToolBar(self)
         toolbar.addWidget(self.hide_uncertainty)
         container = QtWidgets.QVBoxLayout()
@@ -30,6 +29,15 @@ class CFsTab(QtWidgets.QWidget):
         self.cf_table.sync(method)
         self.cf_table.show()
         self.panel.select_tab(self)
+
+        self.connect_signals()
+
+    def connect_signals(self) -> None:
+        self.hide_uncertainty.toggled.connect(self.cf_table.hide_uncertain)
+        self.cf_table.modified.connect(lambda: self.cf_table.sync(self.method))
+        self.cf_table.modified.connect(
+            lambda: self.cf_table.hide_uncertain(self.hide_uncertainty.isChecked())
+        )
 
 
 class MethodsTab(QtWidgets.QWidget):

--- a/activity_browser/app/ui/tabs/impact_categories.py
+++ b/activity_browser/app/ui/tabs/impact_categories.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from PySide2 import QtCore, QtWidgets
 
-from ..style import header
+from ..style import header, horizontal_line
 from ..tables import CFTable, MethodsTable
 from ..panels import ABTab
 from ...signals import signals
@@ -14,8 +14,15 @@ class CFsTab(QtWidgets.QWidget):
         self.method = method
         # Not visible when instantiated
         self.cf_table = CFTable()
+        self.hide_uncertainty = QtWidgets.QCheckBox("Hide uncertainty columns")
+        self.hide_uncertainty.setChecked(True)
+        self.hide_uncertainty.toggled.connect(self.cf_table.hide_uncertain)
+        toolbar = QtWidgets.QToolBar(self)
+        toolbar.addWidget(self.hide_uncertainty)
         container = QtWidgets.QVBoxLayout()
         container.addWidget(header("Method: " + " - ".join(method)))
+        container.addWidget(horizontal_line())
+        container.addWidget(toolbar)
         container.addWidget(self.cf_table)
         container.setAlignment(QtCore.Qt.AlignTop)
         self.setLayout(container)

--- a/activity_browser/app/ui/widgets/__init__.py
+++ b/activity_browser/app/ui/widgets/__init__.py
@@ -4,7 +4,7 @@ from .biosphere_update import BiosphereUpdater
 from .comparison_switch import SwitchComboBox
 from .cutoff_menu import CutoffMenu
 from .database_copy import CopyDatabaseDialog
-from .dialog import ForceInputDialog
+from .dialog import ForceInputDialog, TupleNameDialog
 from .line_edit import (SignalledPlainTextEdit, SignalledComboEdit,
                         SignalledLineEdit)
 from .message import parameter_save_errorbox, simple_warning_box

--- a/activity_browser/app/ui/widgets/dialog.py
+++ b/activity_browser/app/ui/widgets/dialog.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtWidgets
-from PySide2.QtCore import Slot
+from PySide2 import QtGui, QtWidgets
+from PySide2.QtCore import QRegExp, Slot
+
+from ..style import style_group_box
 
 
 class ForceInputDialog(QtWidgets.QDialog):
@@ -42,4 +44,69 @@ class ForceInputDialog(QtWidgets.QDialog):
         obj.setWindowTitle(title)
         obj.label.setText(label)
         obj.input.setText(text)
+        return obj
+
+
+class TupleNameDialog(QtWidgets.QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.name_label = QtWidgets.QLabel("New name")
+        self.view_name = QtWidgets.QLabel()
+        self.no_comma_validator = QtGui.QRegExpValidator(QRegExp("[^,]+"))
+        self.input_fields = []
+        self.buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
+        )
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout()
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(self.name_label)
+        row.addWidget(self.view_name)
+        layout.addLayout(row)
+        self.input_box = QtWidgets.QGroupBox(self)
+        self.input_box.setStyleSheet(style_group_box.border_title)
+        input_field_layout = QtWidgets.QVBoxLayout()
+        self.input_box.setLayout(input_field_layout)
+        layout.addWidget(self.input_box)
+        layout.addWidget(self.buttons)
+        self.setLayout(layout)
+
+    @property
+    def combined_names(self) -> str:
+        """Reads all of the input fields in order and returns a string."""
+        return ", ".join(self.result_tuple)
+
+    @property
+    def result_tuple(self) -> tuple:
+        result = [f.text() for f in self.input_fields if f.text()]
+        if not self.input_fields[-1].text():
+            result.append(self.input_fields[-1].placeholderText())
+        return tuple(result)
+
+    @Slot(name="inputChanged")
+    def changed(self) -> None:
+        """Rebuild the view_name with text from all of the input fields."""
+        self.view_name.setText("'({})'".format(self.combined_names))
+
+    def add_input_field(self, text: str, placeholder: str = None) -> None:
+        edit = QtWidgets.QLineEdit(text, self)
+        edit.setPlaceholderText(placeholder or "")
+        edit.setValidator(self.no_comma_validator)
+        edit.textChanged.connect(self.changed)
+        self.input_fields.append(edit)
+        self.input_box.layout().addWidget(edit)
+
+    @classmethod
+    def get_combined_name(cls, parent: QtWidgets.QWidget, title: str, label: str,
+                          fields: tuple, extra: str = "Extra") -> 'TupleNameDialog':
+        obj = cls(parent)
+        obj.setWindowTitle(title)
+        obj.name_label.setText(label)
+        for field in fields:
+            obj.add_input_field(str(field))
+        obj.add_input_field("", extra)
+        obj.input_box.updateGeometry()
+        obj.changed()
         return obj

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -255,7 +255,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
             self.max_label.setHidden(hide)
             self.maximum.setHidden(hide)
 
-    def special_lognormal_handling(self):
+    def special_distribution_handling(self):
         """Special kansas city shuffling for this distribution."""
         if self.dist.id == LognormalUncertainty.id:
             self.mean.setHidden(False)
@@ -303,7 +303,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
         elif self.dist.id in {8, 9, 10, 11, 12}:
             self.hide_param("min", "max")
             self.hide_param("loc", "scale", "shape", hide=False)
-        self.special_lognormal_handling()
+        self.special_distribution_handling()
         self.generate_plot()
 
     @property

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -2,7 +2,8 @@
 from PySide2 import QtCore, QtGui, QtWidgets
 from PySide2.QtCore import Signal, Slot
 import numpy as np
-from stats_arrays import LognormalUncertainty, uncertainty_choices as uc
+from stats_arrays import uncertainty_choices as uc
+from stats_arrays.distributions import *
 
 from ..figures import SimpleDistributionPlot
 from ..style import style_group_box
@@ -121,7 +122,7 @@ class UncertaintyWizard(QtWidgets.QWizard):
          the user altering the loc/mean value.
          """
         mean = float(self.field("loc"))
-        if self.type.is_lognormal_uncertainty:
+        if self.field("uncertainty type") == LognormalUncertainty.id:
             mean = np.exp(mean)
         if not np.isclose(self.obj.amount, mean):
             msg = ("Do you want to update the 'amount' field to match mean?"
@@ -256,7 +257,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
 
     def special_lognormal_handling(self):
         """Special kansas city shuffling for this distribution."""
-        if self.is_lognormal_uncertainty:
+        if self.dist.id == LognormalUncertainty.id:
             self.mean.setHidden(False)
             self.mean_label.setHidden(False)
             self.loc_label.setText("Loc (ln(mean)):")
@@ -306,10 +307,6 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
         self.generate_plot()
 
     @property
-    def is_lognormal_uncertainty(self) -> bool:
-        return self.dist.id == LognormalUncertainty.id
-
-    @property
     def active_fields(self) -> tuple:
         """Returns anywhere from 0 to 3 fields"""
         if self.dist.id in {0, 1}:
@@ -341,7 +338,7 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
 
         Another special edge-case for the lognormal distribution.
         """
-        if self.is_lognormal_uncertainty and self.mean.text().startswith("-"):
+        if self.dist.id == LognormalUncertainty.id and float(self.mean.text()) < 0:
             self.setField("negative", True)
         else:
             self.setField("negative", False)

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -28,6 +28,8 @@ class UncertaintyWizard(QtWidgets.QWizard):
     TYPE = 0
     PEDIGREE = 1
 
+    complete = Signal(tuple, object)  # feed the CF uncertainty back to the origin
+
     def __init__(self, unc_object: Union[ExchangeProxyBase, ParameterBase], parent=None):
         super().__init__(parent)
 
@@ -77,6 +79,8 @@ class UncertaintyWizard(QtWidgets.QWizard):
             signals.parameter_uncertainty_modified.emit(self.obj, self.uncertainty_info)
             if self.using_pedigree:
                 signals.parameter_pedigree_modified.emit(self.obj, self.pedigree.matrix.factors)
+        elif isinstance(self.obj, tuple):
+            self.complete.emit(self.obj, self.uncertainty_info)
 
     def extract_uncertainty(self) -> None:
         """Used to extract possibly existing uncertainty information from the
@@ -175,7 +179,7 @@ class UncertaintyWizard(QtWidgets.QWizard):
                     signals.parameter_modified.emit(self.obj, "amount", mean)
                 elif isinstance(self.obj, tuple):
                     uncertain = self.obj[-1] if isinstance(self.obj[-1], dict) else {}
-                    altered = {k: v for k, v in uncertain}
+                    altered = {k: v for k, v in uncertain.items()}
                     altered["amount"] = mean
                     self.obj = (self.obj[0], altered)
 

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -374,10 +374,12 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
 
     @Slot(name="meanToLoc")
     def balance_loc_with_mean(self):
-        val_str = self.mean.text()
-        if val_str.startswith("-"):
-            val_str = val_str.lstrip("-")
-        self.loc.setText(str(np.log(float(val_str))))
+        if not self.mean.hasAcceptableInput():
+            self.loc.setText("nan")
+            return
+        val = float(self.mean.text() if self.mean.text() else "nan")
+        val = -1 * val if val < 0 else val
+        self.loc.setText(str(np.log(val) if val != 0 else float("nan")))
 
     @Slot(name="testValueNegative")
     def check_negative(self) -> None:
@@ -385,7 +387,10 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
 
         Another special edge-case for the lognormal distribution.
         """
-        if self.dist.id == LognormalUncertainty.id and float(self.mean.text()) < 0:
+        if not self.mean.hasAcceptableInput():
+            return
+        val = float(self.mean.text() if self.mean.text() else "nan")
+        if self.dist.id == LognormalUncertainty.id and val < 0:
             self.setField("negative", True)
         else:
             self.setField("negative", False)

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -417,14 +417,19 @@ class UncertaintyTypePage(QtWidgets.QWizardPage):
             (field.hasAcceptableInput() and field.text())
             for field in self.active_fields
         )
-        if self.complete and self.dist.id in self.mean_is_calculated:
-            self.blocked_mean.setText(str(self.calculate_mean))
-        if self.complete or self.dist.id in {0, 1}:
-            data = self.dist.random_variables(
-                self.dist.from_dicts(self.wizard().uncertainty_info), 1000
-            )
+        no_dist = self.dist.id in {UndefinedUncertainty.id, NoUncertainty.id}
+        if self.complete or no_dist:
+            array = self.dist.from_dicts(self.wizard().uncertainty_info)
+            if self.dist.id in self.mean_is_calculated:
+                mean = self.calculate_mean
+                self.blocked_mean.setText(str(mean))
+            elif no_dist:
+                mean = self.wizard().obj.amount
+            else:
+                mean = self.dist.statistics(array).get("mean")
+            data = self.dist.random_variables(array, 1000)
             if not np.any(np.isnan(data)):
-                self.plot.plot(data)
+                self.plot.plot(data, mean)
         self.completeChanged.emit()
 
 

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -124,9 +124,10 @@ class UncertaintyWizard(QtWidgets.QWizard):
         if self.type.is_lognormal_uncertainty:
             mean = np.exp(mean)
         if not np.isclose(self.obj.amount, mean):
+            msg = ("Do you want to update the 'amount' field to match mean?"
+                   "\nAmount: {}\tMean: {}".format(self.obj.amount, mean))
             choice = QtWidgets.QMessageBox.question(
-                self, "Amount differs from mean",
-                "Do you want to update the 'amount' field to match mean?",
+                self, "Amount differs from mean", msg,
                 QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.Yes
             )
             if choice == QtWidgets.QMessageBox.Yes:


### PR DESCRIPTION
Resolves #355.
Fixes #359.

Initial work contains code required to modify the Characterization Factor uncertainty information.

Additional work to do:

- [x] Allow users to copy existing impact assessment methods, handling name alterations when doing so.
- [x] Add small interface classes for the uncertainty wizard, with three different types of objects the logic which handles how to extract uncertainty is not very clear anymore. Should leave the way open for future additions.