### PR TITLE
Restructure importer code

### DIFF
--- a/activity_browser/app/bwutils/importers.py
+++ b/activity_browser/app/bwutils/importers.py
@@ -5,7 +5,7 @@ import warnings
 
 import brightway2 as bw
 from bw2io import ExcelImporter
-from bw2io.errors import StrategyError
+from bw2io.errors import InvalidPackage, StrategyError
 from bw2io.importers.excel import valid_first_cell
 from bw2io.strategies import (
     csv_restore_tuples, csv_restore_booleans, csv_numerize,
@@ -19,6 +19,8 @@ from bw2io.strategies import (
     convert_uncertainty_types_to_integers,
     convert_activity_parameters_to_list
 )
+
+from .strategies import relink_exchanges_bw2package
 
 
 INNER_FIELDS = ("name", "unit", "database", "location")
@@ -104,3 +106,70 @@ class ABExcelImporter(ExcelImporter):
             link_technosphere_by_activity_hash,
             external_db_name=db_name, fields=fields
         ))
+
+
+class ABPackage(bw.BW2Package):
+    """ Inherits from brightway2 `BW2Package` and handles importing BW2Packages.
+
+    This implementation is done to raise exceptions and show errors on imports
+    much faster.
+    """
+    @classmethod
+    def evaluate_metadata(cls, metadata: dict, ignore_dbs: set):
+        """ Take the given metadata dictionary and test it against realities
+        of the current brightway project.
+        """
+        if "depends" in metadata:
+            missing = set(metadata["depends"]).difference(bw.databases)
+            # Remove any databases present in ignore_dbs (these will be relinked)
+            missing = missing.difference(ignore_dbs)
+            if missing:
+                raise InvalidPackage(
+                    "Package data links to database names that do not exist: {}".format(missing),
+                    missing
+                )
+
+    @classmethod
+    def load_file(cls, filepath, whitelist=True, relink: dict = None):
+        """Similar to how the base class loads the data, but also perform
+        a number of evaluations on the metadata.
+
+        Also, if given a 'relink' dictionary, perform relinking of exchanges.
+        """
+        data = super().load_file(filepath, whitelist)
+        relinking = set(relink.keys()) if relink else set([])
+        if isinstance(data, dict):
+            if "metadata" in data:
+                cls.evaluate_metadata(data["metadata"], relinking)
+            if relink:
+                data["data"] = relink_exchanges_bw2package(data["data"], relink)
+        else:
+            for obj in data:
+                if "metadata" in obj:
+                    cls.evaluate_metadata(obj["metadata"], relinking)
+                if relink:
+                    obj["data"] = relink_exchanges_bw2package(obj["data"], relink)
+        return data
+
+    @classmethod
+    def import_file(cls, filepath, whitelist=True, relink: dict = None):
+        """Import bw2package file, and create the loaded objects, including registering, writing, and processing the created objects.
+
+        Args:
+            * *filepath* (str): Path of file to import
+            * *whitelist* (bool): Apply whitelist to allowed types. Default is ``True``.
+        Kwargs:
+            * *relink* (dict): A dictionary of keys with which to relink exchanges
+              within the imported package file.
+
+        Returns:
+            Created object or list of created objects.
+
+        """
+        loaded = cls.load_file(filepath, whitelist, relink)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            if isinstance(loaded, dict):
+                return cls._create_obj(loaded)
+            else:
+                return [cls._create_obj(o) for o in loaded]

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -235,7 +235,8 @@ class ChooseDirPage(QtWidgets.QWizardPage):
         layout.addWidget(box)
         self.setLayout(layout)
 
-    def get_directory(self):
+    @Slot(name="getDirectory")
+    def get_directory(self) -> None:
         path = QtWidgets.QFileDialog.getExistingDirectory(
             self, 'Select directory with ecospold2 files')
         self.path_edit.setText(path)
@@ -291,10 +292,12 @@ class Choose7zArchivePage(QtWidgets.QWizardPage):
         self.stored_combobox.clear()
         self.stored_combobox.addItems(sorted(self.stored_dbs.keys()))
 
