### PR TITLE
Combine test jobs in github actions workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,9 +94,7 @@ jobs:
   deploy-development:
     # Make sure to only run a deploy if all tests pass.
     needs:
-      - test-linux
-      - test-macos
-      - test-windows
+      - tests
     # And only on a push event, not a pull_request.
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Upload final environment as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: env-${{ matrix.os }}-${{ matrix.python-version }}.yaml
+          name: env-${{ matrix.os }}-${{ matrix.python-version }}
           path: env.yaml
       - name: Install linux dependencies
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,7 @@ jobs:
           name: env-${{ matrix.os }}-${{ matrix.python-version }}.yaml
           path: env.yaml
       - name: Install linux dependencies
-        if: ${{ matrix.os == ubuntu-latest}}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
         run: |
           sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 \
@@ -71,17 +71,17 @@ jobs:
           1920x1200x24 -ac +extension GLX +render -noreset;
           conda install -q -y coveralls coverage pytest-cov
       - name: Run linux tests
-        if: ${{ matrix.os == ubuntu-latest}}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         env:
           QT_DEBUG_PLUGINS: 1
         run: |
           catchsegv xvfb-run --auto-servernum pytest --cov=activity_browser --cov-report=;
       - name: Run tests
-        if: ${{ matrix.os != ubuntu-latest}}
+        if: ${{ matrix.os != 'ubuntu-latest' }}
         run: |
           pytest
       - name: Upload coverage
-        if: ${{ matrix.python-version == '3.9' && matrix.os == ubuntu-latest }}
+        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
         # https://github.com/lemurheavy/coveralls-public/issues/1435#issuecomment-763357004
         # https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support
         # https://github.com/TheKevJames/coveralls-python/issues/252

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,11 +26,13 @@ jobs:
           name: patched-environment
           path: patched-environment.yml
 
-  test-macos:
-    runs-on: macos-latest
+  tests:
+    runs-on: ${{ matrix.os }}
     needs: patch-test-environment
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9]
     defaults:
       run:
@@ -41,7 +43,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: patched-environment
-      - name: Testing python ${{ matrix.python-version }}
+      - name: Setup python ${{ matrix.python-version }} conda environment
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -49,84 +51,17 @@ jobs:
           environment-file: patched-environment.yml
       - name: Environment info
         run: |
-          conda list -n test
-          conda env export -n test
-          conda env export -n test -f env-osx64.yaml
+          conda list
+          conda env export
+          conda env export -f env.yaml
       - name: Upload final environment as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: env-osx64.yaml
-          path: env-osx64.yaml
-      - name: Run tests
-        run: |
-          pytest
-
-  test-windows:
-    runs-on: windows-latest
-    needs: patch-test-environment
-    strategy:
-      matrix:
-        python-version: [3.8, 3.9]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download patched test environment
-        uses: actions/download-artifact@v2
-        with:
-          name: patched-environment
-      - name: Testing python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          activate-environment: test
-          environment-file: patched-environment.yml
-      - name: Environment info
-        run: |
-          conda list -n test
-          conda env export -n test
-          conda env export -n test -f env-win64.yaml
-      - name: Upload final environment as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: env-win64.yaml
-          path: env-win64.yaml
-      - name: Run tests
-        run: |
-          pytest
-
-  test-linux:
-    runs-on: ubuntu-latest
-    needs: patch-test-environment
-    strategy:
-      matrix:
-        python-version: [3.8, 3.9]
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download patched test environment
-        uses: actions/download-artifact@v2
-        with:
-          name: patched-environment
-      - name: Testing python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          activate-environment: test
-          environment-file: patched-environment.yml
-      # See https://stackoverflow.com/a/60694208/14506150
-      # and https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
-      - name: Environment info
-        run: |
-          conda list -n test
-          conda env export -n test
-          conda env export -n test -f env-linux64.yaml
-      - name: Upload final environment as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: env-linux64.yaml
-          path: env-linux64.yaml
+          name: env-${{ matrix.os }}-${{ matrix.python-version }}.yaml
+          path: env.yaml
       - name: Install linux dependencies
+        if: ${{ matrix.os == ubuntu-latest}}
+        # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
         run: |
           sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 \
             libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 \
@@ -134,16 +69,19 @@ jobs:
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid \
           --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 \
           1920x1200x24 -ac +extension GLX +render -noreset;
-      - name: Install coveralls dependencies
-        run: |
           conda install -q -y coveralls coverage pytest-cov
       - name: Run linux tests
+        if: ${{ matrix.os == ubuntu-latest}}
         env:
           QT_DEBUG_PLUGINS: 1
         run: |
           catchsegv xvfb-run --auto-servernum pytest --cov=activity_browser --cov-report=;
+      - name: Run tests
+        if: ${{ matrix.os != ubuntu-latest}}
+        run: |
+          pytest
       - name: Upload coverage
-        if: ${{ matrix.python-version == '3.8' }}
+        if: ${{ matrix.python-version == '3.9' && matrix.os == ubuntu-latest }}
         # https://github.com/lemurheavy/coveralls-public/issues/1435#issuecomment-763357004
         # https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support
         # https://github.com/TheKevJames/coveralls-python/issues/252


### PR DESCRIPTION
Previously we had separate jobs per operating systems in the tests workflow. This PR combines this into a single job, which reduces redundancies and makes it easier to maintain.

It also ensures that all tests are run, no matter if other os+py version combinations fail.

Additionally all environments used for testing are uploaded as workflow artifacts (`conda env export`) to help with debugging dependency problems.