### PR TITLE
Do parameterization without looking up activity param

### DIFF
--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -575,7 +575,8 @@ class ActivityParameterTable(BaseParameterTable):
             group = self.get_current_group(proxy)
             bw.parameters.remove_from_group(group, act)
             # Also clear the group if there are no more parameters in it
-            if ActivityParameter.get_or_none(group=group) is None:
+            if not (ActivityParameter.select()
+                    .where(ActivityParameter.group == group).exists()):
                 with bw.parameters.db.atomic():
                     Group.get(name=group).delete_instance()
 

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -482,8 +482,9 @@ class ActivityParameterTable(BaseParameterTable):
         signals.blockSignals(False)
         signals.parameters_changed.emit()
 
-    @Slot(tuple)
-    def add_parameter(self, key: tuple) -> None:
+    @staticmethod
+    @Slot(tuple, name="addActivityParameter")
+    def add_parameter(key: tuple) -> None:
         """ Given the activity key, generate a new row with data from
         the activity and immediately call `new_activity_parameters`.
         """
@@ -656,20 +657,22 @@ class ExchangesTable(ABDictTreeView):
     def _select_model(self):
         return ParameterTreeModel(self.data)
 
-    @Slot(tuple)
+    @Slot(tuple, name="parameterizeExchangesForKey")
     def parameterize_exchanges(self, key: tuple) -> None:
         """ Used whenever a formula is set on an exchange in an activity.
 
         If no `ActivityParameter` exists for the key, generate one immediately
         """
-        if ActivityParameter.get_or_none(database=key[0], code=key[1]) is None:
-            signals.add_activity_parameter.emit(key)
+        group = bc.build_activity_group_name(key)
+        if not (ActivityParameter.select()
+                .where(ActivityParameter.group == group).count()):
+            ActivityParameterTable.add_parameter(key)
 
-        param = ActivityParameter.get(database=key[0], code=key[1])
         act = bw.get_activity(key)
-        bw.parameters.remove_exchanges_from_group(param.group, act)
-        bw.parameters.add_exchanges_to_group(param.group, act)
-        ActivityParameter.recalculate_exchanges(param.group)
+        with bw.parameters.db.atomic():
+            bw.parameters.remove_exchanges_from_group(group, act)
+            bw.parameters.add_exchanges_to_group(group, act)
+            ActivityParameter.recalculate_exchanges(group)
         signals.parameters_changed.emit()
 
     @staticmethod

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -61,7 +61,7 @@ def test_create_project_param(qtbot):
     # New parameter is named 'param_1'
     assert table.model.index(0, 0).data() == "param_1"
     assert ProjectParameter.select().count() == 3
-    assert ProjectParameter.get_or_none(name="param_1") is not None
+    assert ProjectParameter.select().where(ProjectParameter.name == "param_1").exists()
 
 
 def test_edit_project_param(qtbot):
@@ -336,7 +336,7 @@ def test_delete_activity_param(qtbot):
     table.delete_parameter(table.currentIndex())
     assert table.rowCount() == 2
     assert ActivityParameter.select().count() == 2
-    assert Group.get_or_none(name=group)
+    assert Group.select().where(Group.name == group).exists()
 
     # And delete the other two parameters one by one.
     table.delete_parameter(table.proxy_model.index(0, 0))
@@ -344,4 +344,4 @@ def test_delete_activity_param(qtbot):
     assert table.rowCount() == 0
     assert ActivityParameter.select().count() == 0
     # Group is automatically removed with the last parameter gone
-    assert Group.get_or_none(name=group) is None
+    assert not Group.select().where(Group.name == group).exists()


### PR DESCRIPTION
Instead of doing a lookup with database and code, use the group value all the way through. Also, use a static function call instead of signalling.

Should fix #441.