### PR TITLE
Github actions rework

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Deploy to anaconda
+name: stable conda release
 on:
   release:
     types:
@@ -7,39 +7,21 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      PKG_NAME: "activity-browser"
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
-      - name: Build and deploy
-        uses: s-weigand/setup-conda@v1.0.5
+      - name: Build and deploy 3.8
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.8
-      - name: Install dependencies
+          activate-environment: build
+          environment-file: ci/environment-build.yml
+      - name: Build activity-browser stable
         run: |
-          conda install -q -y -c defaults conda-build anaconda-client conda-verify
-      - name: Prepare workdir and variables
-        # For setting the tag as version:
-        # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
+          conda build ci/recipe/stable
+      - name: Upload to anaconda.org
         run: |
-          mkdir -p ~/miniconda/conda-bld
-          echo "CONDA_BLD_PATH=~/miniconda/conda-bld" >> $GITHUB_ENV
-          echo "BUILD_YAML=${{ github.workspace }}/ci/travis/recipe" >> $GITHUB_ENV
-          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Alter yaml file
-        # Strip the last sentence (as this is the stable version) out of the meta.yaml file.
-        # NOTE: this can get fiddly.
-        run: |
-          sed -i -e "`wc -l ${{ env.BUILD_YAML }}/meta.yaml | cut -d ' ' -f 1`d" ${{ env.BUILD_YAML }}/meta.yaml
-      - name: Build package
-        env:
-          BUILD_ARGS: "--no-anaconda-upload --no-test"
-        run: |
-          conda-build -c defaults -c conda-forge -c cmutel -c haasad -c pascallesage \
-            ${{ env.BUILD_ARGS }} ${{ env.BUILD_YAML }}
-      - name: Upload the stable package
-        env:
-          USER: "bsteubing"
-        run: |
-          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload -u ${{ env.USER }} \
-            -l main ${{ env.CONDA_BLD_PATH }}/noarch/${{ env.PKG_NAME }}-${{ env.VERSION }}-pypy_0.tar.bz2
+          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload \
+          /usr/share/miniconda/envs/build/conda-bld/noarch/*.tar.bz2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,71 +1,99 @@
-name: Pull request tests
+name: tests and development release
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
   push:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
-  test-macos:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: [ 3.7, 3.8 ]
+  patch-test-environment:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Patch test environment dependencies
+        # This step adds the run requirements from the stable recipe to the test environment
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq eval-all 'select(fi == 0).dependencies += select(fi == 1).requirements.run | select(fi == 0)' ci/environment-test.yml ci/recipe/stable/meta.yaml > patched-environment.yml
+      - name: Show patched environment
+        run: cat patched-environment.yml
+      - name: Upload patched environment as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: patched-environment
+          path: patched-environment.yml
+
+  test-macos:
+    runs-on: macos-latest
+    needs: patch-test-environment
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download patched test environment
+        uses: actions/download-artifact@v2
+        with:
+          name: patched-environment
       - name: Testing python ${{ matrix.python-version }}
-        uses: s-weigand/setup-conda@v1.0.5
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          conda install -q -y -c defaults -c conda-forge -c cmutel -c haasad \
-            -c pascallesage arrow "brightway2>=2.1.2" "bw2io>=0.8.6" "bw2calc=1.8.0" \
-            "bw2data>=3.6.1" "eidl>=1.2.0" fuzzywuzzy "matplotlib-base>=2.2.2" \
-            networkx "pandas>=0.24.1" "pyside2>=5.13.1" "salib>=1.4" \
-            seaborn presamples openpyxl "pytest>=5.2" pytest-qt \
-            pytest-mock "xlrd=1.2.0"
+          activate-environment: test
+          environment-file: patched-environment.yml
       - name: Run tests
         run: |
           pytest
 
   test-windows:
     runs-on: windows-latest
+    needs: patch-test-environment
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8 ]
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
+      - name: Download patched test environment
+        uses: actions/download-artifact@v2
+        with:
+          name: patched-environment
       - name: Testing python ${{ matrix.python-version }}
-        uses: s-weigand/setup-conda@v1.0.5
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install conda fix
-        run: |
-          conda install conda
-      - name: Install dependencies
-        run: |
-          conda install -q -y -c defaults -c conda-forge -c cmutel -c haasad `
-            -c pascallesage arrow "brightway2>=2.1.2" "bw2io >=0.8.6"  "bw2calc=1.8.0" `
-            "bw2data>=3.6.1" "eidl>=1.2.0" fuzzywuzzy "matplotlib-base>=2.2.2" `
-            networkx "pandas>=0.24.1" "pyside2>=5.13.1" "salib>=1.4" `
-            seaborn presamples openpyxl "pytest>=5.2" pytest-qt `
-            pytest-mock "xlrd=1.2.0"
+          activate-environment: test
+          environment-file: patched-environment.yml
       - name: Run tests
         run: |
           pytest
 
   test-linux:
     runs-on: ubuntu-latest
+    needs: patch-test-environment
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8 ]
+        python-version: [3.8, 3.9]
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+      - name: Download patched test environment
+        uses: actions/download-artifact@v2
+        with:
+          name: patched-environment
       - name: Testing python ${{ matrix.python-version }}
-        uses: s-weigand/setup-conda@v1.0.5
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
+          activate-environment: test
+          environment-file: patched-environment.yml
       # See https://stackoverflow.com/a/60694208/14506150
       # and https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
       - name: Install linux dependencies
@@ -76,21 +104,16 @@ jobs:
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid \
           --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 \
           1920x1200x24 -ac +extension GLX +render -noreset;
-      - name: Install dependencies
+      - name: Install coveralls dependencies
         run: |
-          conda install -q -y -c defaults -c conda-forge -c cmutel -c haasad \
-            -c pascallesage arrow "brightway2>=2.1.2" "bw2io >=0.8.6" "bw2calc=1.8.0" \
-            "bw2data>=3.6.1" "eidl>=1.2.0" fuzzywuzzy "matplotlib-base>=2.2.2" \
-            networkx "pandas>=0.24.1" "pyside2>=5.13.1" "salib>=1.4" \
-            seaborn presamples openpyxl "pytest>=5.2" pytest-qt \
-            pytest-mock "xlrd=1.2.0" coveralls coverage pytest-cov
+          conda install -q -y coveralls coverage pytest-cov
       - name: Run linux tests
         env:
           QT_DEBUG_PLUGINS: 1
         run: |
           catchsegv xvfb-run --auto-servernum pytest --cov=activity_browser --cov-report=;
       - name: Upload coverage
-        if: ${{ matrix.python-version == '3.7' }}
+        if: ${{ matrix.python-version == '3.8' }}
         # https://github.com/lemurheavy/coveralls-public/issues/1435#issuecomment-763357004
         # https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support
         # https://github.com/TheKevJames/coveralls-python/issues/252
@@ -102,38 +125,41 @@ jobs:
 
   deploy-development:
     # Make sure to only run a deploy if all tests pass.
-    #needs: [ "test-linux", "test-macos", "test-windows" ]
+    needs:
+      - test-linux
+      - test-macos
+      - test-windows
     # And only on a push event, not a pull_request.
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     env:
       PKG_NAME: "activity-browser-dev"
     steps:
       - uses: actions/checkout@v2
-      - name: Build and deploy 3.7
-        uses: s-weigand/setup-conda@v1.0.5
+      - name: Build and deploy 3.8
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7
-      - name: Install dependencies
+          python-version: 3.8
+          activate-environment: build
+          environment-file: ci/environment-build.yml
+      - name: Export version
         run: |
-          conda install -q -y -c defaults conda-build anaconda-client conda-verify
-      - name: Prepare workdir and variables
-        run: |
-          mkdir -p ~/miniconda/conda-bld
           echo "VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
-          echo "CONDA_BLD_PATH=~/miniconda/conda-bld" >> $GITHUB_ENV
-          echo "BUILD_YAML=${{ github.workspace }}/ci/travis/recipe" >> $GITHUB_ENV
+      - name: Patch recipe with run requirements from stable
+        uses: mikefarah/yq@master
+        # Adds the run dependencies from the stable recipe to the dev recipe (inplace)
+        with:
+          cmd: |
+            yq eval-all -i 'select(fi == 0).requirements.run += select(fi == 1).requirements.run | select(fi == 0)' ci/recipe/dev/meta.yaml ci/recipe/stable/meta.yaml
+      - name: Show patched dev recipe
+        run: cat ci/recipe/dev/meta.yaml
       - name: Build development package
-        env:
-          BUILD_ARGS: "--old-build-string --no-anaconda-upload --no-test"
         run: |
-          conda-build -c defaults -c conda-forge -c cmutel -c haasad -c pascallesage \
-            ${{ env.BUILD_ARGS }} ${{ env.BUILD_YAML }}
+          conda build ci/recipe/dev
       - name: Upload the development package
-        env:
-          UPLOAD_ARGS: "--force"
-          USER: "bsteubing"
         run: |
-          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload -u ${{ env.USER }} \
-            -l main ${{ env.CONDA_BLD_PATH }}/noarch/${{ env.PKG_NAME }}-${{ env.VERSION }}-py_0.tar.bz2 \
-            ${{ env.UPLOAD_ARGS }}
+          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --force \
+          /usr/share/miniconda/envs/build/conda-bld/noarch/*.tar.bz2

--- a/ci/environment-build.yml
+++ b/ci/environment-build.yml
@@ -1,0 +1,11 @@
+name: build
+channels:
+  - conda-forge
+  - cmutel
+  - bsteubing
+  - haasad
+  - pascallesage
+dependencies:
+  - conda-build
+  - anaconda-client
+  - conda-verify

--- a/ci/environment-test.yml
+++ b/ci/environment-test.yml
@@ -1,0 +1,11 @@
+name: test
+channels:
+  - conda-forge
+  - cmutel
+  - bsteubing
+  - haasad
+  - pascallesage
+dependencies:
+  - pytest
+  - pytest-qt
+  - pytest-mock

--- a/ci/recipe/dev/meta.yaml
+++ b/ci/recipe/dev/meta.yaml
@@ -12,7 +12,6 @@ build:
   script_env:
     - PKG_NAME
     - VERSION
-    - CONDA_BLD_PATH
   entry_points:
     - activity-browser = activity_browser:run_activity_browser
     - activity-browser-cleanup = activity_browser.bwutils:cleanup
@@ -21,24 +20,7 @@ requirements:
   build:
     - python
     - setuptools
-  run:
-    - python>=3.8, <=3.9  # https://github.com/conda-forge/pyside2-feedstock/issues/56
-    - arrow
-    - brightway2 >=2.1.2
-    - bw2io >=0.8.6
-    - bw2data >=3.6.1
-    - bw2calc=1.8.0
-    - eidl >=1.2.0
-    - fuzzywuzzy
-    - matplotlib-base >=2.2.2
-    - networkx
-    - pandas >=0.24.1
-    - pyside2 >=5.13.1
-    - salib >=1.4
-    - seaborn
-    - presamples
-    - openpyxl
-    - xlrd <2.0  # https://github.com/brightway-lca/brightway2-io/issues/86
+  run:  # dependencies are added via github action from ci/recipe/stable/meta.yaml
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser

--- a/ci/recipe/stable/meta.yaml
+++ b/ci/recipe/stable/meta.yaml
@@ -1,13 +1,11 @@
 # Used https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml as example
-{% set version = "2.6.4" %}
-
 package:
   name: activity-browser
-  version: "{{ version }}"
+  version: "{{ GIT_DESCRIBE_TAG }}"
 
 source:
   # Note for future: https://conda-forge.org/docs/maintainer/adding_pkgs.html#tarballs-no-repos
-  git_rev: "{{ version }}"
+  git_rev: master
   git_url: https://github.com/LCA-ActivityBrowser/activity-browser.git
 
 build:


### PR DESCRIPTION
When I opened #661, I saw it is required to change dependency versions in __5!__ different places (both recipes and the tests for all 3 OSs) and there's no guarantee that the changes have the desired effect. You only know after pushing to master, because that's where the github action workflows are defined.
So I thought I take a look at the github action workflows to see if I can improve this and this PR is the result.

This PR includes the following changes:
- Move the conda recipes to `ci/recipe/dev` and `ci/recipe/stable`
- `ci/recipe/stable/meta.yaml` is now the single source of truth for the dependencies
    - test environments for linux/macos/windows all use the dependencies from stable
    - the dev package also uses dependencies defined in `ci/recipe/stable`
- dependencies for tests and build, as well as the required channels are configured in an `environment.yaml` file

Advantages of this setup:
- Dependencies only need to be changed in a single place
- Tests are run against the exact same versions as the package will later use
- You can create a PR with changes in dependencies and the tests will give meaningful feedback
    - see this example where I removed two dependencies: https://github.com/haasad/activity-browser/pull/1

How does it work:
- I changed to github action to set up miniconda to https://github.com/conda-incubator/setup-miniconda, because it accepts an environment file as input
- The test environment is patched with the dependencies from the stable recipe with some `yq` yaml magic:
https://github.com/LCA-ActivityBrowser/activity-browser/compare/master...haasad:gh-actions-rework-pr?expand=1#diff-71cabc4177e41ea8f15a89eb65398fa8187739f68a2762706d84885cd8b2ddc3R15-R20
- the dev recipe is also patched with `yq` with the dependencies from the stable recipe in the workflow

You can see it in action here: https://github.com/haasad/activity-browser/actions
The "test" packages I created with the workflows are called `abfork` and `abfork-dev` here: https://anaconda.org/haasad/repo


I'm not entirely sure what the current responsibilities are in the activity-browser project, but it probably makes sense if you all have a look a this to see if it's good to merge @bsteubing @StpdFox @nabilahmed739 
Let me know what you think