### PR TITLE
Add cursor loading animation

### DIFF
--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -12,6 +12,7 @@ from PySide2.QtWidgets import (
     QWidget, QTabWidget, QVBoxLayout, QHBoxLayout, QScrollArea, QRadioButton,
     QLabel, QLineEdit, QCheckBox, QPushButton, QComboBox, QTableView,
     QButtonGroup, QMessageBox, QGroupBox, QGridLayout, QFileDialog,
+    QApplication
 )
 from PySide2 import QtGui, QtCore
 from stats_arrays.errors import InvalidParamsError
@@ -98,6 +99,7 @@ class LCAResultsSubTab(QTabWidget):
         self.setVisible(False)
         self.visible = False
 
+        QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         self.mlca, self.contributions, self.mc = calculations.do_LCA_calculations(data)
         self.method_dict = bc.get_LCIA_method_name_dict(self.mlca.methods)
         self.single_func_unit = True if len(self.mlca.func_units) == 1 else False
@@ -124,6 +126,7 @@ class LCAResultsSubTab(QTabWidget):
         self.setup_tabs()
         self.setCurrentWidget(self.tabs.results)
         self.currentChanged.connect(self.generate_content_on_click)
+        QApplication.restoreOverrideCursor()
 
     def setup_tabs(self):
         """Have all of the tabs pull in their required data and add them."""
@@ -1132,6 +1135,7 @@ class MonteCarloTab(NewAnalysisTab):
             "parameters": self.include_parameters.isChecked(),
         }
 
+        QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         try:
             self.parent.mc.calculate(iterations=iterations, seed=seed, **includes)
             signals.monte_carlo_finished.emit()
@@ -1140,6 +1144,7 @@ class MonteCarloTab(NewAnalysisTab):
             # print(e)
             traceback.print_exc()
             QMessageBox.warning(self, 'Could not perform Monte Carlo simulation', str(e))
+        QApplication.restoreOverrideCursor()
 
         # a threaded way for this - unfortunatley this crashes as:
         # pypardsio_solver is used for the 'spsolve' and 'factorized' functions. Python crashes on windows if multiple
@@ -1366,6 +1371,7 @@ class GSATab(NewAnalysisTab):
         # print('Calculating GSA for: ', act_number, method_number, cutoff_technosphere, cutoff_biosphere)
 
         try:
+            QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
             self.GSA.perform_GSA(act_number=act_number, method_number=method_number,
                                  cutoff_technosphere=cutoff_technosphere, cutoff_biosphere=cutoff_biosphere)
             # self.update_mc()
@@ -1381,6 +1387,7 @@ class GSATab(NewAnalysisTab):
                 message_addition = "\nThe reason for this is likely that there are no uncertain exchanges. Please check " \
                                    "the checkboxes in the Monte Carlo tab."
             QMessageBox.warning(self, 'Could not perform GSA', str(message) + message_addition)
+        QApplication.restoreOverrideCursor()
 
         self.update_gsa()
 

--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -2,7 +2,7 @@
 from collections import namedtuple
 
 from PySide2 import QtWidgets
-from PySide2.QtCore import Slot
+from PySide2.QtCore import Slot, Qt
 from brightway2 import calculation_setups
 import pandas as pd
 
@@ -478,6 +478,8 @@ class ScenarioImportWidget(QtWidgets.QWidget):
         if dialog.exec_() == ExcelReadDialog.Accepted:
             path = dialog.path
             idx = dialog.import_sheet.currentIndex()
+            QtWidgets.QApplication.setOverrideCursor(Qt.WaitCursor)
+            print('Loading Scenario file. This may take a while for large files')
             try:
                 # Try and read as a superstructure file
                 df = import_from_excel(path, idx)
@@ -500,6 +502,7 @@ class ScenarioImportWidget(QtWidgets.QWidget):
             finally:
                 self.scenario_name.setText(path.name)
                 self.scenario_name.setToolTip(path.name)
+            QtWidgets.QApplication.restoreOverrideCursor()
 
     def sync_superstructure(self, df: pd.DataFrame) -> None:
         # TODO: Move the 'scenario_df' into the model itself.

--- a/activity_browser/ui/tables/models/inventory.py
+++ b/activity_browser/ui/tables/models/inventory.py
@@ -8,6 +8,7 @@ from bw2data.utils import natural_sort
 import numpy as np
 import pandas as pd
 from PySide2.QtCore import Qt, QModelIndex, Slot
+from PySide2.QtWidgets import QApplication
 
 from activity_browser.bwutils import AB_metadata, commontasks as bc
 from activity_browser.settings import project_settings
@@ -119,8 +120,10 @@ class ActivitiesBiosphereModel(DragPandasModel):
         self.technosphere = bc.is_technosphere_db(db_name)
 
         # Get dataframe from metadata and update column-names
+        QApplication.setOverrideCursor(Qt.WaitCursor)
         df = self.df_from_metadata(db_name)
         self._dataframe = df.reset_index(drop=True)
+        QApplication.restoreOverrideCursor()
         self.updated.emit()
 
     def search(self, pattern1: str = None, pattern2: str = None, logic='AND') -> None:


### PR DESCRIPTION
Fixes request #598.

Add cursor loading animation to:
- Loading Scenario files
  - Also adds print statement to warn user for long import times with big files
- Opening databases
- LCA calculation
- Monte Carlo
- GSA

The cursor is set to `QtWaitCursor` during the above processes and set back to the normal cursor after. Unfortunately, I can't screenshot my cursor for some reason, but it is the normal 'loading' display for the cursor in the given OS (in Windows the blue spinning circle thing).

Leaving this as draft for suggestions to put the loading icon in other places too.

If there are no additional suggestions this PR is ready to go.