### PR TITLE
Edited activities may now require themselves as exchanges

### DIFF
--- a/activity_browser/controllers/activity.py
+++ b/activity_browser/controllers/activity.py
@@ -218,9 +218,7 @@ class ExchangeController(QObject):
         for key in from_keys:
             technosphere_db = bc.is_technosphere_db(key[0])
             exc = activity.new_exchange(input=key, amount=1)
-            if key == to_key:
-                exc['type'] = 'production'
-            elif technosphere_db is True:
+            if technosphere_db is True:
                 exc['type'] = 'technosphere'
             elif technosphere_db is False:
                 exc['type'] = 'biosphere'


### PR DESCRIPTION
Removed the ability to add 'production' to an activity. This enables users to build loops i.e. exchanges that require themselves (1 unit of A requires 0.1 unit of A to be produced). Calculation result also seems to be correct.

This fixes #593 but has no effect on #587 

Keeping the `production` test is useless, as that option would never be true when the `technosphere` option is not true.