### PR TITLE
Pin bw2calc to a 1.* version instead of hard pinning to 1.8.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda install -q -y -c defaults -c conda-forge -c cmutel -c haasad \
-            -c pascallesage arrow "brightway2>=2.1.2" "bw2io>=0.8.6" "bw2calc=1.8.0" \
+            -c pascallesage arrow "brightway2>=2.1.2" "bw2io>=0.8.6" "bw2calc<2" \
             "bw2data>=3.6.1" "eidl>=1.2.0" fuzzywuzzy "matplotlib-base>=2.2.2" \
             networkx "pandas>=0.24.1" "pyside2>=5.13.1" "salib>=1.3.11" \
             seaborn presamples openpyxl "pytest>=5.2" pytest-qt \
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda install -q -y -c defaults -c conda-forge -c cmutel -c haasad `
-            -c pascallesage arrow "brightway2>=2.1.2" "bw2io >=0.8.6"  "bw2calc=1.8.0" `
+            -c pascallesage arrow "brightway2>=2.1.2" "bw2io >=0.8.6"  "bw2calc<2" `
             "bw2data>=3.6.1" "eidl>=1.2.0" fuzzywuzzy "matplotlib-base>=2.2.2" `
             networkx "pandas>=0.24.1" "pyside2>=5.13.1" "salib>=1.3.11" `
             seaborn presamples openpyxl "pytest>=5.2" pytest-qt `
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda install -q -y -c defaults -c conda-forge -c cmutel -c haasad \
-            -c pascallesage arrow "brightway2>=2.1.2" "bw2io >=0.8.6" "bw2calc=1.8.0" \
+            -c pascallesage arrow "brightway2>=2.1.2" "bw2io >=0.8.6" "bw2calc<2" \
             "bw2data>=3.6.1" "eidl>=1.2.0" fuzzywuzzy "matplotlib-base>=2.2.2" \
             networkx "pandas>=0.24.1" "pyside2>=5.13.1" "salib>=1.3.11" \
             seaborn presamples openpyxl "pytest>=5.2" pytest-qt \

--- a/ci/travis/recipe/meta.yaml
+++ b/ci/travis/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - brightway2 >=2.1.2
     - bw2io >=0.8.6
     - bw2data >=3.6.1
-    - bw2calc=1.8.0
+    - bw2calc <2
     - eidl >=1.2.0
     - fuzzywuzzy
     - matplotlib-base >=2.2.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - brightway2 >=2.1.2
     - bw2io >=0.8.6
     - bw2data >=3.6.1
-    - bw2calc=1.8.0
+    - bw2calc <2
     - eidl >=1.2.0
     - fuzzywuzzy
     - matplotlib-base >=2.2.2


### PR DESCRIPTION
Otherwise the activity-browser won't get fixes for bw2calc, version 2 is
still in development and there might be bugfix releases for version 1.

Relates: #657 