### PR TITLE
Automate the version number in setup.py and info.py

### DIFF
--- a/activity_browser/info.py
+++ b/activity_browser/info.py
@@ -1,3 +1,6 @@
-# -*- coding: utf-8 -*-
-__version__ = "2.6.3"
-__version_info__ = (2, 6, 3)
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__package__)
+except PackageNotFoundError:
+    __version__ = "0.0.0"

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,14 @@ for dirpath, dirnames, filenames in os.walk('activity_browser'):
             pkg = pkg.replace(os.path.altsep, '.')
         packages.append(pkg)
 
+if 'VERSION' in os.environ:
+    version = os.environ['VERSION']
+else:
+    version = os.environ.get('GIT_DESCRIBE_TAG', '0.0.0')
+
 setup(
     name='activity-browser',
-    version="2.6.3",
+    version=version,
     packages=packages,
     include_package_data=True,
     author="Bernhard Steubing",


### PR DESCRIPTION
This PR removes the need to manually update the version number before making a new release.

- info.py gets the version at runtime from the package metadata (ie. the version set in setup.py during the build step of the package)
- setup.py in turn gets the version from environment variables
    - dev: uses the `VERSION` environment variable exported in the pipeline
    - stable: uses `GIT_DESCRIBE_TAG`, which is set by the conda build process ([docs](https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html#git-environment-variables))

Limitations:
- only works for python 3.8+ (because of [importlib.metadata](https://docs.python.org/3.8/library/importlib.metadata.html))
- Releases need to be based on a tag (we already do this)
- when running the activity-browser outside of an installed package (eg. with `python run-activity-browser.py`), version 0.0.0 is shown in the "Help -> About AB" section

Relates: #685 