### PR TITLE
Fix superstructure keys in excel

### DIFF
--- a/activity_browser/app/bwutils/superstructure/excel.py
+++ b/activity_browser/app/bwutils/superstructure/excel.py
@@ -3,6 +3,7 @@ from ast import literal_eval
 from pathlib import Path
 from typing import List, Union
 
+import numpy as np
 import openpyxl
 import pandas as pd
 
@@ -78,8 +79,9 @@ def import_from_excel(document_path: Union[str, Path], import_sheet: int = 1):
         raise ValueError("Missing required column(s) for superstructure: {}".format(diff.to_list()))
 
     # Convert specific columns that may have tuples as strings
-    data["from categories"] = data["from categories"].apply(convert_tuple_str)
-    data["from key"] = data["from key"].apply(convert_tuple_str)
-    data["to categories"] = data["to categories"].apply(convert_tuple_str)
-    data["to key"] = data["to key"].apply(convert_tuple_str)
+    data.loc[:, "from categories"] = data["from categories"].apply(convert_tuple_str)
+    data.loc[:, "to categories"] = data["to categories"].apply(convert_tuple_str)
+    # TODO: find better way of handling keys from excel, purge them for now to
+    #  avoid 'incorrect' keys causing issues.
+    data.loc[:, ["from key", "to key"]] = np.NaN
     return data

--- a/activity_browser/app/bwutils/superstructure/excel.py
+++ b/activity_browser/app/bwutils/superstructure/excel.py
@@ -78,8 +78,8 @@ def import_from_excel(document_path: Union[str, Path], import_sheet: int = 1):
         raise ValueError("Missing required column(s) for superstructure: {}".format(diff.to_list()))
 
     # Convert specific columns that may have tuples as strings
-    data["from categories"] = data["from categories"].apply(lambda x: convert_tuple_str(x))
-    data["from key"] = data["from key"].apply(lambda x: convert_tuple_str(x))
-    data["to categories"] = data["to categories"].apply(lambda x: convert_tuple_str(x))
-    data["to key"] = data["to key"].apply(lambda x: convert_tuple_str(x))
+    data["from categories"] = data["from categories"].apply(convert_tuple_str)
+    data["from key"] = data["from key"].apply(convert_tuple_str)
+    data["to categories"] = data["to categories"].apply(convert_tuple_str)
+    data["to key"] = data["to key"].apply(convert_tuple_str)
     return data

--- a/activity_browser/app/ui/tabs/base.py
+++ b/activity_browser/app/ui/tabs/base.py
@@ -28,7 +28,7 @@ class BaseRightTab(QWidget):
         """
         raise NotImplementedError
 
-    @Slot()
+    @Slot(name="showExplanationBox")
     def explanation(self):
         """ Builds and shows a message box containing whatever text is set
         on self.explain_text


### PR DESCRIPTION
Due to keys not always being shared / equal between different users (eg. When importing ecoinvent from website codes for processes are semi-randomly generated to avoid clashes).

This will sometimes cause issues when the superstructure is exported from the AB due to it including the process keys.

Current (temporary?) fix is to just dump the keys during import from excel and have each instance of AB do its own lookup of the processes using the remaining given identifiers.