### PR TITLE
Fix for excel export

### DIFF
--- a/activity_browser/app/bwutils/errors.py
+++ b/activity_browser/app/bwutils/errors.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+class ImportCanceledError(Exception):
+    """Import of data was cancelled by the user."""
+    pass
+
+
+class LinkingFailed(Exception):
+    """Unlinked exchanges remain after relinking."""
+    pass

--- a/activity_browser/app/bwutils/exporters.py
+++ b/activity_browser/app/bwutils/exporters.py
@@ -16,6 +16,23 @@ from .pedigree import PedigreeMatrix
 #  - Add handler for pedigree data to exporter
 
 
+class ABCSVFormatter(CSVFormatter):
+    def exchange_as_dict(self, exc):
+        """Same as CSVFormatter, but explicitly pull the database from the
+        input activity.
+
+        This ensures that the database value is always included, even when
+        it is not stored in the exchange _data.
+        """
+        inp = exc.input
+        inp_fields = ("name", "unit", "location", "categories", "database")
+        skip_fields = ("input", "output")
+        data = {k: v for k, v in exc._data.items()
+                if k not in skip_fields}
+        data.update(**{k: inp[k] for k in inp_fields if inp.get(k)})
+        return data
+
+
 def format_pedigree(data: dict) -> str:
     """Converts pedigree dict to tuple."""
     try:

--- a/activity_browser/app/bwutils/exporters.py
+++ b/activity_browser/app/bwutils/exporters.py
@@ -3,7 +3,6 @@ import numbers
 from pathlib import Path
 from typing import Union
 
-import brightway2 as bw
 from bw2data.utils import safe_filename
 from bw2io.export.excel import CSVFormatter, create_valid_worksheet_name
 import xlsxwriter
@@ -71,7 +70,7 @@ def write_lci_excel(db_name: str, path: str, objs=None, sections=None) -> Path:
 
     sheet = workbook.add_worksheet(create_valid_worksheet_name(db_name))
 
-    data = CSVFormatter(db_name, objs).get_formatted_data(sections)
+    data = ABCSVFormatter(db_name, objs).get_formatted_data(sections)
 
     for row_index, row in enumerate(data):
         for col_index, value in enumerate(row):

--- a/activity_browser/app/bwutils/importers.py
+++ b/activity_browser/app/bwutils/importers.py
@@ -114,14 +114,6 @@ class ABExcelImporter(ExcelImporter):
             bw.parameters.recalculate()
         return [db]
 
