### PR TITLE
Skip failing and segfaulting tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,6 +47,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: test
           environment-file: patched-environment.yml
+      - name: Environment info
+        run: |
+          conda list -n test
+          conda env export -n test
+          conda env export -n test -f env-osx64.yaml
+      - name: Upload final environment as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: env-osx64.yaml
+          path: env-osx64.yaml
       - name: Run tests
         run: |
           pytest
@@ -69,6 +79,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: test
           environment-file: patched-environment.yml
+      - name: Environment info
+        run: |
+          conda list -n test
+          conda env export -n test
+          conda env export -n test -f env-win64.yaml
+      - name: Upload final environment as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: env-win64.yaml
+          path: env-win64.yaml
       - name: Run tests
         run: |
           pytest
@@ -96,6 +116,16 @@ jobs:
           environment-file: patched-environment.yml
       # See https://stackoverflow.com/a/60694208/14506150
       # and https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
+      - name: Environment info
+        run: |
+          conda list -n test
+          conda env export -n test
+          conda env export -n test -f env-linux64.yaml
+      - name: Upload final environment as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: env-linux64.yaml
+          path: env-linux64.yaml
       - name: Install linux dependencies
         run: |
           sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 \

--- a/tests/test_presample_scenarios.py
+++ b/tests/test_presample_scenarios.py
@@ -36,93 +36,99 @@ def scenario_dataframes():
     return df, new_df
 
 
