### PR TITLE
Show/Hide comment field for exchanges in the Techno/Biosphere.

### DIFF
--- a/activity_browser/bwutils/commontasks.py
+++ b/activity_browser/bwutils/commontasks.py
@@ -171,6 +171,7 @@ AB_names_to_bw_keys = {
     "Formula": "formula",
     "Categories": "categories",
     "Type": "type",
+    "Comment": "comment",
 }
 
 bw_keys_to_AB_names = {v: k for k, v in AB_names_to_bw_keys.items()}

--- a/activity_browser/layouts/tabs/activity.py
+++ b/activity_browser/layouts/tabs/activity.py
@@ -110,11 +110,18 @@ class ActivityTab(QtWidgets.QWidget):
         self.show_uncertainty.setChecked(False)
         self.show_uncertainty.toggled.connect(self.show_exchange_uncertainty)
 
+        # Reveal/hide exchange comment columns
+        self.show_comment = QtWidgets.QCheckBox("Show Exchange comments")
+        self.show_comment.setToolTip("Show or hide the comment column in the Technosphere Inputs and Biosphere Flows tables")
+        self.show_comment.setChecked(False)
+        self.show_comment.toggled.connect(self.show_comments)
+
         # Toolbar Layout
         toolbar = QtWidgets.QToolBar()
         toolbar.addWidget(self.checkbox_edit_act)
         toolbar.addWidget(self.checkbox_activity_description)
         toolbar.addWidget(self.show_uncertainty)
+        toolbar.addWidget(self.show_comment)
         self.graph_action = toolbar.addAction(
             qicons.graph_explorer, "Show graph", self.open_graph
         )
@@ -187,6 +194,7 @@ class ActivityTab(QtWidgets.QWidget):
         self.downstream.model.sync(self.activity.upstream())
 
         self.show_exchange_uncertainty(self.show_uncertainty.isChecked())
+        self.show_comments(self.show_comment.isChecked())
 
     def populate_description_box(self):
         """Populate the activity description."""
@@ -209,6 +217,11 @@ class ActivityTab(QtWidgets.QWidget):
     def show_exchange_uncertainty(self, toggled: bool) -> None:
         self.technosphere.show_uncertainty(toggled)
         self.biosphere.show_uncertainty(toggled)
+
+    @Slot(bool, name="toggleCommentColumn")
+    def show_comments(self, toggled: bool) -> None:
+        self.technosphere.show_comments(toggled)
+        self.biosphere.show_comments(toggled)
 
     @Slot(bool, name="toggleReadOnly")
     def act_read_only_changed(self, read_only: bool) -> None:

--- a/activity_browser/ui/tables/activity.py
+++ b/activity_browser/ui/tables/activity.py
@@ -148,6 +148,7 @@ class TechnosphereExchangeTable(BaseExchangeTable):
         self.setItemDelegateForColumn(0, FloatDelegate(self))
         self.setItemDelegateForColumn(6, ViewOnlyUncertaintyDelegate(self))
         self.setItemDelegateForColumn(13, FormulaDelegate(self))
+        self.setItemDelegateForColumn(14, StringDelegate(self))
         self.setDragDropMode(QtWidgets.QTableView.DragDrop)
         self.table_name = "technosphere"
 
@@ -166,6 +167,12 @@ class TechnosphereExchangeTable(BaseExchangeTable):
         self.setColumnHidden(cols.index("pedigree"), not show)
         for c in self.model.UNCERTAINTY:
             self.setColumnHidden(cols.index(c), not show)
+
+    def show_comments(self, show: bool = False) -> None:
+        """Show or hide the comment column.
+        """
+        cols = self.model.columns
+        self.setColumnHidden(cols.index("Comment"), not show)
 
     def contextMenuEvent(self, event) -> None:
         if self.indexAt(event.pos()).row() == -1:
@@ -204,8 +211,9 @@ class BiosphereExchangeTable(BaseExchangeTable):
         self.setItemDelegateForColumn(0, FloatDelegate(self))
         self.setItemDelegateForColumn(5, ViewOnlyUncertaintyDelegate(self))
         self.setItemDelegateForColumn(12, FormulaDelegate(self))
-        self.table_name = "biosphere"
+        self.setItemDelegateForColumn(13, StringDelegate(self))
         self.setDragDropMode(QtWidgets.QTableView.DropOnly)
