### PR TITLE
Combine multiple scenario files

### DIFF
--- a/activity_browser/app/bwutils/superstructure/__init__.py
+++ b/activity_browser/app/bwutils/superstructure/__init__.py
@@ -3,5 +3,6 @@ from .dataframe import (
     scenario_names_from_df, superstructure_from_arrays
 )
 from .excel import import_from_excel, get_sheet_names
+from .manager import SuperstructureManager
 from .mlca import SuperstructureMLCA, SuperstructureContributions
 from .utils import SUPERSTRUCTURE

--- a/activity_browser/app/bwutils/superstructure/dataframe.py
+++ b/activity_browser/app/bwutils/superstructure/dataframe.py
@@ -49,6 +49,22 @@ def arrays_from_superstructure(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
     return result, values.to_numpy()
 
 
+def arrays_from_indexed_superstructure(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
+    def guess(row: tuple) -> str:
+        if row[0][0] == bw.config.biosphere:
+            return "biosphere"
+        elif row[0] == row[1]:
+            return "production"
+        else:
+            return "technosphere"
+    result = np.zeros(df.shape[0], dtype=object)
+    for i, data in enumerate(df.index.to_flat_index()):
+        result[i] = Index.build_from_dict(
+            {"input": data[0], "output": data[1], "flow type": guess(data)}
+        )
+    return result, df.to_numpy(dtype=float)
+
+
 def scenario_names_from_df(df: pd.DataFrame) -> list:
     """Returns the list of scenario names from a given superstructure.
 

--- a/activity_browser/app/bwutils/superstructure/manager.py
+++ b/activity_browser/app/bwutils/superstructure/manager.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+import itertools
+from typing import List
+
+import pandas as pd
+
+from .activities import fill_df_keys_with_fields
+from .utils import SUPERSTRUCTURE, EXCHANGE_KEYS
+
+
+class SuperstructureManager(object):
+    """A combination of methods used to manipulate and transform superstructures."""
+    def __init__(self, df: pd.DataFrame, *dfs: pd.DataFrame):
+        # Prepare dataframes for further processing
+        self.frames: List[pd.DataFrame] = [
+            SuperstructureManager.remove_duplicates(df)
+        ] + [SuperstructureManager.remove_duplicates(f) for f in dfs]
+        self.is_multiple = len(self.frames) > 1
+
+    def combined_data(self, kind: str = "product") -> pd.DataFrame:
+        """Combines multiple superstructures using a specific kind of logic.
+
+        Currently implemented: 'product' creates an outer-product combination
+        from all of the columns of the dataframes and injects values from all
+        the frames for their specific indexes, any shared indexes are overridden
+        where the later dataframes have preference.
+
+        Uses parts of https://stackoverflow.com/a/45286061
+
+        If only a single dataframe is given to the manager, return this dataframe instead.
+        """
+        if not self.is_multiple:
+            df = next(iter(self.frames))
+            cols = df.columns.difference(SUPERSTRUCTURE, sort=False)
+            return pd.DataFrame(
+                data=df.loc[:, cols], index=df.index, columns=cols
+            )
+        combo_idx = self._combine_indexes()
+
+        if kind == "product":
+            combo_cols = self._combine_columns()
+            df = SuperstructureManager.product_combine_frames(
+                self.frames, combo_cols, combo_idx
+            )
+            # Flatten the columns again for later processing.
+            df.columns = df.columns.to_flat_index()
+        else:
+            df = pd.DataFrame([], index=combo_idx)
+
+        return df
+
+    def _combine_columns(self) -> pd.MultiIndex:
+        cols = [df.columns.difference(SUPERSTRUCTURE, sort=False).to_list() for df in self.frames]
+        return pd.MultiIndex.from_tuples(list(itertools.product(*cols)))
+
+    def _combine_indexes(self) -> pd.MultiIndex:
+        """Returns a union of all of the given dataframe indexes."""
+        iterable = iter(self.frames)
+        idx = next(iterable).index
+        for df in iterable:
+            idx = idx.union(df.index)
+        return idx
+
+    @staticmethod
+    def product_combine_frames(data: List[pd.DataFrame], cols: pd.MultiIndex, index: pd.MultiIndex) -> pd.DataFrame:
+        """Iterate through the dataframes, filling data into the combined
+        dataframe with duplicate indexes being resolved using a 'last one wins'
+        logic.
+        """
+        df = pd.DataFrame([], index=index, columns=cols)
+        for idx, f in enumerate(data):
+            data = f.loc[:, cols.get_level_values(idx)]
+            data.columns = cols
+            df.loc[data.index, :] = data
+        return df
+
+    @staticmethod
+    def remove_duplicates(df: pd.DataFrame) -> pd.DataFrame:
+        """Using the input/output index for a superstructure, drop duplicates
+        where the last instance survives.
+        """
+        if not isinstance(df.index, pd.MultiIndex):
+            df.index = SuperstructureManager.index_from_keys(df)
+        duplicates = df.index.duplicated(keep="last")
+        return df.loc[~duplicates, :] if duplicates.any() else df
+
+    @staticmethod
+    def index_from_keys(df: pd.DataFrame) -> pd.MultiIndex:
+        """Construct MultiIndex from exchange keys, allowing for data merging."""
+        if df.loc[:, EXCHANGE_KEYS].isna().any().all():
+            df = fill_df_keys_with_fields(df)
+            assert df.loc[:, EXCHANGE_KEYS].notna().all().all(), "Cannot find all keys."
+        return pd.MultiIndex.from_tuples(
+            df.loc[:, EXCHANGE_KEYS].apply(tuple, axis=1),
+            names=["input", "output"]
+        )

--- a/activity_browser/app/bwutils/superstructure/mlca.py
+++ b/activity_browser/app/bwutils/superstructure/mlca.py
@@ -7,11 +7,7 @@ import pandas as pd
 
 from ..multilca import MLCA, Contributions
 from ..utils import Index
-from .activities import fill_df_keys_with_fields
-from .dataframe import (
-    scenario_names_from_df, arrays_from_superstructure, guesstimate_flow_type
-)
-from .utils import EXCHANGE_KEYS
+from .dataframe import scenario_names_from_df, arrays_from_indexed_superstructure
 
 
 class SuperstructureMLCA(MLCA):
@@ -32,14 +28,7 @@ class SuperstructureMLCA(MLCA):
 
         super().__init__(cs_name)
 
-        # Ensure all keys are present in the dataframe.
-        df = fill_df_keys_with_fields(df)
-        assert df.loc[:, EXCHANGE_KEYS].notna().all().all(), "Not all processes were found in the project"
-        # If entire 'flow type' column is empty, guess the types.
-        if df["flow type"].isna().all():
-            df = guesstimate_flow_type(df)
-        # Convert the dataframe into numpy arrays
-        self.indices, self.values = arrays_from_superstructure(df)
+        self.indices, self.values = arrays_from_indexed_superstructure(df)
         # Note: Using the mapping scheme from brightway and presamples,
         # the 'input' keys are matched to the product_dict or
         # biosphere_dict ('rows') while the 'output' keys are matched
@@ -48,7 +37,6 @@ class SuperstructureMLCA(MLCA):
             ('row', np.uint32), ('col', np.uint32), ('type', np.uint8),
         ])
         self.indices_to_matrix()
-
 
         # Construct an index dictionary similar to fu_index and method_index
         self._current_index = 0

--- a/activity_browser/app/ui/tabs/LCA_setup.py
+++ b/activity_browser/app/ui/tabs/LCA_setup.py
@@ -6,7 +6,9 @@ from PySide2.QtCore import Slot
 from brightway2 import calculation_setups
 import pandas as pd
 
-from ...bwutils.superstructure import import_from_excel, scenario_names_from_df
+from ...bwutils.superstructure import (
+    SuperstructureManager, import_from_excel, scenario_names_from_df
+)
 from ...signals import signals
 from ..icons import qicons
 from ..style import horizontal_line, header, style_group_box
@@ -342,15 +344,10 @@ class ScenarioImportPanel(QtWidgets.QWidget):
             # Return an empty dataframe, will almost immediately cause a
             # validation exception.
             return pd.DataFrame()
-        if len(self.tables) == 1:
-            # Return the dataframe from the only table there is.
-            table = next(iter(self.tables))
-            return table.scenario_df
-        # Now, check which combination to do.
-        if self.product_choice.isChecked():
-            pass
-        else:
-            pass
+        data = [t.scenario_df for t in self.tables]
+        manager = SuperstructureManager(*data)
+        kind = "product" if self.product_choice.isChecked() else "addition"
+        return manager.combined_data(kind)
 
     @Slot(name="addTable")
     def add_table(self) -> None:


### PR DESCRIPTION
Allows combining multiple scenario files into a single superstructure.

This will allow users to combine their data in multiple different ways:
**Product**: Creates an outer product of the scenarios from the files, if there are shared indexes (input/output keys) in the files, the right-most file 'wins'.
**Addition**: Creates a union of the scenarios, summing values if there are any indexes shared by the separate files.