### PR TITLE
Add more checks to switch from GPU to CPU for Qt chromium

### DIFF
--- a/activity_browser/__init__.py
+++ b/activity_browser/__init__.py
@@ -3,9 +3,7 @@ import os
 import sys
 import traceback
 
-from PySide2.QtCore import (
-    QOperatingSystemVersion, QSysInfo, __version__ as qt_version
-)
+from PySide2.QtCore import QSysInfo, __version__ as qt_version
 from PySide2.QtWidgets import QApplication
 
 from .application import Application
@@ -17,8 +15,7 @@ from .info import __version__
 # https://github.com/mapeditor/tiled/issues/2845
 # https://doc.qt.io/qt-5/qoperatingsystemversion.html#MacOSBigSur-var
 if QSysInfo.productType() == "osx" and (
-    QOperatingSystemVersion.majorVersion() == 10 and QOperatingSystemVersion.minorVersion() == 16 or
-    QOperatingSystemVersion.majorVersion() == 11 and QOperatingSystemVersion.minorVersion() == 0
+    QSysInfo.productVersion() == "10.16" or QSysInfo.productVersion() == "11.0"
 ):
     os.environ["QT_MAC_WANTS_LAYER"] = "1"
     os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-gpu"

--- a/activity_browser/__init__.py
+++ b/activity_browser/__init__.py
@@ -3,14 +3,26 @@ import os
 import sys
 import traceback
 
-from PySide2.QtCore import __version__ as qt_version
+from PySide2.QtCore import (
+    QOperatingSystemVersion, QSysInfo, __version__ as qt_version
+)
 from PySide2.QtWidgets import QApplication
 
 from .application import Application
 from .info import __version__
 
+
 # https://bugreports.qt.io/browse/QTBUG-87014
-os.environ['QT_MAC_WANTS_LAYER'] = '1'
+# https://bugreports.qt.io/browse/QTBUG-85546
+# https://github.com/mapeditor/tiled/issues/2845
+# https://doc.qt.io/qt-5/qoperatingsystemversion.html#MacOSBigSur-var
+if QSysInfo.productType() == "osx" and (
+    QOperatingSystemVersion.majorVersion() == 10 and QOperatingSystemVersion.minorVersion() == 16 or
+    QOperatingSystemVersion.majorVersion() == 11 and QOperatingSystemVersion.minorVersion() == 0
+):
+    os.environ["QT_MAC_WANTS_LAYER"] = "1"
+    os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-gpu"
+    print("Warning! The currently used version of Qt cannot properly handle BigSur yet.")
 
 
 def run_activity_browser():


### PR DESCRIPTION
Until the switch from PySide2 (Qt 5.12 - 5.15) to PySide6 (Qt 6) (which basically depends on anaconda or conda-forge creating a package).

This fix basically 'degrades' Activity Browser performance by using the CPU to render all Chromium-based views (basically the start-screen view and all graphs). This should hopefully resolve a bunch of the MacOS issues.