+        self.table_name = "biosphere"
 
     @Slot(name="resizeView")
     def custom_view_sizing(self) -> None:
@@ -220,6 +228,12 @@ class BiosphereExchangeTable(BaseExchangeTable):
         self.setColumnHidden(cols.index("pedigree"), not show)
         for c in self.model.UNCERTAINTY:
             self.setColumnHidden(cols.index(c), not show)
+
+    def show_comments(self, show: bool = False) -> None:
+        """Show or hide the comment column.
+        """
+        cols = self.model.columns
+        self.setColumnHidden(cols.index("Comment"), not show)
 
     def contextMenuEvent(self, event) -> None:
         if self.indexAt(event.pos()).row() == -1:

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -22,7 +22,7 @@ class BaseExchangeModel(EditablePandasModel):
     # Fields accepted by brightway to be stored in exchange objects.
     VALID_FIELDS = {
         "amount", "formula", "uncertainty type", "loc", "scale", "shape",
-        "minimum", "maximum"
+        "minimum", "maximum", "comment"
     }
 
     def __init__(self, key=None, parent=None):
@@ -204,7 +204,7 @@ class ProductExchangeModel(BaseExchangeModel):
 class TechnosphereExchangeModel(BaseExchangeModel):
     COLUMNS = [
         "Amount", "Unit", "Product", "Activity", "Location", "Database",
-        "Uncertainty", "Formula"
+        "Uncertainty", "Formula", "Comment"
     ]
     UNCERTAINTY = [
         "loc", "scale", "shape", "minimum", "maximum"
@@ -228,6 +228,7 @@ class TechnosphereExchangeModel(BaseExchangeModel):
                 "Database": act.get("database"),
                 "Uncertainty": exchange.get("uncertainty type", 0),
                 "Formula": exchange.get("formula"),
+                "Comment": exchange.get("comment"),
             })
             try:
                 matrix = PedigreeMatrix.from_dict(exchange.get("pedigree", {}))
@@ -246,7 +247,7 @@ class TechnosphereExchangeModel(BaseExchangeModel):
 class BiosphereExchangeModel(BaseExchangeModel):
     COLUMNS = [
         "Amount", "Unit", "Flow Name", "Compartments", "Database",
-        "Uncertainty", "Formula"
+        "Uncertainty", "Formula", "Comment"
     ]
     UNCERTAINTY = [
         "loc", "scale", "shape", "minimum", "maximum"
@@ -269,6 +270,7 @@ class BiosphereExchangeModel(BaseExchangeModel):
                 "Database": act.get("database"),
                 "Uncertainty": exchange.get("uncertainty type", 0),
                 "Formula": exchange.get("formula"),
+                "Comment": exchange.get("comment"),
             })
             try:
                 matrix = PedigreeMatrix.from_dict(exchange.get("pedigree", {}))


### PR DESCRIPTION
Fixes: requests #706, #583, #567 and #303

Adds a new checkbox in the toolbar of an activity tab:
![image](https://user-images.githubusercontent.com/34626062/152782975-667e9212-44a8-4a17-a9cd-c8aacbf87334.png)

Checking this box shows the `Comment` column after the `Formula` line in both the `Technosphere Inputs` and the `Biosphere Flows` tables.
![image](https://user-images.githubusercontent.com/34626062/152783162-3100964f-af0a-45bf-8e7c-a1cf058998e9.png)

Comment field shows existing comments and allows user to add their own text to the field. Of course, the `edit activitiy` checkbox should also be checked to edit comments.

Comments in the ecoinvent database are also shown. This includes 'weird' comments like `EcoSpold01Location=GLO`.
![image](https://user-images.githubusercontent.com/34626062/152783506-ad1352ee-5261-4965-95af-f9a3209c509e.png)

Also works as intended in combination with the `Show Uncertainty` option, though showing both at the same time can become quite wide in the table view.
![image](https://user-images.githubusercontent.com/34626062/152956935-a45d1694-b297-4a1c-8028-74485ca9a786.png)


The comments are stored in the Brightway `exchange.comment` field, and thus compatible with database import/export.


I'm aware there were more detailed plans to integrate this in a better way, but this took me less than an hour to write and I think this has substantial added value to users.