### PR TITLE
Childproof uncertainty

### DIFF
--- a/activity_browser/app/bwutils/uncertainty.py
+++ b/activity_browser/app/bwutils/uncertainty.py
@@ -3,9 +3,21 @@ import abc
 
 from bw2data.parameters import ParameterBase
 from bw2data.proxies import ExchangeProxyBase
+import numpy as np
 from stats_arrays import (
     UncertaintyBase, UndefinedUncertainty, uncertainty_choices as uc
 )
+
+
+EMPTY_UNCERTAINTY = {
+    "uncertainty type": UndefinedUncertainty.id,
+    "loc": np.NaN,
+    "scale": np.NaN,
+    "shape": np.NaN,
+    "minimum": np.NaN,
+    "maximum": np.NaN,
+    "negative": False,
+}
 
 
 class BaseUncertaintyInterface(abc.ABC):

--- a/activity_browser/app/ui/tables/activity.py
+++ b/activity_browser/app/ui/tables/activity.py
@@ -9,8 +9,7 @@ import pandas as pd
 from PySide2 import QtCore, QtWidgets
 from PySide2.QtCore import Signal, Slot
 
-from .delegates import (FloatDelegate, FormulaDelegate, StringDelegate,
-                        UncertaintyDelegate, ViewOnlyDelegate)
+from .delegates import *
 from .views import ABDataFrameEdit, dataframe_sync
 from ..icons import qicons
 from ..wizards import UncertaintyWizard
