### PR TITLE
Tweak excel importer

### DIFF
--- a/activity_browser/app/bwutils/importers.py
+++ b/activity_browser/app/bwutils/importers.py
@@ -19,7 +19,9 @@ from bw2io.strategies import (
     convert_activity_parameters_to_list
 )
 
-from .strategies import relink_exchanges_bw2package, alter_database_name
+from .strategies import (
+    relink_exchanges_bw2package, alter_database_name, hash_parameter_group
+)
 
 
 INNER_FIELDS = ("name", "unit", "database", "location")
@@ -71,6 +73,7 @@ class ABExcelImporter(ExcelImporter):
             ),
             drop_falsey_uncertainty_fields_but_keep_zeros,
             convert_uncertainty_types_to_integers,
+            hash_parameter_group,
             convert_activity_parameters_to_list,
         ]
         obj.db_name = db_name

--- a/activity_browser/app/bwutils/importers.py
+++ b/activity_browser/app/bwutils/importers.py
@@ -97,7 +97,8 @@ class ABExcelImporter(ExcelImporter):
         if any(obj.unlinked):
             # Still have unlinked fields? Raise exception.
             excs = [exc for exc in obj.unlinked][:10]
-            raise StrategyError(excs)
+            databases = {exc.get("database", "missing_db") for exc in obj.unlinked}
+            raise StrategyError(excs, databases)
         db = obj.write_database(delete_existing=True, activate_parameters=True)
         if has_params:
             bw.parameters.recalculate()

--- a/activity_browser/app/bwutils/strategies.py
+++ b/activity_browser/app/bwutils/strategies.py
@@ -6,8 +6,11 @@ import brightway2 as bw
 from bw2data.backends.peewee import ActivityDataset, sqlite3_lci_db
 from bw2data.errors import ValidityError
 from bw2io.errors import StrategyError
-from bw2io.strategies.generic import format_nonunique_key_error
+from bw2io.strategies.generic import format_nonunique_key_error, link_technosphere_by_activity_hash
 from bw2io.utils import DEFAULT_FIELDS, activity_hash
+
+
+INNER_FIELDS = ("name", "unit", "database", "location")
 
 
 def relink_exchanges_dbs(data: Collection, relink: dict) -> Collection:
@@ -25,6 +28,20 @@ def relink_exchanges_dbs(data: Collection, relink: dict) -> Collection:
                     raise ValueError("Cannot relink exchange '{}', key '{}' not found.".format(exc, new_key)
                                      ).with_traceback(e.__traceback__)
     return data
+
+
+def relink_exchanges_with_db(data: list, old: str, new: str) -> list:
+    for act in data:
+        for exc in (exc for exc in act.get("exchanges", []) if exc.get("database") == old):
+            exc["database"] = new
+    return link_technosphere_by_activity_hash(data, external_db_name=new, fields=INNER_FIELDS)
+
+
+def link_exchanges_without_db(data: list, db: str) -> list:
+    for act in data:
+        for exc in (exc for exc in act.get("exchanges", []) if "database" not in exc):
+            exc["database"] = db
+    return link_technosphere_by_activity_hash(data, external_db_name=db, fields=INNER_FIELDS)
 
 
 def relink_exchanges_bw2package(data: dict, relink: dict) -> dict:

--- a/activity_browser/app/ui/widgets/dialog.py
+++ b/activity_browser/app/ui/widgets/dialog.py
@@ -299,5 +299,7 @@ class DatabaseRelinkDialog(QtWidgets.QDialog):
         obj.label.setText(cls.LINK_UNKNOWN.format(db))
         obj.choice.clear()
         obj.choice.addItems(options)
+        if db in options:
+            obj.choice.setCurrentText(db)
         obj.choice.setEnabled(True)
         return obj


### PR DESCRIPTION
Allow relinking of all external technosphere databases

Ignore given activity parameter group in favour of generating one from the `name`, `database` and `code` of the activity.