-# def test_empty_presamples_list(qtbot, bw2test):
-#     """ The presamples dropdown list has default values when no presample
-#     packages exist.
-#     """
-#     p_list = PresamplesList()
-#     qtbot.addWidget(p_list)
-#     assert p_list.get_package_names() == []
-#     assert p_list.has_packages is False
-#     assert p_list.selection == ""
-#
-#
-# def test_existing_presamples_list(qtbot, bw2test):
-#     """ The presamples dropdown can recognize existing presample packages.
-#     """
-#     cereal = np.array([49197200, 50778200, 50962400], dtype=np.int64)
-#     fertilizer = np.array([57.63016664, 58.92761065, 54.63277483], dtype=np.float64)
-#     land = np.array([17833000, 16161700, 15846800], dtype=np.int64)
-#     array_stack = np.stack([cereal, fertilizer, land], axis=0)
-#     names = ['cereal production [t]', 'fert consumption [kg/km2]', 'land [ha]']
-#     _, pp_path = ps.create_presamples_package(
-#         parameter_data=[(array_stack, names, "default")], name="testificate"
-#     )
-#
-#     p_list = PresamplesList()
-#     qtbot.addWidget(p_list)
-#
-#     packages = p_list.get_package_names()
-#     pkg_name = next(iter(packages))
-#     p_list.sync(pkg_name)
-#
-#     assert packages == ["testificate"]
-#     assert p_list.has_packages is True
-#     assert p_list.selection == "testificate"
+@pytest.mark.skip(reason="test needs to be fixed")
+def test_empty_presamples_list(qtbot, bw2test):
+    """ The presamples dropdown list has default values when no presample
+    packages exist.
+    """
+    p_list = PresamplesList()
+    qtbot.addWidget(p_list)
+    assert p_list.get_package_names() == []
+    assert p_list.has_packages is False
+    assert p_list.selection == ""
 
 
-# def test_empty_scenario_table(qtbot, bw2test):
-#     """ In a new/unparameterized project, the scenario table is empty.
-#     """
-#     table = ScenarioTable()
-#     qtbot.addWidget(table)
-#     table.model.sync()
-#     assert table.rowCount() == 0
+@pytest.mark.skip(reason="test needs to be fixed")
+def test_existing_presamples_list(qtbot, bw2test):
+    """ The presamples dropdown can recognize existing presample packages.
+    """
+    cereal = np.array([49197200, 50778200, 50962400], dtype=np.int64)
+    fertilizer = np.array([57.63016664, 58.92761065, 54.63277483], dtype=np.float64)
+    land = np.array([17833000, 16161700, 15846800], dtype=np.int64)
+    array_stack = np.stack([cereal, fertilizer, land], axis=0)
+    names = ['cereal production [t]', 'fert consumption [kg/km2]', 'land [ha]']
+    _, pp_path = ps.create_presamples_package(
+        parameter_data=[(array_stack, names, "default")], name="testificate"
+    )
+
+    p_list = PresamplesList()
+    qtbot.addWidget(p_list)
+
+    packages = p_list.get_package_names()
+    pkg_name = next(iter(packages))
+    p_list.sync(pkg_name)
+
+    assert packages == ["testificate"]
+    assert p_list.has_packages is True
+    assert p_list.selection == "testificate"
 
 
-# def test_scenario_table(qtbot, project_parameters):
-#     """ The scenario table will recognize existing parameters during sync.
-#     """
-#     table = ScenarioTable()
-#     qtbot.addWidget(table)
-#     table.model.sync()
-#     assert table.rowCount() == 3
+@pytest.mark.skip(reason="test needs to be fixed")
+def test_empty_scenario_table(qtbot, bw2test):
+    """ In a new/unparameterized project, the scenario table is empty.
+    """
+    table = ScenarioTable()
+    qtbot.addWidget(table)
+    table.model.sync()
+    assert table.rowCount() == 0
 
 
-# def test_scenario_table_rebuild(qtbot, project_parameters):
-#     """ Altering the amount of a parameter causes the scenario table to rebuild.
-#     """
-#     tab = ParametersTab()
-#     qtbot.addWidget(tab)
-#     project_table = tab.tabs.get("Definitions").project_table
-#     scenario_table = tab.tabs.get("Scenarios").tbl
-#     scenario_table.model.sync()  # Trigger a clean sync
-#
-#     begin_df = scenario_table.model._dataframe.copy()
-#
-#     assert begin_df.equals(scenario_table.model._dataframe)
-#     with qtbot.waitSignal(signals.parameters_changed, timeout=500):
-#         project_table.model.setData(project_table.model.index(0, 1), 16)
-#     assert not begin_df.equals(scenario_table.model._dataframe)
+@pytest.mark.skip(reason="test needs to be fixed")
+def test_scenario_table(qtbot, project_parameters):
+    """ The scenario table will recognize existing parameters during sync.
+    """
+    table = ScenarioTable()
+    qtbot.addWidget(table)
+    table.model.sync()
+    assert table.rowCount() == 3
 
 
-# def test_scenario_table_rename(qtbot, project_parameters, monkeypatch):
-#     """ Renaming a parameter will change the index of the dataframe
-#     but not the values. (not that there is an easy way to test this)
-#     """
-#     tab = ParametersTab()
-#     qtbot.addWidget(tab)
-#     project_table = tab.tabs.get("Definitions").project_table
-#     scenario_table = tab.tabs.get("Scenarios").tbl
-#     scenario_table.model.sync()  # Trigger a clean sync
-#
-#     assert scenario_table.model._dataframe.index[0] == "test1"
-#     monkeypatch.setattr(
-#         QInputDialog, "getText", staticmethod(lambda *args, **kwargs: ("newname", True))
-#     )
-#     with qtbot.waitSignal(signals.parameter_renamed, timeout=500):
-#         project_table.model.handle_parameter_rename(project_table.proxy_model.index(0, 0))
-#     assert scenario_table.model._dataframe.index[0] == "newname"
+@pytest.mark.skip(reason="test needs to be fixed")
+def test_scenario_table_rebuild(qtbot, project_parameters):
+    """ Altering the amount of a parameter causes the scenario table to rebuild.
+    """
+    tab = ParametersTab()
+    qtbot.addWidget(tab)
+    project_table = tab.tabs.get("Definitions").project_table
+    scenario_table = tab.tabs.get("Scenarios").tbl
+    scenario_table.model.sync()  # Trigger a clean sync
+
+    begin_df = scenario_table.model._dataframe.copy()
+
+    assert begin_df.equals(scenario_table.model._dataframe)
+    with qtbot.waitSignal(signals.parameters_changed, timeout=500):
+        project_table.model.setData(project_table.model.index(0, 1), 16)
+    assert not begin_df.equals(scenario_table.model._dataframe)
+
+
+@pytest.mark.skip(reason="test needs to be fixed")
+def test_scenario_table_rename(qtbot, project_parameters, monkeypatch):
+    """ Renaming a parameter will change the index of the dataframe
+    but not the values. (not that there is an easy way to test this)
+    """
+    tab = ParametersTab()
+    qtbot.addWidget(tab)
+    project_table = tab.tabs.get("Definitions").project_table
+    scenario_table = tab.tabs.get("Scenarios").tbl
+    scenario_table.model.sync()  # Trigger a clean sync
+
+    assert scenario_table.model._dataframe.index[0] == "test1"
+    monkeypatch.setattr(
+        QInputDialog, "getText", staticmethod(lambda *args, **kwargs: ("newname", True))
+    )
+    with qtbot.waitSignal(signals.parameter_renamed, timeout=500):
+        project_table.model.handle_parameter_rename(project_table.proxy_model.index(0, 0))
+    assert scenario_table.model._dataframe.index[0] == "newname"
 
 
 def test_scenario_merge_new_scenarios(scenario_dataframes):
