### PR TITLE
Allow for parameter scenarios without including default values

### DIFF
--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -364,6 +364,8 @@ class ScenarioImportPanel(BaseRightTab):
             # validation exception.
             return pd.DataFrame()
         data = [df for df in (t.dataframe for t in self.tables) if not df.empty]
+        if not data:
+            return pd.DataFrame()
         manager = SuperstructureManager(*data)
         if self.product_choice.isChecked():
             kind = "product"

--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -473,7 +473,17 @@ class ScenarioImportWidget(QtWidgets.QWidget):
                 # Try and read as parameter scenario file.
                 print("Superstructure: {}\nAttempting to read as parameter scenario file.".format(e))
                 df = pd.read_excel(path, sheet_name=idx, engine="openpyxl")
-                signals.parameter_scenario_sync.emit(self.index, df)
+                include_default = True
+                if "default" not in df.columns:
+                    query = QtWidgets.QMessageBox.question(
+                        self, "Default column not found",
+                        "Attempt to load and include the 'default' scenario column?",
+                        QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                        QtWidgets.QMessageBox.No
+                    )
+                    if query == QtWidgets.QMessageBox.No:
+                        include_default = False
+                signals.parameter_scenario_sync.emit(self.index, df, include_default)
             finally:
                 self.scenario_name.setText(path.name)
                 self.scenario_name.setToolTip(path.name)

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -277,17 +277,31 @@ class ParameterScenariosTab(BaseRightTab):
         super().__init__(parent)
 
         self.load_btn = QPushButton(qicons.add, "Import parameter-scenarios")
+        self.load_btn.setToolTip(
+            "Load prepared excel files with additional parameter scenarios."
+        )
         self.save_btn = QPushButton(
             self.style().standardIcon(QStyle.SP_DialogSaveButton),
             "Export parameter-scenarios"
         )
+        self.save_btn.setToolTip(
+            "Export the current parameter scenario table to excel."
+        )
         self.calculate_btn = QPushButton(
             qicons.calculate, "Export as flow-scenarios"
         )
+        self.calculate_btn.setToolTip(
+            ("Process the current parameter scenario table into prepared flow"
+             " scenario data.")
+        )
         self.reset_btn = QPushButton(qicons.history, "Reset table")
+        self.reset_btn.setToolTip("Reset the scenario table, wiping any changes.")
         self.hide_group = QCheckBox("Show group column")
 
         self.tbl = ScenarioTable(self)
+        self.tbl.setToolTip(
+            "This table is not editable, use the export/import functionality"
+        )
 
         self._construct_layout()
         self._connect_signals()

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -340,14 +340,19 @@ class ParameterScenariosTab(BaseRightTab):
         layout.addStretch(1)
         self.setLayout(layout)
 
-    @Slot(int, object, name="processParameterScenarios")
-    def process_scenarios(self, table_idx: int, df: pd.DataFrame):
+    @Slot(int, object, bool, name="processParameterScenarios")
+    def process_scenarios(self, table_idx: int, df: pd.DataFrame, default: bool) -> None:
         """Use this method to discretely process a parameter scenario file
         for the LCA setup.
         """
-        self.tbl.model.sync(df=df)
-        scenarios = self.build_flow_scenarios()
-        signals.parameter_superstructure_built.emit(table_idx, scenarios)
+        try:
+            self.tbl.model.sync(df=df, include_default=default)
+            scenarios = self.build_flow_scenarios()
+            signals.parameter_superstructure_built.emit(table_idx, scenarios)
+        except AssertionError as e:
+            QMessageBox.critical(
+                self, "Cannot load parameters", str(e), QMessageBox.Ok, QMessageBox.Ok
+            )
 
     @Slot(name="loadSenarioTable")
     def select_read_file(self):

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -284,6 +284,7 @@ class ParameterScenariosTab(BaseRightTab):
         self.calculate_btn = QPushButton(
             qicons.calculate, "Export as flow-scenarios"
         )
+        self.reset_btn = QPushButton(qicons.history, "Reset table")
         self.hide_group = QCheckBox("Show group column")
 
         self.tbl = ScenarioTable(self)
@@ -314,6 +315,7 @@ class ParameterScenariosTab(BaseRightTab):
         self.load_btn.clicked.connect(self.select_read_file)
         self.save_btn.clicked.connect(self.save_scenarios)
         self.calculate_btn.clicked.connect(self.calculate_scenarios)
+        self.reset_btn.clicked.connect(self.tbl.model.sync)
         self.hide_group.toggled.connect(self.tbl.group_column)
         signals.parameter_scenario_sync.connect(self.process_scenarios)
 
@@ -330,6 +332,7 @@ class ParameterScenariosTab(BaseRightTab):
         layout.addWidget(horizontal_line())
 
         row = QHBoxLayout()
+        row.addWidget(self.reset_btn)
         row.addWidget(self.save_btn)
         row.addWidget(self.load_btn)
         row.addWidget(self.calculate_btn)

--- a/activity_browser/signals.py
+++ b/activity_browser/signals.py
@@ -81,7 +81,7 @@ class Signals(QObject):
     parameter_uncertainty_modified = Signal(object, object)
     parameter_pedigree_modified = Signal(object, object)
     delete_parameter = Signal(object)
-    parameter_scenario_sync = Signal(int, object)
+    parameter_scenario_sync = Signal(int, object, bool)
     parameter_superstructure_built = Signal(int, object)
     clear_activity_parameter = Signal(str, str, str)
 


### PR DESCRIPTION
As requested by @angelajanenagle.

This will allow users to import parameter scenarios into a scenario-based LCA without having the 'default' column (and values) included by default.

Included in this PR are:

* A catch for the user trying to run Scenario-based LCA without having data loaded.
* A catch for the user trying to use parameter scenarios in a project without parameters.
* A yes/no question when loading parameter scenarios without a 'default' column in the excel file.
