### PR TITLE
Impact category tree view added.

### DIFF
--- a/activity_browser/app/ui/tables/LCA_setup.py
+++ b/activity_browser/app/ui/tables/LCA_setup.py
@@ -8,7 +8,7 @@ from PySide2 import QtWidgets
 from activity_browser.app.bwutils.commontasks import AB_names_to_bw_keys
 
 from .delegates import FloatDelegate, ViewOnlyDelegate
-from .impact_categories import MethodsTable
+from .impact_categories import MethodsTable, MethodsTree
 from .views import ABDataFrameEdit, ABDataFrameView, dataframe_sync
 from ..icons import qicons
 from ...signals import signals
@@ -210,7 +210,7 @@ class CSMethodsTable(ABDataFrameView):
         menu.exec_(a0.globalPos())
 
     def dragEnterEvent(self, event):
-        if isinstance(event.source(), MethodsTable):
+        if isinstance(event.source(), MethodsTable) or isinstance(event.source(), MethodsTree):
             event.accept()
 
     def dragMoveEvent(self, event) -> None:

--- a/activity_browser/app/ui/tables/__init__.py
+++ b/activity_browser/app/ui/tables/__init__.py
@@ -2,7 +2,7 @@
 from .activity import (BiosphereExchangeTable, DownstreamExchangeTable,
                        ProductExchangeTable, TechnosphereExchangeTable)
 from .history import ActivitiesHistoryTable
-from .impact_categories import CFTable, MethodsTable
+from .impact_categories import CFTable, MethodsTable, MethodsTree
 from .inventory import ActivitiesBiosphereTable, DatabasesTable
 from .lca_results import ContributionTable, InventoryTable, LCAResultsTable
 from .LCA_setup import CSActivityTable, CSList, CSMethodsTable, ScenarioImportTable

--- a/activity_browser/app/ui/tables/impact_categories.py
+++ b/activity_browser/app/ui/tables/impact_categories.py
@@ -11,7 +11,8 @@ from ...signals import signals
 from ..icons import qicons
 from ..widgets import TupleNameDialog
 from ..wizards import UncertaintyWizard
-from .views import ABDataFrameView, dataframe_sync
+from .views import ABDataFrameView, ABDictTreeView, dataframe_sync, tree_model_decorate
+from .models import MethodsTreeModel
 from .delegates import FloatDelegate, UncertaintyDelegate
 
 
@@ -81,6 +82,219 @@ class MethodsTable(ABDataFrameView):
     def copy_method(self) -> None:
         """Call copy on the (first) selected method and present rename dialog."""
         method = bw.Method(self.get_method(next(p for p in self.selectedIndexes())))
