### PR TITLE
Remove presamples

### DIFF
--- a/activity_browser/app/bwutils/presamples/__init__.py
+++ b/activity_browser/app/bwutils/presamples/__init__.py
@@ -2,7 +2,7 @@
 from .manager import PresamplesParameterManager
 from .presamples_mlca import PresamplesContributions, PresamplesMLCA
 from .utils import (
-    count_presample_packages, find_all_package_names, get_package_path,
-    load_scenarios_from_file, presamples_dir, presamples_packages,
-    remove_package, save_scenarios_to_file,
+    clear_resource_by_name, count_presample_packages, find_all_package_names,
+    get_package_path, load_scenarios_from_file, presamples_dir,
+    presamples_packages, remove_package, save_scenarios_to_file,
 )

--- a/activity_browser/app/bwutils/presamples/utils.py
+++ b/activity_browser/app/bwutils/presamples/utils.py
@@ -4,6 +4,7 @@ from typing import Iterable, List, Optional
 
 import brightway2 as bw
 import pandas as pd
+from presamples import PresampleResource
 
 
 def load_scenarios_from_file(path: str) -> pd.DataFrame:
@@ -66,5 +67,16 @@ def remove_package(path: Path) -> bool:
         for p in path.iterdir():
             p.unlink()
         path.rmdir()
+        return True
+    return False
+
+
+def clear_resource_by_name(name_id: str) -> bool:
+    """Attempts to clear a PresamplesResource object from the database."""
+    obj = PresampleResource.get_or_none(name=name_id)
+    if obj:
+        db_tuple = next(db for db in bw.config.sqlite3_databases if db[0] == "campaigns.db")
+        with db_tuple[1].atomic():
+            PresampleResource.delete().where(PresampleResource.id == obj.id).execute()
         return True
     return False

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -12,6 +12,7 @@ from bw2data.project import ProjectDataset, SubstitutableDatabase
 from bw2data.proxies import ExchangeProxyBase
 
 from .bwutils import commontasks as bc, AB_metadata
+from .bwutils.presamples import clear_resource_by_name, get_package_path, remove_package
 from .settings import ab_settings, project_settings
 from .signals import signals
 from .ui.widgets import CopyDatabaseDialog
@@ -88,6 +89,9 @@ class Controller(object):
         signals.project_selected.connect(self.reset_metadata)
         signals.metadata_changed.connect(self.update_metadata)
         signals.edit_activity.connect(self.print_convenience_information)
+
+        # Presamples
+        signals.presample_package_delete.connect(self.remove_presamples_package)
 
 # SETTINGS
     def load_settings(self):
@@ -588,3 +592,17 @@ class Controller(object):
     @Slot(str, name="printDatabaseInformation")
     def print_convenience_information(db_name: str) -> None:
         AB_metadata.print_convenience_information(db_name)
+
+    @staticmethod
+    @Slot(str, name="removePresamplesPackage")
+    def remove_presamples_package(name_id: str) -> None:
+        path = get_package_path(name_id)
+        resource = clear_resource_by_name(name_id)
+        if path is None and not resource:
+            raise ValueError(
+                "Given presample package '{}' could not be found.".format(name_id)
+            )
+        print("Removed PresampleResource object?", resource)
+        files = remove_package(path)
+        print("Removed Presample files?", files)
+        signals.presample_package_removed.emit()

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -71,6 +71,7 @@ class Signals(QObject):
 
     # Presamples
     presample_package_created = Signal(str)
+    presample_package_delete = Signal(str)
     presample_package_removed = Signal()
 
     # Calculation Setups

--- a/activity_browser/app/ui/tabs/LCA_setup.py
+++ b/activity_browser/app/ui/tabs/LCA_setup.py
@@ -73,7 +73,7 @@ State data
 The currently selected calculation setup is retrieved by getting the currently selected value in ``CSList``.
 
 """
-PresamplesTuple = namedtuple("presamples", ["label", "list", "button"])
+PresamplesTuple = namedtuple("presamples", ["label", "list", "button", "remove"])
 
 
 class LCASetupTab(QtWidgets.QWidget):
@@ -94,6 +94,7 @@ class LCASetupTab(QtWidgets.QWidget):
             QtWidgets.QLabel("Prepared scenarios:"),
             PresamplesList(self),
             QtWidgets.QPushButton(qicons.calculate, "Calculate"),
+            QtWidgets.QPushButton(qicons.delete, "Remove"),
         )
         for obj in self.presamples:
             obj.hide()
@@ -112,6 +113,7 @@ class LCASetupTab(QtWidgets.QWidget):
         calc_row.addWidget(self.calculation_type)
         calc_row.addWidget(self.presamples.label)
         calc_row.addWidget(self.presamples.list)
+        calc_row.addWidget(self.presamples.remove)
         calc_row.addStretch(1)
 
         container = QtWidgets.QVBoxLayout()
@@ -132,6 +134,7 @@ class LCASetupTab(QtWidgets.QWidget):
         # Signals
         self.calculate_button.clicked.connect(self.start_calculation)
         self.presamples.button.clicked.connect(self.presamples_calculation)
+        self.presamples.remove.clicked.connect(self.remove_presamples_package)
 
         self.new_cs_button.clicked.connect(signals.new_calculation_setup.emit)
         self.delete_cs_button.clicked.connect(
@@ -171,6 +174,19 @@ class LCASetupTab(QtWidgets.QWidget):
         signals.lca_presamples_calculation.emit(
             self.list_widget.name, self.presamples.list.selection
         )
+
+    @Slot(name="removePresamplesPackage")
+    def remove_presamples_package(self):
+        """Removes the current presamples package selected from the list."""
+        name_id = self.presamples.list.selection
+        do_remove = QtWidgets.QMessageBox.question(
+            self, "Removing presample package",
+            "Are you sure you want to remove presample package '{}'?".format(name_id),
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+            QtWidgets.QMessageBox.No
+        )
+        if do_remove == QtWidgets.QMessageBox.Yes:
+            signals.presample_package_delete.emit(name_id)
 
     @Slot(name="toggleDefaultCalculation")
     def set_default_calculation_setup(self):


### PR DESCRIPTION
Partial solution for #391.

Allow for the complete removal of presample packages and the possibly existing `PresampleResource` object.

Of specific note, `Campaign` objects are not considered in any way.