-    def update_stored(self, index):
+    @Slot(int, name="updateSelectedIndex")
+    def update_stored(self, index: int) -> None:
         self.path_edit.setText(self.stored_dbs[self.stored_combobox.currentText()])
 
-    def get_archive(self):
+    @Slot(name="getArchiveFile")
+    def get_archive(self) -> None:
         path, _ = QtWidgets.QFileDialog.getOpenFileName(
             self, 'Select 7z archive')
         if path:

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -19,6 +19,7 @@ from PySide2.QtCore import Signal, Slot
 from ...bwutils.commontasks import is_technosphere_db
 from ...bwutils.importers import ABExcelImporter, ABPackage
 from ...signals import signals
+from ..style import style_group_box
 from ..widgets import DatabaseRelinkDialog
 
 # TODO: Rework the entire import wizard, the amount of different classes
@@ -153,6 +154,66 @@ class ImportTypePage(QtWidgets.QWizardPage):
                 return DatabaseImportWizard.EI_LOGIN
         else:
             return self.options[option_id][2]
+
+
+class RemoteImportPage(QtWidgets.QWizardPage):
+    """Contains all the options for remote importing of data."""
+    OPTIONS = (
+        ("ecoinvent (requires login)", "homepage", DatabaseImportWizard.EI_LOGIN),
+        ("Forwast", "forwast", DatabaseImportWizard.DB_NAME),
+    )
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.wizard = parent
+        self.radio_buttons = [QtWidgets.QRadioButton(o[0]) for o in self.OPTIONS]
+        self.radio_buttons[0].setChecked(True)
+
+        layout = QtWidgets.QVBoxLayout()
+        box = QtWidgets.QGroupBox("Data source:")
+        box_layout = QtWidgets.QVBoxLayout()
+        for i, button in enumerate(self.radio_buttons):
+            box_layout.addWidget(button)
+        box.setLayout(box_layout)
+        box.setStyleSheet(style_group_box.border_title)
+        layout.addWidget(box)
+        self.setLayout(layout)
+
+    def nextId(self):
+        option_id = [b.isChecked() for b in self.radio_buttons].index(True)
+        self.wizard.import_type = self.OPTIONS[option_id][1]
+        return self.OPTIONS[option_id][2]
+
+
+class LocalImportPage(QtWidgets.QWizardPage):
+    """Contains all the options for the local importing of data."""
+    OPTIONS = (
+        ("Local 7z-archive of previously downloaded database", "archive", DatabaseImportWizard.ARCHIVE),
+        ("Local directory with ecospold2 files", "directory", DatabaseImportWizard.DIR),
+        ("Local Excel file", "local", DatabaseImportWizard.EXCEL),
+        ("Local brightway database file", "local", DatabaseImportWizard.LOCAL),
+    )
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.wizard = parent
+        self.radio_buttons = [QtWidgets.QRadioButton(o[0]) for o in self.OPTIONS]
+        self.radio_buttons[0].setChecked(True)
+
+        layout = QtWidgets.QVBoxLayout()
+        box = QtWidgets.QGroupBox("Data source:")
+        box_layout = QtWidgets.QVBoxLayout()
+        for i, button in enumerate(self.radio_buttons):
+            box_layout.addWidget(button)
+        box.setLayout(box_layout)
+        box.setStyleSheet(style_group_box.border_title)
+        layout.addWidget(box)
+        self.setLayout(layout)
+
+    def nextId(self):
+        option_id = [b.isChecked() for b in self.radio_buttons].index(True)
+        self.wizard.import_type = self.OPTIONS[option_id][1]
+        return self.OPTIONS[option_id][2]
 
 
 class ChooseDirPage(QtWidgets.QWizardPage):

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -223,13 +223,16 @@ class ChooseDirPage(QtWidgets.QWizardPage):
         self.browse_button.clicked.connect(self.get_directory)
 
         layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(QtWidgets.QLabel(
-            'Choose location of existing ecospold2 directory:'))
-        layout.addWidget(self.path_edit)
+        box = QtWidgets.QGroupBox("Choose location of existing ecospold2 directory:")
+        box_layout = QtWidgets.QVBoxLayout()
+        box_layout.addWidget(self.path_edit)
         browse_lay = QtWidgets.QHBoxLayout()
         browse_lay.addWidget(self.browse_button)
         browse_lay.addStretch(1)
