### PR TITLE
Include flow type superstructure

### DIFF
--- a/activity_browser/bwutils/superstructure/activities.py
+++ b/activity_browser/bwutils/superstructure/activities.py
@@ -73,7 +73,7 @@ def data_from_index(index: tuple) -> dict:
         "to categories": to_data[3],
         "to database": to_data[4],
         "to key": to_key,
-        "flow type": getattr(index, "flow_type", np.NaN),
+        "flow type": index[2] if len(index) > 2 else np.NaN,
     }
 
 

--- a/activity_browser/bwutils/superstructure/dataframe.py
+++ b/activity_browser/bwutils/superstructure/dataframe.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import List
+from typing import List, Tuple
 
 import brightway2 as bw
 import numpy as np
@@ -34,7 +34,7 @@ def superstructure_from_arrays(samples: np.ndarray, indices: np.ndarray, names: 
     return df
 
 
-def arrays_from_superstructure(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
+def arrays_from_superstructure(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
     """Construct a presamples package from a superstructure DataFrame.
 
     Shortcut over the previous method, avoiding database calls improves
@@ -49,7 +49,7 @@ def arrays_from_superstructure(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
     return result, values.to_numpy()
 
 
-def arrays_from_indexed_superstructure(df: pd.DataFrame) -> (np.ndarray, np.ndarray):
+def arrays_from_indexed_superstructure(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
     def guess(row: tuple) -> str:
         if row[0][0] == bw.config.biosphere:
             return "biosphere"

--- a/activity_browser/bwutils/superstructure/dataframe.py
+++ b/activity_browser/bwutils/superstructure/dataframe.py
@@ -50,17 +50,10 @@ def arrays_from_superstructure(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray
 
 
 def arrays_from_indexed_superstructure(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
-    def guess(row: tuple) -> str:
-        if row[0][0] == bw.config.biosphere:
-            return "biosphere"
-        elif row[0] == row[1]:
-            return "production"
-        else:
-            return "technosphere"
     result = np.zeros(df.shape[0], dtype=object)
     for i, data in enumerate(df.index.to_flat_index()):
         result[i] = Index.build_from_dict(
-            {"input": data[0], "output": data[1], "flow type": guess(data)}
+            {"input": data[0], "output": data[1], "flow type": data[2]}
         )
     return result, df.to_numpy(dtype=float)
 

--- a/activity_browser/bwutils/superstructure/utils.py
+++ b/activity_browser/bwutils/superstructure/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import brightway2 as bw
 import pandas as pd
 
 
@@ -31,4 +32,12 @@ TO_ALL = pd.Index([
 ])
 
 
-
+def guess_flow_type(row: pd.Series) -> str:
+    """Given a series of input- and output keys, make a guess on the flow type.
+    """
+    if row.iat[0][0] == bw.config.biosphere:
+        return "biosphere"
+    elif row.iat[0] == row.iat[1]:
+        return "production"
+    else:
+        return "technosphere"


### PR DESCRIPTION
Make more explicit use of the `flow type` column in superstructure excel files.

The AB will now only guess the flow type of an exchange if:
- The column `flow type` is not present in the excel file (very possible with older files).
- The exchange does not have a value in the `flow type` column.

Also made sure that the `export parameter scenarios as flow scenarios` method in the AB correctly fills in the `flow type` field in the generated superstructure/flow scenario file.