+        dialog = TupleNameDialog.get_combined_name(
+            self, "Impact category name", "Combined name:", method.name, "Copy"
+        )
+        if dialog.exec_() == TupleNameDialog.Accepted:
+            new_name = dialog.result_tuple
+            if new_name in bw.methods:
+                warn = "Impact Category with name '{}' already exists!".format(new_name)
+                QtWidgets.QMessageBox.warning(self, "Copy failed", warn)
+                return
+            method.copy(new_name)
+            print("Copied method {} into {}".format(str(method.name), str(new_name)))
+            self.new_method.emit(new_name)
+
+
+class MethodsTree(ABDictTreeView):
+    HEADERS = ["Name", "Unit", "# CFs", "method"]
+    new_method = Signal(tuple)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # set drag ability
+        self.drag_model = True
+        self.setDragEnabled(True)
+        self.setDragDropMode(ABDictTreeView.DragOnly)
+        # set data
+        self.sync()
+        self.setColumnHidden(self.method_col, True)
+
+    def _connect_signals(self):
+        super()._connect_signals()
+        signals.project_selected.connect(self.sync)
+        self.doubleClicked.connect(self.method_double_clicked)
+
+    def _select_model(self):
+        return MethodsTreeModel(self.data)
+
+    @tree_model_decorate
+    def sync(self, query=None) -> None:
+        sorted_names = sorted([(", ".join(method), method) for method in bw.methods])
+        if query:
+            sorted_names = filter(
+                lambda obj: query.lower() in obj[0].lower(), sorted_names
+            )
+        self.dataframe = DataFrame([
+            self.build_row(method_obj) for method_obj in sorted_names
+        ], columns=self.HEADERS)
+        self.method_col = self.dataframe.columns.get_loc("method")
+
+        self.nest_data()
+
+    def build_row(self, method_obj) -> dict:
+        method = bw.methods[method_obj[1]]
+        return {
+            "Name": method_obj[0],
+            "Unit": method.get("unit", "Unknown"),
+            "# CFs": str(method.get("num_cfs", 0)),
+            "method": method_obj[1],
+        }
+
+    def nest_data(self):
+        """Convert impact category dataframe into nested dict format.
+
+        Format is:
+        {root1: {branch1: {leaf1: data},
+                          {leaf2: data}},
+                {branch2: {branch3: {leaf3: data},
+                                    {leaf4: data}},
+                          {branch4: {leaf5: data},
+                                    {leaf6: data}},
+                          {leaf7: data}}}
+        Where:
+        rootx  : top level category (str) eg: CML 2001
+        branchx: sub level category (str) eg: climate change
+                 can be arbitrary amount of branches
+        leafx  : category level (str)     eg: GWP 100a
+                 leaves and branches can be mixed together under roots or other branches
+        data   : data of category (tuple) eg: ('CML 2001, climate change, GWP 100a',
+                                               'kg CO2-Eq',
+                                               160,
+                                               "('CML 2001', 'climate change', 'GWP 100a')")
+                 here each index of the tuple refers to the data in the HEADERS list of this class
+        """
+        updated_df = self.prep_df(self.dataframe)
+        dirty_nested_df = self.retro_dictify(updated_df)
+        self.data, _ = self.names_dict_clean(dirty_nested_df)
+
+    def get_method(self, tree_level=None) -> tuple:
+        if not tree_level:
+            tree_level = self.tree_level()
+        return self.dataframe[self.dataframe['Name'] == tree_level[1]]['method']
+
+    @Slot(QModelIndex, name="methodSelection")
+    def method_double_clicked(self):
+        tree_level = self.tree_level()
+        if tree_level[0] == 'leaf':
+            print("+ there should be a 'duplicate' function here")
+            method = self.get_method(tree_level).to_list()[0]
+            signals.method_selected.emit(method)
+
+    def contextMenuEvent(self, event) -> None:
+        """Right clicked menu, action depends on item level."""
+        if self.tree_level()[0] == 'leaf':
+            menu = QtWidgets.QMenu(self)
+            menu.addAction(qicons.copy, "Duplicate Impact Category", self.copy_method)
+            menu.exec_(event.globalPos())
+
+    def selected_methods(self) -> Iterable:
+        """Returns a generator which yields the 'method' for each row."""
+
+        tree_level = self.tree_level()
+        if tree_level[0] == 'leaf':
+            # filter on the leaf
+            method = self.get_method(tree_level)
+            return (m for m in method)
+        elif tree_level[0] == 'root':
+            # filter on the root + ', '
+            # (this needs to be added in case one root level starts with a shorter name of another one
+            # example: 'ecological scarcity 2013' and 'ecological scarcity 2013 no LT'
+            filter_on = tree_level[1] + ', '
+        else:
+            # filter on the branch and its parents/roots
+            filter_on = ', '.join(tree_level[1])
+
+        methods = self.dataframe[self.dataframe['Name'].str.startswith(filter_on)]['method']
+        return (m for m in methods)
+
+    def tree_level(self):
+        """Return list of [tree level, content].
+
+        Where content depends on level:
+        leaf:   the name of impact category, str()
+        root:   the name of the root, str()
+        branch: the descending list of branch levels, list()
+            branch example: ['CML 2001', 'climate change']"""
+        if self.selectedIndexes()[1].data() != '' or self.selectedIndexes()[2].data() != '':
+            return ['leaf', self.selectedIndexes()[0].data()]
+        elif self.selectedIndexes()[0].parent().data() is None:
+            return ['root', self.selectedIndexes()[0].data()]
+        else:
+            return ['branch', self.find_levels()]
+
+    def find_levels(self, level=None):
+        """Find all levels of branch."""
+        if not level:
+            level = self.selectedIndexes()[0]
+        par = level.parent()  # par for parent
+        levels = [level.data()]
+        if par.data() != None:
+            while par.data() != None:
+                levels.append(par.data())
+                par = par.parent()
+        else:
+            levels.append(par.data())
+        return levels[::-1]
+
+    def prep_df(self, df):
+        """Prepare data to be nested."""
+        splits = []
+        for row in df.iterrows():
+            data = tuple(row[1])
+            names = data[0]  # 'Name' column
+
+            split = names.split(', ')
+            split.append(data)
+            splits.append(split)
+        return DataFrame(splits)
+
+    def retro_dictify(self, frame):
+        """Create nested dict from dataframe."""
+        # From https://stackoverflow.com/a/19900276 but changed -2 to -1
+        # this version is ~2 orders of magnitude faster than the pandas option in the same answer
+        d = {}
+        for row in frame.values:
+            here = d
+            for elem in row[:-1]:
+                if elem not in here:
+                    here[elem] = {}
+                here = here[elem]
+            here[row[-1]] = row[-1]
+        return d
+
+    def names_dict_clean(self, names_dict):
+        """Clean output from retro_dictify.
+
+        Removes 'None' nodes and combines irrelevant nodes (with only 1 sublevel)
+        """
+        clean_dict = {}
+        for key, *value in names_dict.items():
+
+            if type(value[0]) == dict and None not in value[0].keys():
+                # this is not the leaf node, go deeper to find leaf
+
+                tree, is_leaf = self.names_dict_clean(value[0])
+                if not is_leaf and len(value[0]) == 1:
+                    # 'tree' is not leaf (end node) and only one sub level
+                    # combine sublevel, then add to tree
+
+                    key_orig = [k for k in tree.keys()][0]
+                    key = key + ', ' + key_orig
+                    clean_dict[key] = tree[key_orig]
+                else:
+                    # 'tree' is either a leaf or has more sublevels
+                    # add as dict entry
+                    clean_dict[key] = tree
+            else:
+                # this is a leaf node, return the key
+                return key, True
+        return clean_dict, False
+
+    @Slot(name="copyMethod")
+    def copy_method(self) -> None:
+        """Call copy on the (first) selected method and present rename dialog."""
+        method = bw.Method(self.get_method())
         dialog = TupleNameDialog.get_combined_name(
             self, "Impact category name", "Combined name:", method.name, "Copy"
         )