-        layout.addLayout(browse_lay)
+        box_layout.addLayout(browse_lay)
+        box.setLayout(box_layout)
+        box.setStyleSheet(style_group_box.border_title)
+        layout.addWidget(box)
         self.setLayout(layout)
 
     def get_directory(self):
@@ -264,19 +267,23 @@ class Choose7zArchivePage(QtWidgets.QWizardPage):
         self.registerField('archive_path*', self.path_edit)
         self.browse_button = QtWidgets.QPushButton('Browse')
         self.browse_button.clicked.connect(self.get_archive)
+        self.stored_dbs = {}
         self.stored_combobox = QtWidgets.QComboBox()
         self.stored_combobox.activated.connect(self.update_stored)
 
         layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(QtWidgets.QLabel(
-            'Choose location of 7z archive:'))
-        layout.addWidget(self.path_edit)
+        box = QtWidgets.QGroupBox("Choose location of 7z archive:")
+        box_layout = QtWidgets.QVBoxLayout()
+        box_layout.addWidget(self.path_edit)
         browse_lay = QtWidgets.QHBoxLayout()
         browse_lay.addWidget(self.browse_button)
         browse_lay.addStretch(1)
-        layout.addLayout(browse_lay)
-        layout.addWidget(QtWidgets.QLabel('Previous downloads:'))
-        layout.addWidget(self.stored_combobox)
+        box_layout.addLayout(browse_lay)
+        box_layout.addWidget(QtWidgets.QLabel("Previous downloads:"))
+        box_layout.addWidget(self.stored_combobox)
+        box.setLayout(box_layout)
+        box.setStyleSheet(style_group_box.border_title)
+        layout.addWidget(box)
         self.setLayout(layout)
 
     def initializePage(self):
@@ -320,9 +327,12 @@ class DBNamePage(QtWidgets.QWizardPage):
         self.registerField('db_name*', self.name_edit)
 
         layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(QtWidgets.QLabel(
-            'Name of the new database:'))
-        layout.addWidget(self.name_edit)
+        box = QtWidgets.QGroupBox("Name of the new database:")
+        box_layout = QtWidgets.QVBoxLayout()
+        box_layout.addWidget(self.name_edit)
+        box.setLayout(box_layout)
+        box.setStyleSheet(style_group_box.border_title)
+        layout.addWidget(box)
         self.setLayout(layout)
 
     def initializePage(self):
@@ -362,10 +372,16 @@ class ConfirmationPage(QtWidgets.QWizardPage):
         self.current_project_label = QtWidgets.QLabel('empty')
         self.db_name_label = QtWidgets.QLabel('empty')
         self.path_label = QtWidgets.QLabel('empty')
+
         layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(self.current_project_label)
-        layout.addWidget(self.db_name_label)
-        layout.addWidget(self.path_label)
+        box = QtWidgets.QGroupBox("Import Summary:")
+        box_layout = QtWidgets.QVBoxLayout()
+        box_layout.addWidget(self.current_project_label)
+        box_layout.addWidget(self.db_name_label)
+        box_layout.addWidget(self.path_label)
+        box.setLayout(box_layout)
+        box.setStyleSheet(style_group_box.border_title)
+        layout.addWidget(box)
         self.setLayout(layout)
 
     def initializePage(self):
@@ -908,14 +924,15 @@ class LocalDatabaseImportPage(QtWidgets.QWizardPage):
         self.path_btn.clicked.connect(self.browse)
         self.complete = False
 
-        option_box = QtWidgets.QGroupBox("Import local database file:")
+        box = QtWidgets.QGroupBox("Import local database file:")
         grid_layout = QtWidgets.QGridLayout()
         layout = QtWidgets.QVBoxLayout()
         grid_layout.addWidget(QtWidgets.QLabel("Path to file*"), 0, 0, 1, 1)
         grid_layout.addWidget(self.path, 0, 1, 1, 2)
         grid_layout.addWidget(self.path_btn, 0, 3, 1, 1)
