### PR TITLE
Tiny parameter changes

### DIFF
--- a/activity_browser/controllers/parameter.py
+++ b/activity_browser/controllers/parameter.py
@@ -187,8 +187,9 @@ class ParameterController(QObject):
         by sub-classing the QInputDialog class it becomes possible to allow
         users to decide if they want to update downstream parameters.
         """
+        text = "Rename parameter '{}' to:".format(param.name)
         new_name, ok = QInputDialog.getText(
-            self.window, "Rename parameter", "New parameter name:",
+            self.window, "Rename parameter", text,
         )
         if not ok or not new_name:
             return

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -132,7 +132,7 @@ can be used within the formula!</p>
             lambda: signals.add_parameter.emit(None)
         )
         self.new_database_param.clicked.connect(
-            lambda: signals.add_parameter.emit(None)
+            lambda: signals.add_parameter.emit(("db", ""))
         )
         self.show_order.stateChanged.connect(self.activity_order_column)
         self.uncertainty_columns.stateChanged.connect(

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -183,12 +183,10 @@ can be used within the formula!</p>
         layout.addStretch(1)
         self.setLayout(layout)
 
+    @Slot(name="rebuildParameterTables")
     def build_tables(self):
         """ Read parameters from brightway and build dataframe tables
         """
-        self.project_table.model.sync()
-        self.database_table.model.sync()
-        self.activity_table.model.sync()
         self.hide_uncertainty_columns()
         self.activity_order_column()
         # Cannot create database parameters without databases

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -82,6 +82,8 @@ class ParameterDefinitionTab(BaseRightTab):
             "project": self.project_table, "database": self.database_table,
             "activity": self.activity_table,
         }
+        for t in self.tables.values():
+            t.model.sync()
 
         self.new_project_param = QPushButton(qicons.add, "New")
         self.database_header = header("Database:")

--- a/activity_browser/ui/tables/models/parameters.py
+++ b/activity_browser/ui/tables/models/parameters.py
@@ -25,6 +25,9 @@ class BaseParameterModel(EditablePandasModel):
         super().__init__(parent=parent)
         self.param_col = 0
         self.dataChanged.connect(self.edit_single_parameter)
+        signals.project_selected.connect(self.sync)
+        signals.parameters_changed.connect(self.sync)
+        signals.added_parameter.connect(self.sync)
 
     def get_parameter(self, proxy: QModelIndex) -> object:
         idx = self.proxy_to_source(proxy)

--- a/activity_browser/ui/wizards/parameter_wizard.py
+++ b/activity_browser/ui/wizards/parameter_wizard.py
@@ -72,6 +72,10 @@ class SelectParameterTypePage(QtWidgets.QWizardPage):
         # If we have a complete key, pre-select the activity parameter btn.
         if all(self.key):
             self.button_group.button(2).setChecked(True)
+        elif self.key[0] != "":
+            # default to database parameter is we have something.
+            self.button_group.button(2).setEnabled(False)
+            self.button_group.button(1).setChecked(True)
         else:
             # If we don't have a complete key, we can't create an activity parameter
             self.button_group.button(2).setEnabled(False)
@@ -138,7 +142,7 @@ class CompleteParameterPage(QtWidgets.QWizardPage):
             self.database.clear()
             dbs = bw.databases.list
             self.database.insertItems(0, dbs)
-            if self.key[0] != "":
+            if self.key[0] in dbs:
                 self.database.setCurrentIndex(
                     dbs.index(self.key[0])
                 )


### PR DESCRIPTION
Ensure parameter tables update independently, after parameters are created.

Default to 'database' parameter option when clicking 'add database parameter'.

Include old parameter name in dialog text when renaming a parameter.