--- a/activity_browser/app/ui/tabs/impact_categories.py
+++ b/activity_browser/app/ui/tabs/impact_categories.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple
-
 from PySide2 import QtCore, QtWidgets
 
 from ..style import header, horizontal_line

--- a/activity_browser/app/ui/tabs/impact_categories.py
+++ b/activity_browser/app/ui/tabs/impact_categories.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+
+from collections import namedtuple
+
 from PySide2 import QtCore, QtWidgets
 
 from ..style import header, horizontal_line
-from ..tables import CFTable, MethodsTable
+from ..tables import CFTable, MethodsTable, MethodsTree
 from ..panels import ABTab
 from ...signals import signals
 
@@ -45,31 +48,70 @@ class MethodsTab(QtWidgets.QWidget):
         super(MethodsTab, self).__init__(parent)
 
         self.table = MethodsTable(self)
+        self.table.setToolTip(
+            "Drag (groups of) impact categories to the calculation setup")
+        self.tree = MethodsTree(self)
+        self.tree.setToolTip(
+            "Drag (groups of) impact categories to the calculation setup")
+        #
         self.search_box = QtWidgets.QLineEdit()
         self.search_box.setPlaceholderText("Filter impact categories")
-        reset_search_button = QtWidgets.QPushButton("Reset")
+        self.reset_search_button = QtWidgets.QPushButton("Reset")
+        #
+        self.mode_radio_list = QtWidgets.QRadioButton("List view")
+        self.mode_radio_list.setChecked(True)
+        self.mode_radio_list.setToolTip(
+            "List view of impact categories")
+        #
+        self.mode_radio_tree = QtWidgets.QRadioButton("Tree view")
+        self.mode_radio_tree.setToolTip(
+            "Tree view of impact categories\n"
+            "v CML 2001\n"
+            "    v climate change\n"
+            "        CML 2001, climate change, GWP 100a\n"
+            "        ...\n"
+            "You can drag entire 'branches' of impact categories at once")
         #
         search_layout = QtWidgets.QHBoxLayout()