-        option_box.setLayout(grid_layout)
-        layout.addWidget(option_box)
+        box.setLayout(grid_layout)
+        box.setStyleSheet(style_group_box.border_title)
+        layout.addWidget(box)
         self.setLayout(layout)
 
         # Register field to ensure user cannot advance without selecting file.
@@ -987,6 +1004,7 @@ class ExcelDatabaseImport(QtWidgets.QWizardPage):
         grid_layout.addWidget(self.link_option, 3, 0, 1, 2)
         grid_layout.addWidget(self.link_choice, 3, 2, 1, 2)
         option_box.setLayout(grid_layout)
+        option_box.setStyleSheet(style_group_box.border_title)
         layout.addWidget(option_box)
         self.setLayout(layout)
 

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -3,7 +3,6 @@ import os
 import io
 import subprocess
 import tempfile
-import warnings
 import zipfile
 
 import eidl
@@ -18,8 +17,7 @@ from PySide2 import QtWidgets, QtCore
 from PySide2.QtCore import Signal, Slot
 
 from ...bwutils.commontasks import is_technosphere_db
-from ...bwutils.strategies import relink_exchanges_bw2package
-from ...bwutils.importers import ABExcelImporter
+from ...bwutils.importers import ABExcelImporter, ABPackage
 from ...signals import signals
 from ..widgets import DatabaseRelinkDialog
 
@@ -1114,70 +1112,3 @@ class ABEcoinventDownloader(eidl.EcoinventDownloader):
             msg += ("\n\nIf you work offline you can use your previously downloaded databases" +
                     " via the archive option of the import wizard.")
         import_signals.connection_problem.emit(('Connection problem', msg))
-
-
-class ABPackage(bw.BW2Package):
-    """ Inherits from brightway2 `BW2Package` and handles importing BW2Packages.
-
-    This implementation is done to raise exceptions and show errors on imports
-    much faster.
-    """
-    @classmethod
-    def evaluate_metadata(cls, metadata: dict, ignore_dbs: set):
-        """ Take the given metadata dictionary and test it against realities
-        of the current brightway project.
-        """
-        if "depends" in metadata:
-            missing = set(metadata["depends"]).difference(bw.databases)
-            # Remove any databases present in ignore_dbs (these will be relinked)
-            missing = missing.difference(ignore_dbs)
-            if missing:
-                raise InvalidPackage(
-                    "Package data links to database names that do not exist: {}".format(missing),
-                    missing
-                )
-
-    @classmethod
-    def load_file(cls, filepath, whitelist=True, relink: dict = None):
-        """Similar to how the base class loads the data, but also perform
-        a number of evaluations on the metadata.
-
-        Also, if given a 'relink' dictionary, perform relinking of exchanges.
-        """
-        data = super().load_file(filepath, whitelist)
-        relinking = set(relink.keys()) if relink else set([])
-        if isinstance(data, dict):
-            if "metadata" in data:
-                cls.evaluate_metadata(data["metadata"], relinking)
-            if relink:
-                data["data"] = relink_exchanges_bw2package(data["data"], relink)
-        else:
-            for obj in data:
-                if "metadata" in obj:
-                    cls.evaluate_metadata(obj["metadata"], relinking)
-                if relink:
-                    obj["data"] = relink_exchanges_bw2package(obj["data"], relink)
-        return data
-
-    @classmethod
-    def import_file(cls, filepath, whitelist=True, relink: dict = None):
-        """Import bw2package file, and create the loaded objects, including registering, writing, and processing the created objects.
-
-        Args:
-            * *filepath* (str): Path of file to import
-            * *whitelist* (bool): Apply whitelist to allowed types. Default is ``True``.
-        Kwargs:
-            * *relink* (dict): A dictionary of keys with which to relink exchanges
-              within the imported package file.
-
-        Returns:
-            Created object or list of created objects.
-
-        """
-        loaded = cls.load_file(filepath, whitelist, relink)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            if isinstance(loaded, dict):
-                return cls._create_obj(loaded)
-            else:
-                return [cls._create_obj(o) for o in loaded]


### PR DESCRIPTION
Separate remote and local imports into two pages.

Add group boxes everywhere, with the same styling.

Move `ABPackage` code to the importers.py file in `bwutils`.