### PR TITLE
Improve parameter deleting

### DIFF
--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -636,12 +636,14 @@ class Controller(object):
         """Take the given information and attempt to remove all of the
         downstream parameter information.
         """
-        with bw.parameters.db.atomic():
+        with bw.parameters.db.atomic() as txn:
             bw.parameters.remove_exchanges_from_group(group, None, False)
             ActivityParameter.delete().where(
                 ActivityParameter.database == database,
                 ActivityParameter.code == code
             ).execute()
+            # Do commit to ensure .exists() call does not include deleted params
+            txn.commit()
             exists = (ActivityParameter.select()
                       .where(ActivityParameter.group == group)
                       .exists())

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -79,6 +79,7 @@ class Controller(object):
         signals.parameter_modified.connect(self.modify_parameter)
         signals.parameter_uncertainty_modified.connect(self.modify_parameter_uncertainty)
         signals.parameter_pedigree_modified.connect(self.modify_parameter_pedigree)
+        signals.clear_activity_parameter.connect(self.clear_broken_activity_parameter)
         # Calculation Setups
         signals.new_calculation_setup.connect(self.new_calculation_setup)
         signals.rename_calculation_setup.connect(self.rename_calculation_setup)
@@ -663,6 +664,7 @@ class Controller(object):
     def print_convenience_information(db_name: str) -> None:
         AB_metadata.print_convenience_information(db_name)
 
+# Presamples
     @staticmethod
     @Slot(str, name="removePresamplesPackage")
     def remove_presamples_package(name_id: str) -> None:

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Iterable, Optional
 
 import brightway2 as bw
-from bw2data.parameters import ActivityParameter
+from bw2data.parameters import ActivityParameter, Group
 from PySide2 import QtWidgets
 from PySide2.QtCore import QObject, Slot
 from bw2data.backends.peewee import sqlite3_lci_db
@@ -267,7 +267,8 @@ class Controller(object):
             except ValueError as e:
                 QtWidgets.QMessageBox.information(parent, "Not possible", str(e))
 
-    def delete_database(self, name):
+    @Slot(str, name="deleteDatabase")
+    def delete_database(self, name: str) -> None:
         ok = QtWidgets.QMessageBox.question(
             None,
             "Delete database?",
@@ -277,6 +278,7 @@ class Controller(object):
         if ok == QtWidgets.QMessageBox.Yes:
             project_settings.remove_db(name)
             del bw.databases[name]
+            Group.delete().where(Group.name == name).execute()
             self.change_project(bw.projects.current, reload=True)
 
     @Slot(str, QObject, name="relinkDatabase")

--- a/activity_browser/app/controller.py
+++ b/activity_browser/app/controller.py
@@ -587,6 +587,7 @@ class Controller(object):
         else:
             param.data[field] = value
         param.save()
+        bw.parameters.recalculate()
         signals.parameters_changed.emit()
 
     @staticmethod

--- a/activity_browser/app/signals.py
+++ b/activity_browser/app/signals.py
@@ -71,6 +71,7 @@ class Signals(QObject):
     parameter_pedigree_modified = Signal(object, object)
     parameter_scenario_sync = Signal(int, object)
     parameter_superstructure_built = Signal(int, object)
+    clear_activity_parameter = Signal(str, str, str)
 
     # Presamples
     presample_package_created = Signal(str)

--- a/activity_browser/app/ui/tables/delegates/formula.py
+++ b/activity_browser/app/ui/tables/delegates/formula.py
@@ -247,7 +247,4 @@ class FormulaDelegate(QtWidgets.QStyledItemDelegate):
         if dialog.result() == QtWidgets.QDialog.Rejected:
             # Cancel was clicked, do not store anything.
             return
-        if model.data(index, QtCore.Qt.DisplayRole) == dialog.formula:
-            # The text in the dialog is the same as what is already there.
-            return
         model.setData(index, dialog.formula, QtCore.Qt.EditRole)

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -685,18 +685,3 @@ class ExchangesTable(ABDictTreeView):
             bw.parameters.add_exchanges_to_group(group, act)
             ActivityParameter.recalculate_exchanges(group)
         signals.parameters_changed.emit()
-
-    @staticmethod
-    @Slot()
-    def recalculate_exchanges():
-        """ Will iterate through all activity parameters and rerun the
-        formula interpretation for all exchanges.
-        """
-        for param in ActivityParameter.select().iterator():
-            try:
-                act = bw.get_activity((param.database, param.code))
-                bw.parameters.add_exchanges_to_group(param.group, act)
-                ActivityParameter.recalculate_exchanges(param.group)
-            except:
-                continue
-        signals.parameters_changed.emit()

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -581,10 +581,11 @@ class ActivityParameterTable(BaseParameterTable):
             group = self.get_current_group(proxy)
             bw.parameters.remove_from_group(group, act)
             # Also clear the group if there are no more parameters in it
-            if not (ActivityParameter.select()
-                    .where(ActivityParameter.group == group).exists()):
+            exists = (ActivityParameter.select()
+                      .where(ActivityParameter.group == group).exists())
+            if not exists:
                 with bw.parameters.db.atomic():
-                    Group.get(name=group).delete_instance()
+                    Group.delete().where(Group.name == group).execute()
 
         bw.parameters.recalculate()
         signals.parameters_changed.emit()

--- a/activity_browser/app/ui/tables/parameters.py
+++ b/activity_browser/app/ui/tables/parameters.py
@@ -438,7 +438,10 @@ class ActivityParameterTable(BaseParameterTable):
             act = bw.get_activity(row["key"])
         except:
             # Can occur if an activity parameter exists for a removed activity.
-            print("Activity {} no longer exists, ignoring parameter.".format(row["key"]))
+            print("Activity {} no longer exists, removing parameter.".format(row["key"]))
+            signals.clear_activity_parameter.emit(
+                parameter.database, parameter.code, parameter.group
+            )
             return {}
         row["product"] = act.get("reference product") or act.get("name")
         row["activity"] = act.get("name")


### PR DESCRIPTION
Should improve and hopefully fix #465.

Explicitly try to delete the activity parameter when deleting an activity.
Include deletion of `Group` objects when deleting databases and activities.


