### PR TITLE
Order the LCA Results table columns

### DIFF
--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -569,13 +569,11 @@ class Contributions(object):
         joined = joined.loc[:, col_order.append(methods)]
         return joined.reset_index(drop=False)
 
-    def lca_scores_df(self, normalized=False):
+    def lca_scores_df(self, normalized=False) -> pd.DataFrame:
         """Returns a metadata-annotated DataFrame of the LCA scores.
         """
         scores = self.mlca.lca_scores if not normalized else self.mlca.lca_scores_normalized
-        return self._build_lca_scores_df(
-            scores, self.mlca.fu_activity_keys, self.mlca.methods, self.act_fields
-        )
+        return self._build_lca_scores_df(scores)
 
     @staticmethod
     def _build_contributions(data: np.ndarray, index: int, axis: int) -> np.ndarray:

--- a/activity_browser/app/bwutils/multilca.py
+++ b/activity_browser/app/bwutils/multilca.py
@@ -549,13 +549,24 @@ class Contributions(object):
             )
         return self._build_inventory(*data)
 
-    @staticmethod
-    def _build_lca_scores_df(scores: np.ndarray, indices: list,
-                             columns: list, fields: list) -> pd.DataFrame:
+    def _build_lca_scores_df(self, scores: np.ndarray) -> pd.DataFrame:
         df = pd.DataFrame(
-            scores, index=pd.MultiIndex.from_tuples(indices), columns=columns
+            scores,
+            index=pd.MultiIndex.from_tuples(self.mlca.fu_activity_keys),
+            columns=self.mlca.methods
         )
-        joined = Contributions.join_df_with_metadata(df, x_fields=fields, y_fields=None)
+        # Add amounts column.
+        df["amount"] = [next(iter(fu.values()), 1.0) for fu in self.mlca.func_units]
+        joined = Contributions.join_df_with_metadata(
+            df, x_fields=self.act_fields, y_fields=None
+        )
+        # Precisely order the columns that are shown in the LCA Results overview
+        # tab: “X kg of product Y from activity Z in location L, and database D”
+        col_order = pd.Index([
+            "amount", "unit", "reference product", "name", "location", "database",
+        ])
+        methods = joined.columns.difference(col_order, sort=False)
+        joined = joined.loc[:, col_order.append(methods)]
         return joined.reset_index(drop=False)
 
     def lca_scores_df(self, normalized=False):

--- a/activity_browser/app/bwutils/presamples/presamples_mlca.py
+++ b/activity_browser/app/bwutils/presamples/presamples_mlca.py
@@ -191,9 +191,7 @@ class PresamplesContributions(Contributions):
         """
         scores = self.mlca.lca_scores_normalized if normalized else self.mlca.lca_scores
         scores = scores[:, :, self.mlca.current]
-        return super()._build_lca_scores_df(
-            scores, self.mlca.fu_activity_keys, self.mlca.methods, self.act_fields
-        )
+        return self._build_lca_scores_df(scores)
 
     def _build_contributions(self, data: np.ndarray, index: int, axis: int) -> np.ndarray:
         data = data[:, :, self.mlca.current]

--- a/activity_browser/app/bwutils/superstructure/mlca.py
+++ b/activity_browser/app/bwutils/superstructure/mlca.py
@@ -225,9 +225,7 @@ class SuperstructureContributions(Contributions):
         """
         scores = self.mlca.lca_scores_normalized if normalized else self.mlca.lca_scores
         scores = scores[:, :, self.mlca.current]
-        return super()._build_lca_scores_df(
-            scores, self.mlca.fu_activity_keys, self.mlca.methods, self.act_fields
-        )
+        return self._build_lca_scores_df(scores)
 
     def _build_contributions(self, data: np.ndarray, index: int, axis: int) -> np.ndarray:
         data = data[:, :, self.mlca.current]

--- a/activity_browser/app/ui/figures.py
+++ b/activity_browser/app/ui/figures.py
@@ -126,6 +126,8 @@ class LCAResultsPlot(Plot):
         dfp = df.copy()
         dfp.index = dfp['index']
         dfp.drop(dfp.select_dtypes(['object']), axis=1, inplace=True)  # get rid of all non-numeric columns (metadata)
+        if "amount" in dfp.columns:
+            dfp.drop(["amount"], axis=1, inplace=True)  # Drop the 'amount' col
         if 'Total' in dfp.index:
             dfp.drop("Total", inplace=True)
 

--- a/activity_browser/app/ui/tabs/LCA_results_tabs.py
+++ b/activity_browser/app/ui/tabs/LCA_results_tabs.py
@@ -674,6 +674,10 @@ class LCIAResultsTab(NewAnalysisTab):
             layout.addSpacerItem(stretch)
         return layout
 
+    def update_tab(self):
+        self.df = self.parent.contributions.lca_scores_df(normalized=self.relative)
+        super().update_tab()
+
     def update_plot(self):
         """Update the plot."""
         idx = self.pt_layout.indexOf(self.plot)
@@ -681,7 +685,6 @@ class LCIAResultsTab(NewAnalysisTab):
         self.plot.deleteLater()
         self.plot = LCAResultsPlot(self.parent)
         self.pt_layout.insertWidget(idx, self.plot)
-        self.df = self.parent.contributions.lca_scores_df(normalized=self.relative)
         self.plot.plot(self.df)
         if self.pt_layout.parentWidget():
             self.pt_layout.parentWidget().updateGeometry()
@@ -690,7 +693,6 @@ class LCIAResultsTab(NewAnalysisTab):
         """Update the table."""
         if not isinstance(self.table, LCAResultsTable):
             self.table = LCAResultsTable()
-        self.df = self.parent.contributions.lca_scores_df(normalized=self.relative)
         self.table.sync(self.df)
 
 


### PR DESCRIPTION
This specific order makes it easier to read the table as:

"index … 1 kg of product X from activity Y in location Z, and database D … impact category results a, b, c, … "