### PR TITLE
Pin numpy below 1.18 to avoid linspace exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,20 @@ language: python
 
 matrix:
   include:
-    - python: "3.6"
-      os: linux
-      env: PYENV=3.6 VERSION=2.6.0.dev PKG_NAME=activity-browser-dev
     - python: "3.7"
       os: linux
       env: PYENV=3.7 VERSION=2.6.0.dev PKG_NAME=activity-browser-dev
-    - python: "3.6"
-      language: generic
-      os: osx
-      env: PYENV=3.6 VERSION=2.6.0.dev PKG_NAME=activity-browser-dev
+    - python: "3.8"
+      os: linux
+      env: PYENV=3.8 VERSION=2.6.0.dev PKG_NAME=activity-browser-dev
     - python: "3.7"
       language: generic
       os: osx
       env: PYENV=3.7 VERSION=2.6.0.dev PKG_NAME=activity-browser-dev
+    - python: "3.8"
+      language: generic
+      os: osx
+      env: PYENV=3.8 VERSION=2.6.0.dev PKG_NAME=activity-browser-dev
 
 install:
   # As suggested by https://github.com/conda/conda/issues/9337#issuecomment-542466141

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@
 # https://github.com/AnacondaRecipes/conda-feedstock/blob/master/.appveyor.yml
 build: "off"
 
+image: "Visual Studio 2019"
+
 environment:
   # PYTHONIOENCODING: "UTF-8"
   PYTHONUNBUFFERED: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,10 @@ environment:
   PYTHONUNBUFFERED: 1
 
   matrix:
-    - CONDA_PY: "36"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: "37"
       CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
+    - CONDA_PY: "38"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda38-x64"
 
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat

--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - fuzzywuzzy
     - matplotlib-base >=2.2.2
     - networkx
+    - numpy <1.18  #https://github.com/LCA-ActivityBrowser/activity-browser/issues/427
     - pandas >=0.24.1
     - pyside2 >=5.13.1
     - salib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - fuzzywuzzy
     - matplotlib-base >=2.2.2
     - networkx
+    - numpy <1.18  #https://github.com/LCA-ActivityBrowser/activity-browser/issues/427
     - pandas >=0.24.1
     - pyside2 >=5.13.1
     - salib


### PR DESCRIPTION
A temporary patch for #427, just to avoid an exception that can occur when using the GSA feature.