### PR TITLE
Ensure plot is still generated if KDE bandwidth is 0

### DIFF
--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -276,7 +276,11 @@ class MonteCarloPlot(Plot):
 class SimpleDistributionPlot(Plot):
     def plot(self, data: np.ndarray, mean: float, label: str = "Value"):
         self.reset_plot()
-        sns.distplot(data, axlabel=label, ax=self.ax)
+        try:
+            sns.distplot(data, axlabel=label, ax=self.ax)
+        except RuntimeError as e:
+            print("Runtime error: {}\nPlotting without KDE.".format(e))
+            sns.distplot(data, axlabel=label, kde=False, ax=self.ax)
         self.ax.set_ylabel("Probability density")
         # Add vertical line at given mean of x-axis
         self.ax.axvline(mean, label="Mean / amount", c="r", ymax=0.98)


### PR DESCRIPTION
Values generated for Lognormal uncertainty distribution with a scale of 0 (and in some other cases) will cause the `seaborn.distplot` to fail due to a KDE bandwidth of 0.

<details><summary>Actual error</summary>
<p>

```python
Traceback (most recent call last):
  File "C:\env\abdev\lib\site-packages\statsmodels\nonparametric\kde.py", line 451, in kdensityfft
    bw = float(bw)
ValueError: could not convert string to float: 'scott'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\workspace\activity-browser\activity_browser\app\ui\wizards\uncertainty.py", line 640, in check_complete
    self.generate_plot()
  File "C:\workspace\activity-browser\activity_browser\app\ui\wizards\uncertainty.py", line 652, in generate_plot
    self.plot.plot(data, median)
  File "C:\workspace\activity-browser\activity_browser\app\ui\figures.py", line 279, in plot
    sns.distplot(data, axlabel=label, ax=self.ax)
  File "C:\env\abdev\lib\site-packages\seaborn\distributions.py", line 231, in distplot
    kdeplot(a, vertical=vertical, ax=ax, color=kde_color, **kde_kws)
  File "C:\env\abdev\lib\site-packages\seaborn\distributions.py", line 691, in kdeplot
    cumulative=cumulative, **kwargs)
  File "C:\env\abdev\lib\site-packages\seaborn\distributions.py", line 283, in _univariate_kdeplot
    cumulative=cumulative)
  File "C:\env\abdev\lib\site-packages\seaborn\distributions.py", line 355, in _statsmodels_univariate_kde
    kde.fit(kernel, bw, fft, gridsize=gridsize, cut=cut, clip=clip)
  File "C:\env\abdev\lib\site-packages\statsmodels\nonparametric\kde.py", line 140, in fit
    clip=clip, cut=cut)
  File "C:\env\abdev\lib\site-packages\statsmodels\nonparametric\kde.py", line 453, in kdensityfft
    bw = bandwidths.select_bandwidth(X, bw, kern) # will cross-val fit this pattern?
  File "C:\env\abdev\lib\site-packages\statsmodels\nonparametric\bandwidths.py", line 174, in select_bandwidth
    raise RuntimeError(err)
RuntimeError: Selected KDE bandwidth is 0. Cannot estiamte density.
```

</p>
</details>

This fix ensures a similar box/bin plot is still generated so users are aware that the `distribution` of values is not random for the given combination of uncertainty values.