### PR TITLE
Add 'flow type' field to superstructure

### DIFF
--- a/activity_browser/app/bwutils/superstructure/activities.py
+++ b/activity_browser/app/bwutils/superstructure/activities.py
@@ -53,14 +53,28 @@ def constuct_ad_data(row) -> tuple:
     return key, data
 
 
-def data_from_index(index: tuple) -> tuple:
+def data_from_index(index: tuple) -> dict:
     """Take the given 'Index' tuple and build a complete SUPERSTRUCTURE row
     from it.
     """
     from_key, to_key = index[0], index[1]
     from_key, from_data = constuct_ad_data(ActivityDataset.get(database=from_key[0], code=from_key[1]))
     to_key, to_data = constuct_ad_data(ActivityDataset.get(database=to_key[0], code=to_key[1]))
-    return tuple([*from_data, from_key, *to_data, to_key])
+    return {
+        "from activity name": from_data[0],
+        "from reference product": from_data[1],
+        "from location": from_data[2],
+        "from categories": from_data[3],
+        "from database": from_data[4],
+        "from key": from_key,
+        "to activity name": to_data[0],
+        "to reference product": to_data[1],
+        "to location": to_data[1],
+        "to categories": to_data[2],
+        "to database": to_data[3],
+        "to key": to_key,
+        "flow type": getattr(index, "flow_type", None),
+    }
 
 
 def all_flows_found(df: pd.DataFrame, part: str = "from") -> bool:

--- a/activity_browser/app/bwutils/superstructure/excel.py
+++ b/activity_browser/app/bwutils/superstructure/excel.py
@@ -72,6 +72,12 @@ def import_from_excel(document_path: Union[str, Path], import_sheet: int = 1):
         usecols=valid_cols, comment="*", na_values="", keep_default_na=False
     )
     diff = SUPERSTRUCTURE.difference(data.columns)
+    # 'flow type' is not yet a required column
+    if "flow type" in diff:
+        print("Missing the 'flow type' column, ignoring for now.")
+        diff = diff.drop(["flow type"])
+        cols = data.columns.append(pd.Index(["flow type"]))
+        data = data.reindex(cols, axis="columns")
     if not diff.empty:
         raise ValueError("Missing required column(s) for superstructure: {}".format(diff.to_list()))
 

--- a/activity_browser/app/bwutils/superstructure/presamples.py
+++ b/activity_browser/app/bwutils/superstructure/presamples.py
@@ -9,7 +9,7 @@ from presamples.packaging import format_matrix_data, to_2d, to_array
 
 from ..utils import Index
 from .dataframe import scenario_names_from_df
-from .utils import SUPERSTRUCTURE, EXCHANGE_KEYS
+from .utils import SUPERSTRUCTURE, EXCHANGE_KEYS, INDEX_KEYS
 
 
 def build_presamples_array_from_df(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
@@ -43,7 +43,7 @@ def build_arrays_from_df(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
     values = df.loc[:, scenario_columns]
     assert keys.notna().all().all(), "Need all the keys for this."
     indices = [
-        Index.build_from_tuple(x) for x in keys.itertuples(index=False)
+        Index.build_from_dict(x) for x in df.loc[:, INDEX_KEYS].to_dict("records")
     ]
 
     result = np.zeros(len(indices), dtype=object)

--- a/activity_browser/app/bwutils/superstructure/presamples.py
+++ b/activity_browser/app/bwutils/superstructure/presamples.py
@@ -42,8 +42,9 @@ def build_arrays_from_df(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
     scenario_columns = df.columns.difference(SUPERSTRUCTURE, sort=False)
     values = df.loc[:, scenario_columns]
     assert keys.notna().all().all(), "Need all the keys for this."
+    data = df.loc[:, INDEX_KEYS].rename(columns={"from key": "input", "to key": "output"})
     indices = [
-        Index.build_from_dict(x) for x in df.loc[:, INDEX_KEYS].to_dict("records")
+        Index.build_from_dict(x) for x in data.to_dict("records")
     ]
 
     result = np.zeros(len(indices), dtype=object)

--- a/activity_browser/app/bwutils/superstructure/utils.py
+++ b/activity_browser/app/bwutils/superstructure/utils.py
@@ -17,8 +17,10 @@ SUPERSTRUCTURE = pd.Index([
     "to categories",
     "to database",
     "to key",
+    "flow type",
 ])
 EXCHANGE_KEYS = pd.Index(["from key", "to key"])
+INDEX_KEYS = pd.Index(["from key", "to key", "flow type"])
 FROM_ALL = pd.Index([
     "from activity name", "from reference product", "from location",
     "from categories", "from database", "from key"

--- a/activity_browser/app/bwutils/utils.py
+++ b/activity_browser/app/bwutils/utils.py
@@ -42,19 +42,37 @@ class Key(NamedTuple):
 class Index(NamedTuple):
     input: Key
     output: Key
+    flow_type: Optional[int] = None
 
     @classmethod
     def build_from_exchange(cls, exc: ExchangeDataset) -> 'Index':
         return cls(
             input=Key(exc.input_database, exc.input_code),
-            output=Key(exc.output_database, exc.output_code)
+            output=Key(exc.output_database, exc.output_code),
+            flow_type=exc.type,
         )
 
     @classmethod
     def build_from_tuple(cls, data: tuple) -> 'Index':
-        return cls(
+        obj = cls(
             input=Key(data[0][0], data[0][1]),
-            output=Key(data[1][0], data[1][1])
+            output=Key(data[1][0], data[1][1]),
+        )
+        exc_type = ExchangeDataset.get(
+            ExchangeDataset.input_code == obj.input.code,
+            ExchangeDataset.input_database == obj.input.database,
+            ExchangeDataset.output_code == obj.output.code,
+            ExchangeDataset.output_database == obj.output.database).type
+        return obj._replace(flow_type=exc_type)
+
+    @classmethod
+    def build_from_dict(cls, data: dict) -> 'Index':
+        in_key = data.get("input", ("", ""))
+        out_key = data.get("output", ("", ""))
+        return cls(
+            input=Key(in_key[0], in_key[1]),
+            output=Key(out_key[0], out_key[1]),
+            flow_type=data.get("flow type", None),
         )
 
     @property
@@ -73,6 +91,8 @@ class Index(NamedTuple):
 
     @property
     def exchange_type(self) -> int:
+        if self.flow_type:
+            return TYPE_DICTIONARY.get(self.flow_type, -1)
         exc_type = ExchangeDataset.get(
             ExchangeDataset.input_code == self.input.code,
             ExchangeDataset.input_database == self.input.database,


### PR DESCRIPTION
Expand the superstructure with a string 'flow type' field that is added to the excel file and the dataframe.

This will make MLCA index construction faster while also allowing for faster validation.