-        search_layout.setAlignment(QtCore.Qt.AlignTop)
-        search_layout.addWidget(header('Impact Categories'))
         search_layout.addWidget(self.search_box)
-        search_layout.addWidget(reset_search_button)
+        search_layout.addWidget(self.reset_search_button)
+        #
+        mode_layout = QtWidgets.QHBoxLayout()
+        mode_layout.setAlignment(QtCore.Qt.AlignTop)
+        mode_layout.addWidget(header('Impact Categories'))
+        search_layout.addWidget(self.mode_radio_list)
+        search_layout.addWidget(self.mode_radio_tree)
+        #
+        mode_layout_container = QtWidgets.QWidget()
+        mode_layout_container.setLayout(mode_layout)
         #
         search_layout_container = QtWidgets.QWidget()
         search_layout_container.setLayout(search_layout)
         #
         container = QtWidgets.QVBoxLayout()
         container.setAlignment(QtCore.Qt.AlignTop)
+        container.addWidget(mode_layout_container)
         container.addWidget(search_layout_container)
         # container.addWidget(horizontal_line())
         container.addWidget(self.table)
+        container.addWidget(self.tree)
+        self.tree.setVisible(False)
         self.setLayout(container)
 
-        reset_search_button.clicked.connect(self.table.sync)
-        reset_search_button.clicked.connect(self.search_box.clear)
+        self.reset_search_button.clicked.connect(self.table.sync)
+        self.reset_search_button.clicked.connect(self.tree.sync)
+
+        self.reset_search_button.clicked.connect(self.search_box.clear)
         self.search_box.returnPressed.connect(lambda: self.table.sync(query=self.search_box.text()))
+        self.search_box.returnPressed.connect(lambda: self.tree.sync(query=self.search_box.text()))
+
         signals.project_selected.connect(self.search_box.clear)
         self.table.new_method.connect(self.method_copied)
+
+        self.connect_signals()
+
+    def connect_signals(self):
+        self.mode_radio_list.toggled.connect(self.button_clicked)
 
     @QtCore.Slot(tuple, name="searchCopiedMethod")
     def method_copied(self, method: tuple) -> None:
@@ -77,6 +119,25 @@ class MethodsTab(QtWidgets.QWidget):
         query = ", ".join(method)
         self.search_box.setText(query)
         self.table.sync(query)
+
+    @QtCore.Slot(bool, name="isListToggled")
+    def button_clicked(self, toggled: bool):
+        """Update view according to radiobutton selected."""
+        if not toggled:
+            self.update_view(view='tree')
+        else:
+            self.update_view(view='list')
+
+    def update_view(self, view='list'):
+        """Update the view."""
+        if view == 'list':
+            self.tree.setVisible(False)
+            #
+            self.table.setVisible(True)
+        else:
+            self.table.setVisible(False)
+            #
+            self.tree.setVisible(True)
 
 
 class CharacterizationFactorsTab(ABTab):


### PR DESCRIPTION
Includes:
- radio buttons to switch between list and tree views
- search functionality on both list and tree views
- drag to add impact category or groups of impact categories to calculation setup
- right click on impact category for duplicate menu (same as list view)
- double click on impact category to open impact category (same as list view)
- various relevant tooltips