@@ -187,27 +193,28 @@ def test_scenario_merge_empty_values(scenario_dataframes):
     assert df.iat[1, 4] == df.iat[1, 2]
 
 
-# def test_scenario_tab(qtbot, monkeypatch, project_parameters):
-#     """ Test the simple functioning of the scenario presamples tab.
-#     clicky buttons!
-#     """
-#     tab = ParameterScenariosTab()
-#     qtbot.addWidget(tab)
-#     tab.tbl.model.sync()
-#     tab.tbl.group_column(False)
-#     store_path = Path(bw.projects.dir) / "testsave.xlsx"
-#
-#     # Save the table to the store_path, and load it in afterwards.
-#     assert not store_path.is_file()  # The file doesn't exist.
-#     monkeypatch.setattr(QFileDialog, "getSaveFileName", staticmethod(lambda *args, **kwargs: (store_path, True)))
-#     with qtbot.waitSignal(tab.save_btn.clicked, timeout=500):
-#         qtbot.mouseClick(tab.save_btn, Qt.LeftButton)
-#     qtbot.wait(500)
-#     assert store_path.is_file()  # Yes, saving the file worked.
-#     monkeypatch.setattr(QFileDialog, "getOpenFileName", staticmethod(lambda *args, **kwargs: (store_path, True)))
-#     with qtbot.waitSignal(tab.load_btn.clicked, timeout=500):
-#         qtbot.mouseClick(tab.load_btn, Qt.LeftButton)
-#
-#     assert tab.tbl.isColumnHidden(0) is True
-#     tab.hide_group.toggle()
-#     assert tab.tbl.isColumnHidden(0) is False
+@pytest.mark.skip(reason="test needs to be fixed")
+def test_scenario_tab(qtbot, monkeypatch, project_parameters):
+    """ Test the simple functioning of the scenario presamples tab.
+    clicky buttons!
+    """
+    tab = ParameterScenariosTab()
+    qtbot.addWidget(tab)
+    tab.tbl.model.sync()
+    tab.tbl.group_column(False)
+    store_path = Path(bw.projects.dir) / "testsave.xlsx"
+
+    # Save the table to the store_path, and load it in afterwards.
+    assert not store_path.is_file()  # The file doesn't exist.
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", staticmethod(lambda *args, **kwargs: (store_path, True)))
+    with qtbot.waitSignal(tab.save_btn.clicked, timeout=500):
+        qtbot.mouseClick(tab.save_btn, Qt.LeftButton)
+    qtbot.wait(500)
+    assert store_path.is_file()  # Yes, saving the file worked.
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", staticmethod(lambda *args, **kwargs: (store_path, True)))
+    with qtbot.waitSignal(tab.load_btn.clicked, timeout=500):
+        qtbot.mouseClick(tab.load_btn, Qt.LeftButton)
+
+    assert tab.tbl.isColumnHidden(0) is True
+    tab.hide_group.toggle()
+    assert tab.tbl.isColumnHidden(0) is False

--- a/tests/test_uncertainty_wizard.py
+++ b/tests/test_uncertainty_wizard.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import sys
+
 from bw2data.parameters import ProjectParameter
 import numpy as np
 from PySide2.QtWidgets import QMessageBox, QWizard
@@ -23,6 +25,7 @@ def test_wizard_fail(qtbot):
         UncertaintyWizard(mystery_box)
 
 
+@pytest.mark.skipif(sys.platform=='darwin', reason="tests segfaults on osx")
 def test_uncertainty_wizard_simple(qtbot, bw2test, capsys):
     """Use extremely simple text to open the wizard and go to all the pages."""
     param = ProjectParameter.create(name="test1", amount=3)

--- a/tests/test_uncertainty_wizard.py
+++ b/tests/test_uncertainty_wizard.py
@@ -134,6 +134,7 @@ def test_update_alter_mean(qtbot, monkeypatch, ab_app):
     assert np.isclose(np.log(param.amount), loc)
 
 
+@pytest.mark.skipif(sys.platform=='darwin', reason="tests segfaults on osx")
 def test_lognormal_mean_balance(qtbot, bw2test):
     uncertain = {
         "loc": 2,


### PR DESCRIPTION
This PR includes the following chagnes:
- explicitly skip failing presamples tests instead of just commenting them out (otherwise they're likely forgotten)
- skip 2 tests on osx that lead to segfaults
    - there might be more, but it's unclear to me what exactly causes the segfaults
    - re-running the workflow sometimes doesn't segfault
- add some additional output in the pipeline to help debug dependecy problems and upload an export of the final environment as artifact

I'll create a separate issues for fixing the dependencies, there's something pretty broken atm. But with the changes in this PR it should at least be possible to release a new working version so people don't have broken installations when installing/updating the AB.

Relates: #707 