### PR TITLE
Add openpyxl dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   # - conda update -q conda  # Yeet.
   - conda info -a
   # Install package requirements & test suite
-  - conda install -q -c conda-forge -c cmutel -c haasad -c pascallesage arrow brightway2 bw2io bw2data eidl fuzzywuzzy matplotlib-base networkx pandas pyside2=5.13 seaborn presamples "pytest>=5.2" pytest-qt pytest-mock
+  - conda install -q -c conda-forge -c cmutel -c haasad -c pascallesage arrow brightway2 bw2io bw2data eidl fuzzywuzzy matplotlib-base networkx pandas pyside2=5.13 seaborn presamples openpyxl "pytest>=5.2" pytest-qt pytest-mock
 
 test_script:
   - py.test

--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - pyside2 >=5.13.1
     - seaborn
     - presamples
+    - openpyxl
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - pyside2 >=5.13.1
     - seaborn
     - presamples
+    - openpyxl
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser


### PR DESCRIPTION
When reading large .xlsx files, `openpyxl` is dramatically faster that `xlrd` because it does not have to read the entire file to determine the sheet names.