@@ -307,13 +306,13 @@ class TechnosphereExchangeTable(BaseExchangeTable):
         self.setItemDelegateForColumn(3, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(4, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(5, ViewOnlyDelegate(self))
-        self.setItemDelegateForColumn(6, UncertaintyDelegate(self))
+        self.setItemDelegateForColumn(6, ViewOnlyUncertaintyDelegate(self))
         self.setItemDelegateForColumn(7, ViewOnlyDelegate(self))
-        self.setItemDelegateForColumn(8, FloatDelegate(self))
-        self.setItemDelegateForColumn(9, FloatDelegate(self))
-        self.setItemDelegateForColumn(10, FloatDelegate(self))
-        self.setItemDelegateForColumn(11, FloatDelegate(self))
-        self.setItemDelegateForColumn(12, FloatDelegate(self))
+        self.setItemDelegateForColumn(8, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(9, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(10, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(11, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(12, ViewOnlyFloatDelegate(self))
         self.setItemDelegateForColumn(13, FormulaDelegate(self))
         self.setDragDropMode(QtWidgets.QTableView.DragDrop)
         self.table_name = "technosphere"
@@ -395,13 +394,13 @@ class BiosphereExchangeTable(BaseExchangeTable):
         self.setItemDelegateForColumn(2, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(3, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(4, ViewOnlyDelegate(self))
-        self.setItemDelegateForColumn(5, UncertaintyDelegate(self))
+        self.setItemDelegateForColumn(5, ViewOnlyUncertaintyDelegate(self))
         self.setItemDelegateForColumn(6, ViewOnlyDelegate(self))
-        self.setItemDelegateForColumn(7, FloatDelegate(self))
-        self.setItemDelegateForColumn(8, FloatDelegate(self))
-        self.setItemDelegateForColumn(9, FloatDelegate(self))
-        self.setItemDelegateForColumn(10, FloatDelegate(self))
-        self.setItemDelegateForColumn(11, FloatDelegate(self))
+        self.setItemDelegateForColumn(7, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(8, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(9, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(10, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(11, ViewOnlyFloatDelegate(self))
         self.setItemDelegateForColumn(12, FormulaDelegate(self))
         self.table_name = "biosphere"
         self.setDragDropMode(QtWidgets.QTableView.DropOnly)

--- a/activity_browser/app/ui/tables/delegates/__init__.py
+++ b/activity_browser/app/ui/tables/delegates/__init__.py
@@ -6,7 +6,9 @@ from .formula import FormulaDelegate
 from .list import ListDelegate
 from .string import StringDelegate
 from .uncertainty import UncertaintyDelegate
-from .viewonly import ViewOnlyDelegate
+from .viewonly import (
+    ViewOnlyDelegate, ViewOnlyFloatDelegate, ViewOnlyUncertaintyDelegate
+)
 
 __all__ = [
     "CheckboxDelegate",
@@ -17,4 +19,6 @@ __all__ = [
     "StringDelegate",
     "UncertaintyDelegate",
     "ViewOnlyDelegate",
+    "ViewOnlyFloatDelegate",
+    "ViewOnlyUncertaintyDelegate",
 ]

--- a/activity_browser/app/ui/tables/delegates/viewonly.py
+++ b/activity_browser/app/ui/tables/delegates/viewonly.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from PySide2.QtWidgets import QStyledItemDelegate
 
+from .float import FloatDelegate
+from .uncertainty import UncertaintyDelegate
+
 
 class ViewOnlyDelegate(QStyledItemDelegate):
     """ Disable the editor functionality to allow specific columns of an
@@ -9,5 +12,17 @@ class ViewOnlyDelegate(QStyledItemDelegate):
     def __init__(self, parent=None):
         super().__init__(parent)
 
+    def createEditor(self, parent, option, index):
+        return None
+
+
+class ViewOnlyFloatDelegate(FloatDelegate):
+    """Correctly display float values without allowing modification."""
+    def createEditor(self, parent, option, index):
+        return None
+
+
+class ViewOnlyUncertaintyDelegate(UncertaintyDelegate):
+    """Correctly display uncertainty type without allowing modification."""
     def createEditor(self, parent, option, index):
         return None

--- a/activity_browser/app/ui/tables/impact_categories.py
+++ b/activity_browser/app/ui/tables/impact_categories.py
@@ -96,11 +96,9 @@ class MethodsTable(ABDataFrameView):
 
 
 class CFTable(ABDataFrameView):
-    COLUMNS = ["name", "categories", "amount", "unit", "uncertain"]
-    HEADERS = ["Name", "Category", "Amount", "Unit", "Uncertain"] + ["cf"]
-    UNCERTAINTY = [
-        "uncertainty type", "loc", "scale", "shape", "minimum", "maximum"
-    ]
+    COLUMNS = ["name", "categories", "amount", "unit"]
+    HEADERS = ["Name", "Category", "Amount", "Unit", "Uncertainty"] + ["cf"]
+    UNCERTAINTY = ["loc", "scale", "shape", "minimum", "maximum"]
     modified = Signal()
 
     def __init__(self, parent=None):
@@ -109,12 +107,12 @@ class CFTable(ABDataFrameView):
         self.method: Optional[bw.Method] = None
         self.wizard: Optional[UncertaintyWizard] = None
         self.setVisible(False)
-        self.setItemDelegateForColumn(6, UncertaintyDelegate(self))
+        self.setItemDelegateForColumn(4, UncertaintyDelegate(self))
+        self.setItemDelegateForColumn(6, FloatDelegate(self))
         self.setItemDelegateForColumn(7, FloatDelegate(self))
         self.setItemDelegateForColumn(8, FloatDelegate(self))
         self.setItemDelegateForColumn(9, FloatDelegate(self))
         self.setItemDelegateForColumn(10, FloatDelegate(self))
-        self.setItemDelegateForColumn(11, FloatDelegate(self))
 
     @dataframe_sync
     def sync(self, method: tuple) -> None:
@@ -134,8 +132,11 @@ class CFTable(ABDataFrameView):
         uncertain = not isinstance(amount, numbers.Number)
         if uncertain:
             row.update({k: amount.get(k, "nan") for k in self.UNCERTAINTY})
+            uncertain = amount.get("uncertainty type")
             amount = amount["amount"]
-        row.update({"Amount": amount, "Uncertain": uncertain, "cf": method_cf})
+        else:
+            uncertain = 0
+        row.update({"Amount": amount, "Uncertainty": uncertain, "cf": method_cf})
         return row
 
     def _resize(self) -> None:

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -18,9 +18,7 @@ from activity_browser.app.signals import signals
 from ..icons import qicons
 from ..widgets import simple_warning_box
 from ..wizards import UncertaintyWizard
-from .delegates import (DatabaseDelegate, FloatDelegate, FormulaDelegate,
-                        ListDelegate, StringDelegate, UncertaintyDelegate,
-                        ViewOnlyDelegate)
+from .delegates import *
 from .models import ParameterTreeModel
 from .views import (ABDataFrameEdit, ABDictTreeView, dataframe_sync,
                     tree_model_decorate)
@@ -219,12 +217,12 @@ class ProjectParameterTable(BaseParameterTable):
         self.setItemDelegateForColumn(0, ViewOnlyDelegate(self))
         self.setItemDelegateForColumn(1, FloatDelegate(self))
         self.setItemDelegateForColumn(2, FormulaDelegate(self))
-        self.setItemDelegateForColumn(3, UncertaintyDelegate(self))
-        self.setItemDelegateForColumn(4, FloatDelegate(self))
-        self.setItemDelegateForColumn(5, FloatDelegate(self))
-        self.setItemDelegateForColumn(6, FloatDelegate(self))
-        self.setItemDelegateForColumn(7, FloatDelegate(self))
-        self.setItemDelegateForColumn(8, FloatDelegate(self))
+        self.setItemDelegateForColumn(3, ViewOnlyUncertaintyDelegate(self))
+        self.setItemDelegateForColumn(4, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(5, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(6, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(7, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(8, ViewOnlyFloatDelegate(self))
 
     @classmethod
     def build_df(cls):
@@ -285,12 +283,12 @@ class DataBaseParameterTable(BaseParameterTable):
         self.setItemDelegateForColumn(1, FloatDelegate(self))
         self.setItemDelegateForColumn(2, FormulaDelegate(self))
         self.setItemDelegateForColumn(3, DatabaseDelegate(self))
-        self.setItemDelegateForColumn(4, UncertaintyDelegate(self))
-        self.setItemDelegateForColumn(5, FloatDelegate(self))
-        self.setItemDelegateForColumn(6, FloatDelegate(self))
-        self.setItemDelegateForColumn(7, FloatDelegate(self))
-        self.setItemDelegateForColumn(8, FloatDelegate(self))
-        self.setItemDelegateForColumn(9, FloatDelegate(self))
+        self.setItemDelegateForColumn(4, ViewOnlyUncertaintyDelegate(self))
+        self.setItemDelegateForColumn(5, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(6, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(7, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(8, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(9, ViewOnlyFloatDelegate(self))
 
     @classmethod
     def build_df(cls) -> pd.DataFrame:
@@ -380,12 +378,12 @@ class ActivityParameterTable(BaseParameterTable):
         self.setItemDelegateForColumn(6, StringDelegate(self))
         self.setItemDelegateForColumn(7, ListDelegate(self))
         self.setItemDelegateForColumn(8, ViewOnlyDelegate(self))
-        self.setItemDelegateForColumn(9, UncertaintyDelegate(self))
-        self.setItemDelegateForColumn(10, FloatDelegate(self))
-        self.setItemDelegateForColumn(11, FloatDelegate(self))
-        self.setItemDelegateForColumn(12, FloatDelegate(self))
-        self.setItemDelegateForColumn(13, FloatDelegate(self))
-        self.setItemDelegateForColumn(14, FloatDelegate(self))
+        self.setItemDelegateForColumn(9, ViewOnlyUncertaintyDelegate(self))
+        self.setItemDelegateForColumn(10, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(11, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(12, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(13, ViewOnlyFloatDelegate(self))
+        self.setItemDelegateForColumn(14, ViewOnlyFloatDelegate(self))
 
         # Set dropEnabled
         self.setDragDropMode(ABDataFrameEdit.DropOnly)

--- a/activity_browser/app/ui/tabs/activity.py
+++ b/activity_browser/app/ui/tabs/activity.py
@@ -228,11 +228,13 @@ class ActivityTab(QtWidgets.QWidget):
                 table.delete_exchange_action.setEnabled(False)
                 table.remove_formula_action.setEnabled(False)
                 table.modify_uncertainty_action.setEnabled(False)
+                table.remove_uncertainty_action.setEnabled(False)
             else:
                 table.setEditTriggers(QtWidgets.QTableView.DoubleClicked)
                 table.delete_exchange_action.setEnabled(True)
                 table.remove_formula_action.setEnabled(True)
                 table.modify_uncertainty_action.setEnabled(True)
+                table.remove_uncertainty_action.setEnabled(True)
                 if not table.downstream:  # downstream consumers table never accepts drops
                     table.setAcceptDrops(True)
 

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -117,10 +117,10 @@ class UncertaintyWizard(QtWidgets.QWizard):
         lognormal.
         """
         mean = getattr(self.obj, "amount", 1.0)
-        loc = self.obj.uncertainty.get("loc", None)
-        if loc and self.obj.uncertainty_type != LognormalUncertainty:
+        loc = self.obj.uncertainty.get("loc", np.NaN)
+        if not np.isnan(loc) and self.obj.uncertainty_type != LognormalUncertainty:
             loc = np.log(loc)
-        if loc is None:
+        if np.isnan(loc):
             loc = np.log(mean)
         self.setField("loc", str(loc))
 

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -98,7 +98,8 @@ class UncertaintyWizard(QtWidgets.QWizard):
         objects which sometimes have uncertainty do not.
         """
         for k, v in self.obj.uncertainty.items():
-            self.setField(k, v)
+            if k in self.KEYS:
+                self.setField(k, v)
 
         # If no loc/mean value is set yet, convert the amount.
         if not self.field("loc") or self.field("loc") == "nan":

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -8,6 +8,7 @@ from stats_arrays.distributions import *
 from ..figures import SimpleDistributionPlot
 from ..style import style_group_box
 from ...bwutils import PedigreeMatrix, get_uncertainty_interface
+from ...bwutils.uncertainty import EMPTY_UNCERTAINTY
 from ...signals import signals
 
 
@@ -17,11 +18,6 @@ class UncertaintyWizard(QtWidgets.QWizard):
 
     Note that this can also be used for setting uncertainties on parameters
     """
-    KEYS = {
-        "uncertainty type", "loc", "scale", "shape", "minimum", "maximum",
-        "negative"
-    }
-
     TYPE = 0
     PEDIGREE = 1
 
@@ -61,11 +57,10 @@ class UncertaintyWizard(QtWidgets.QWizard):
 
     @property
     def uncertainty_info(self) -> dict:
-        dist_id = self.field("uncertainty type")
-        data = dict.fromkeys(self.KEYS, np.NaN)
-        data["uncertainty type"] = dist_id
+        data = {k: v for k, v in EMPTY_UNCERTAINTY.items()}
+        data["uncertainty type"] = self.field("uncertainty type")
         data["negative"] = bool(self.field("negative"))
-        for field in self.standard_dist_fields(dist_id):
+        for field in self.standard_dist_fields(data["uncertainty type"]):
             data[field] = float(self.field(field))
         return data
 
@@ -98,7 +93,7 @@ class UncertaintyWizard(QtWidgets.QWizard):
         objects which sometimes have uncertainty do not.
         """
         for k, v in self.obj.uncertainty.items():
-            if k in self.KEYS:
+            if k in EMPTY_UNCERTAINTY:
                 self.setField(k, v)
 
         # If no loc/mean value is set yet, convert the amount.

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -133,12 +133,14 @@ class UncertaintyWizard(QtWidgets.QWizard):
         """Asks if the 'amount' of the object should be updated to account for
          the user altering the loc/mean value.
          """
+        uc_type = self.field("uncertainty type")
+        no_change = {UndefinedUncertainty.id, NoUncertainty.id}
         mean = float(self.field("loc"))
-        if self.field("uncertainty type") == LognormalUncertainty.id:
+        if uc_type == LognormalUncertainty.id:
             mean = np.exp(mean)
-        if self.field("uncertainty type") in self.type.mean_is_calculated:
+        elif uc_type in self.type.mean_is_calculated:
             mean = self.type.calculate_mean
-        if not np.isclose(self.obj.amount, mean):
+        if not np.isclose(self.obj.amount, mean) and uc_type not in no_change:
             msg = ("Do you want to update the 'amount' field to match mean?"
                    "\nAmount: {}\tMean: {}".format(self.obj.amount, mean))
             choice = QtWidgets.QMessageBox.question(

--- a/activity_browser/app/ui/wizards/uncertainty.py
+++ b/activity_browser/app/ui/wizards/uncertainty.py
@@ -102,11 +102,8 @@ class UncertaintyWizard(QtWidgets.QWizard):
             if self.field("uncertainty type") == LognormalUncertainty.id:
                 val = np.log(val)
             self.setField("loc", str(val))
-        # If no sigma is set, default to 0
-        if not self.field("scale") or self.field("scale") == "nan":
-            self.setField("scale", "0")
         # Let the other fields default to 'nan' if no values are set.
-        for f in ("shape", "maximum", "minimum"):
+        for f in ("scale", "shape", "maximum", "minimum"):
             if not self.field(f):
                 self.setField(f, "nan")
 


### PR DESCRIPTION
Issues can occur if the user alters uncertainty within the exchange tables directly. Incorrect values will cause monte-carlo calculations to break down and return a vague exception about uncertainty (this can be extremely difficult to fix, as no information is returned about _which_ exchange has incorrect uncertainty information).

This PR aims to 'fix' that problem, by removing the ability to directly edit the uncertainty columns at all.

Features:
- Make uncertainty columns in all tables 'read-only'.
- Add logic for quickly removing uncertainty from exchanges, parameters and CF's.
- Minor fixes to uncertainty wizard to avoid warnings and incorrect amount changes.