-    def link_to_technosphere(self, db_name: str, fields: tuple = None) -> None:
-        """Apply the 'link to technosphere' strategy with some flexibility."""
-        fields = fields or LINK_FIELDS
-        self.apply_strategy(functools.partial(
-            link_technosphere_by_activity_hash,
-            external_db_name=db_name, fields=fields
-        ))
-
 
 class ABPackage(bw.BW2Package):
     """ Inherits from brightway2 `BW2Package` and handles importing BW2Packages.

--- a/activity_browser/app/bwutils/importers.py
+++ b/activity_browser/app/bwutils/importers.py
@@ -19,6 +19,7 @@ from bw2io.strategies import (
     convert_activity_parameters_to_list
 )
 
+from .errors import LinkingFailed
 from .strategies import (
     relink_exchanges_bw2package, alter_database_name, hash_parameter_group,
     relink_exchanges_with_db, link_exchanges_without_db,
@@ -87,7 +88,7 @@ class ABExcelImporter(ExcelImporter):
         obj.apply_strategies()
         if any(obj.unlinked) and relink:
             for db, new_db in relink.items():
-                if db == "missing_db":
+                if db == "(name missing)":
                     obj.apply_strategy(functools.partial(
                         link_exchanges_without_db, db=new_db
                     ))
@@ -95,10 +96,16 @@ class ABExcelImporter(ExcelImporter):
                     obj.apply_strategy(functools.partial(
                         relink_exchanges_with_db, old=db, new=new_db
                     ))
+                # Relinking failed (some exchanges still unlinked)
+                if any(obj.unlinked):
+                    # Raise a different exception.
+                    excs = [exc for exc in obj.unlinked][:10]
+                    databases = {exc.get("database", "(name missing)") for exc in obj.unlinked}
+                    raise LinkingFailed(excs, databases)
         if any(obj.unlinked):
             # Still have unlinked fields? Raise exception.
             excs = [exc for exc in obj.unlinked][:10]
-            databases = {exc.get("database", "missing_db") for exc in obj.unlinked}
+            databases = {exc.get("database", "(name missing)") for exc in obj.unlinked}
             raise StrategyError(excs, databases)
         if obj.project_parameters:
             obj.write_project_parameters(delete_existing=False)

--- a/activity_browser/app/ui/wizards/db_export_wizard.py
+++ b/activity_browser/app/ui/wizards/db_export_wizard.py
@@ -16,6 +16,10 @@ EXPORTERS = {
     # related to that database as an Excel file.
     "Excel": write_lci_excel,
 }
+EXTENSIONS = {
+    "BW2Package": ".bw2package",
+    "Excel": ".xlsx",
+}
 
 
 class DatabaseExportWizard(QtWidgets.QWizard):
@@ -40,10 +44,20 @@ class DatabaseExportWizard(QtWidgets.QWizard):
         db_name = self.field("database_choice")
         export_as = self.field("export_option")
         out_path = self.field("output_path")
+        # Ensure that extension matches export_option.
+        path, ext = os.path.splitext(out_path)
+        if ext and not ext == EXTENSIONS[export_as]:
+            ext = EXTENSIONS[export_as]
+            out_path = path + ext
         EXPORTERS[export_as](db_name, out_path)
 
 
 class ExportDatabasePage(QtWidgets.QWizardPage):
+    FILTERS = {
+        "BW2Package": "BW2Package Files (*.bw2package);; All Files (*.*)",
+        "Excel": "Excel Files (*.xlsx);; All Files (*.*)",
+    }
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.wizard = parent
@@ -94,9 +108,9 @@ class ExportDatabasePage(QtWidgets.QWizardPage):
 
     @Slot(name="browseFile")
     def browse(self) -> None:
+        file_filter = self.FILTERS[self.field("export_option")]
         path, _ = QtWidgets.QFileDialog.getSaveFileName(
-            parent=self, caption="Save database",
-            filter="Database Files (*.xlsx *.bw2package);; All Files (*.*)"
+            parent=self, caption="Save database", filter=file_filter
         )
         if path:
             self.output_dir.setText(path)

--- a/activity_browser/app/ui/wizards/db_import_wizard.py
+++ b/activity_browser/app/ui/wizards/db_import_wizard.py
@@ -664,6 +664,8 @@ class MainWorkerThread(QtCore.QThread):
         self.relink = relink or {}
 
     def run(self):
+        # Set the cancel sentinal to false whenever the thread (re-)starts
+        import_signals.cancel_sentinel = False
         if self.use_forwast:
             self.run_forwast()
         elif self.use_local:
@@ -672,7 +674,6 @@ class MainWorkerThread(QtCore.QThread):
             self.run_ecoinvent()
 
     def run_ecoinvent(self):
-        import_signals.cancel_sentinel = False
         with tempfile.TemporaryDirectory() as tempdir:
             dataset_dir = self.datasets_path or os.path.join(tempdir, "datasets")
             if not os.path.isdir(dataset_dir):
@@ -693,7 +694,6 @@ class MainWorkerThread(QtCore.QThread):
         """
         adapted from pjamesjoyce/lcopt
         """
-        import_signals.cancel_sentinel = False
         response = requests.get(self.forwast_url)
         forwast_zip = zipfile.ZipFile(io.BytesIO(response.content))
         import_signals.download_complete.emit()


### PR DESCRIPTION
Sometimes the excel import would not include a database column for the exchanges.

Include a possible fix for the 'database is deleted' after a successful import problem.
-> This was likely caused by the user canceling an import and the AB then not resetting the 'cancel sentinel', thus causing any future imports to act as though they were also cancelled.

Also include a special exception to avoid the excel import looping infinitely, this will be raised after the first time a (re)link action fails.