### PR TITLE
Database relink after creation

### DIFF
--- a/activity_browser/app/bwutils/strategies.py
+++ b/activity_browser/app/bwutils/strategies.py
@@ -2,7 +2,11 @@
 from typing import Collection
 
 import brightway2 as bw
-from bw2data.backends.peewee import ActivityDataset
+from bw2data.backends.peewee import ActivityDataset, sqlite3_lci_db
+from bw2data.errors import ValidityError
+from bw2io.errors import StrategyError
+from bw2io.strategies.generic import format_nonunique_key_error
+from bw2io.utils import DEFAULT_FIELDS, activity_hash
 
 
 def relink_exchanges_dbs(data: Collection, relink: dict) -> Collection:
@@ -37,3 +41,48 @@ def relink_exchanges_bw2package(data: dict, relink: dict) -> dict:
                     raise ValueError("Cannot relink exchange '{}', key '{}' not found.".format(exc, new_key)
                                      ).with_traceback(e.__traceback__)
     return data
+
+
+def relink_exchanges_existing_db(db: bw.Database, other: bw.Database) -> None:
+    """Relink exchanges after the database has been created/written.
+
+    This means possibly doing a lot of sqlite update calls.
+    """
+    assert db.backend == "sqlite", "Relinking only allowed for SQLITE backends"
+    assert other.backend == "sqlite", "Relinking only allowed for SQLITE backends"
+
+    duplicates, candidates = {}, {}
+    altered = 0
+
+    for ds in other:
+        key = activity_hash(ds, DEFAULT_FIELDS)
+        if key in candidates:
+            duplicates.setdefault(key, []).append(ds)
+        else:
+            candidates[key] = (ds['database'], ds['code'])
+
+    with sqlite3_lci_db.transaction() as transaction:
+        try:
+            # Only do relinking on external technosphere exchanges.
+            for i, exc in enumerate(
+                    exc for act in db for exc in act.technosphere()
+                    if exc.input[0] != db.name
+            ):
+                # Use the input activity to generate the hash.
+                key = activity_hash(exc.input, DEFAULT_FIELDS)
+                if key in duplicates:
+                    raise StrategyError(format_nonunique_key_error(exc.input, DEFAULT_FIELDS, duplicates[key]))
+                elif key in candidates:
+                    exc["input"] = candidates[key]
+                    altered += 1
+                exc.save()
+                if i % 10000 == 0:
+                    # Commit changes every 10k exchanges.
+                    transaction.commit()
+        except (StrategyError, ValidityError) as e:
+            print(e)
+            transaction.rollback()
+    # Process the database after the transaction is complete.
+    #  this updates the 'depends' in metadata
+    db.process()
+    print("Finished relinking database, {} exchanges altered.".format(altered))

--- a/activity_browser/app/bwutils/strategies.py
+++ b/activity_browser/app/bwutils/strategies.py
@@ -63,10 +63,10 @@ def relink_exchanges_existing_db(db: bw.Database, other: bw.Database) -> None:
 
     with sqlite3_lci_db.transaction() as transaction:
         try:
-            # Only do relinking on external technosphere exchanges.
+            # Only do relinking on external biosphere/technosphere exchanges.
             for i, exc in enumerate(
-                    exc for act in db for exc in act.technosphere()
-                    if exc.input[0] != db.name
+                    exc for act in db for exc in act.exchanges()
+                    if exc.get("type") in {"biosphere", "technosphere"} and exc.input[0] != db.name
             ):
                 # Use the input activity to generate the hash.
                 key = activity_hash(exc.input, DEFAULT_FIELDS)

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -281,8 +281,9 @@ class Controller(object):
 
     @Slot(str, QObject, name="relinkDatabase")
     def relink_database(self, db_name: str, parent: QObject) -> None:
+        """Relink technosphere exchanges within the given database."""
         dialog = DatabaseRelinkDialog.relink_existing(
-            parent, db_name, bw.databases.list
+            parent, db_name, [db for db in bw.databases if db != db_name]
         )
         if dialog.exec_() == DatabaseRelinkDialog.Accepted:
             db = bw.Database(db_name)

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -27,6 +27,7 @@ class Signals(QObject):
     copy_database = Signal(str, QObject)
     install_default_data = Signal()
     import_database = Signal(QObject)
+    relink_database = Signal(str, QObject)
 
     database_selected = Signal(str)
     databases_changed = Signal()

--- a/activity_browser/app/ui/widgets/dialog.py
+++ b/activity_browser/app/ui/widgets/dialog.py
@@ -241,6 +241,10 @@ class DatabaseRelinkDialog(QtWidgets.QDialog):
         " exchanges to a different database?"
         "\n\nReplace database '{}' with:"
     )
+    RELINK_EXISTING = (
+        "Relink exchanges from database '{}' with another database?"
+        "\n\nLink with:"
+    )
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -270,6 +274,15 @@ class DatabaseRelinkDialog(QtWidgets.QDialog):
     def start_relink(cls, parent: QtWidgets.QWidget, db: str, options: List[str]) -> 'DatabaseRelinkDialog':
         obj = cls(parent)
         obj.label.setText(cls.LABEL_TEXT.format(db))
+        obj.choice.clear()
+        obj.choice.addItems(options)
+        obj.choice.setEnabled(True)
+        return obj
+
+    @classmethod
+    def relink_existing(cls, parent: QtWidgets.QWidget, db: str, options: List[str]) -> 'DatabaseRelinkDialog':
+        obj = cls(parent)
+        obj.label.setText(cls.RELINK_EXISTING.format(db))
         obj.choice.clear()
         obj.choice.addItems(options)
         obj.choice.setEnabled(True)


### PR DESCRIPTION
Allow users to relink database exchanges after importing or creating them.

This feature combines the `bw2io` importing tools with the `bw2data` database editing and processing tools.