### PR TITLE
Revert db_import_wizard changes, this is fixed in eidl and required for cutoff EN15804

### DIFF
--- a/activity_browser/ui/wizards/db_import_wizard.py
+++ b/activity_browser/ui/wizards/db_import_wizard.py
@@ -961,8 +961,6 @@ class LoginThread(QtCore.QThread):
 
 
 class EcoinventVersionPage(QtWidgets.QWizardPage):
-    ALLOWED_SYSTEM_MODELS = ["cutoff", "consequential", "apos"]
-
     def __init__(self, parent=None):
         super().__init__(parent)
         self.wizard = self.parent()
@@ -985,22 +983,14 @@ class EcoinventVersionPage(QtWidgets.QWizardPage):
         if self.db_dict is None:
             self.wizard.downloader.db_dict = self.wizard.downloader.get_available_files()
             self.db_dict = self.wizard.downloader.db_dict
-        self.system_models = {}
-        for key_tuple in list(self.db_dict.keys()):
-            # Ignore items like ('electricity emission factors – scope 2 – 3 in v3.8.7z',) without system information
-            if len(key_tuple) == 2:
-                key, value = key_tuple
-                # Ignore the values like "Change Report"
-                if value in list(self.ALLOWED_SYSTEM_MODELS):
-                    self.system_models.setdefault(key, []).append(value)
-
+        self.system_models = {
+            version: sorted({k[1] for k in self.db_dict.keys() if k[0] == version}, reverse=True)
+            for version in sorted({k[0] for k in self.db_dict.keys()}, reverse=True)
+        }
         # Catch for incorrect 'universal' key presence
         # (introduced in version 3.6 of ecoinvent)
-        if "technical report" in self.system_models:
-            del self.system_models["technical report"]
         if "universal" in self.system_models:
             del self.system_models["universal"]
-
         self.version_combobox.clear()
         self.system_model_combobox.clear()
         self.version_combobox.addItems(list(self.system_models.keys()))


### PR DESCRIPTION
Reverts changes to import wizard from 669027eebdc6dd5d4be4f0b32ebddbd418bc666e

The original problem was fixed in the ecoinvent downloader version 1.3.2, see https://github.com/haasad/EcoInventDownLoader/pull/18

Reverting these changes makes it possible again to download the `Allocation, cut-off, EN15804` for ecoinvent 3.8, see discussion in https://github.com/haasad/EcoInventDownLoader/issues/19