### PR TITLE
Minor calculation setup updates

### DIFF
--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -146,11 +146,16 @@ class LCASetupTab(QtWidgets.QWidget):
         container.addLayout(calc_row)
         container.addWidget(horizontal_line())
 
-        cs_panel_layout.addWidget(header('Reference flows:'))
+        self.ref_flow_header = header('Reference flows:')
+        self.impact_cat_header = header('Impact categories:')
+        self.middle_split = horizontal_line()
+        self.no_setup_label = QtWidgets.QLabel("To do an LCA, create a new calculation setup first by pressing 'New'.")
+        cs_panel_layout.addWidget(self.ref_flow_header)
         cs_panel_layout.addWidget(self.activities_table)
-        cs_panel_layout.addWidget(horizontal_line())
-        cs_panel_layout.addWidget(header('Impact categories:'))
+        cs_panel_layout.addWidget(self.middle_split)
+        cs_panel_layout.addWidget(self.impact_cat_header)
         cs_panel_layout.addWidget(self.methods_table)
+        cs_panel_layout.addWidget(self.no_setup_label)
 
         self.cs_panel.setLayout(cs_panel_layout)
         container.addWidget(self.cs_panel)
@@ -264,11 +269,40 @@ class LCASetupTab(QtWidgets.QWidget):
         self.presamples.button.setEnabled(valid)
 
     def show_details(self, show: bool = True):
+        # show/hide items from name_row
         self.rename_cs_button.setVisible(show)
         self.delete_cs_button.setVisible(show)
+        self.copy_cs_button.setVisible(show)
         self.list_widget.setVisible(show)
+        # show/hide items from calc_row
+        if not show:
+            self.calculate_button.setVisible(show)
+            self.presamples.button.setVisible(show)
+            self.scenario_calc_btn.setVisible(show)
+            self.calculation_type.setVisible(show)
+            self.presamples.label.setVisible(show)
+            self.presamples.list.setVisible(show)
+            self.presamples.remove.setVisible(show)
+        else:
+            self.calculation_type.setVisible(show)
+            calc_type = self.calculation_type.currentText()
+            if calc_type == "Standard LCA":
+                self.calculate_button.setVisible(show)
+            elif calc_type == "Scenario LCA":
+                self.scenario_calc_btn.setVisible(show)
+            elif calc_type == "Presamples LCA":
+                self.presamples.button.setVisible(show)
+                self.presamples.label.setVisible(show)
+                self.presamples.list.setVisible(show)
+                self.presamples.remove.setVisible(show)
+
+        # show/hide other things
+        self.ref_flow_header.setVisible(show)
         self.activities_table.setVisible(show)
+        self.middle_split.setVisible(show)
+        self.impact_cat_header.setVisible(show)
         self.methods_table.setVisible(show)
+        self.no_setup_label.setVisible(not(show))
 
     @Slot(int, name="changeCalculationType")
     def select_calculation_type(self, index: int):

--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -146,16 +146,28 @@ class LCASetupTab(QtWidgets.QWidget):
         container.addLayout(calc_row)
         container.addWidget(horizontal_line())
 
-        self.ref_flow_header = header('Reference flows:')
-        self.impact_cat_header = header('Impact categories:')
-        self.middle_split = horizontal_line()
+        # widget for the reference flows
+        self.reference_flow_widget = QtWidgets.QWidget()
+        reference_flow_layout = QtWidgets.QVBoxLayout()
+        reference_flow_layout.addWidget(header('Reference flows:'))
+        reference_flow_layout.addWidget(self.activities_table)
+        self.reference_flow_widget.setLayout(reference_flow_layout)
+
+        # widget for the impact categories
+        self.impact_categories_widget = QtWidgets.QWidget()
+        impact_categories_layout = QtWidgets.QVBoxLayout()
+        impact_categories_layout.addWidget(header('Impact categories:'))
+        impact_categories_layout.addWidget(self.methods_table)
+        self.impact_categories_widget.setLayout(impact_categories_layout)
+
+        # splitter widget to combine the two above widgets
+        self.splitter = QtWidgets.QSplitter(Qt.Vertical)
+        self.splitter.addWidget(self.reference_flow_widget)
+        self.splitter.addWidget(self.impact_categories_widget)
+
         self.no_setup_label = QtWidgets.QLabel("To do an LCA, create a new calculation setup first by pressing 'New'.")
-        cs_panel_layout.addWidget(self.ref_flow_header)
-        cs_panel_layout.addWidget(self.activities_table)
-        cs_panel_layout.addWidget(self.middle_split)
-        cs_panel_layout.addWidget(self.impact_cat_header)
-        cs_panel_layout.addWidget(self.methods_table)
         cs_panel_layout.addWidget(self.no_setup_label)
+        cs_panel_layout.addWidget(self.splitter)
 
         self.cs_panel.setLayout(cs_panel_layout)
         container.addWidget(self.cs_panel)
@@ -296,12 +308,8 @@ class LCASetupTab(QtWidgets.QWidget):
                 self.presamples.list.setVisible(show)
                 self.presamples.remove.setVisible(show)
 
-        # show/hide other things
-        self.ref_flow_header.setVisible(show)
-        self.activities_table.setVisible(show)
-        self.middle_split.setVisible(show)
-        self.impact_cat_header.setVisible(show)
-        self.methods_table.setVisible(show)
+        # show/hide tables widgets
+        self.splitter.setVisible(show)
         self.no_setup_label.setVisible(not(show))
 
     @Slot(int, name="changeCalculationType")

--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -78,6 +78,7 @@ class CSActivityModel(CSGenericModel):
 
         signals.calculation_setup_selected.connect(self.sync)
         signals.databases_changed.connect(self.sync)
+        signals.database_changed.connect(self.check_activities)
         # after editing the model, signal that the calculation setup has changed.
         self.dataChanged.connect(lambda: signals.calculation_setup_changed.emit())
 
@@ -85,6 +86,11 @@ class CSActivityModel(CSGenericModel):
     def activities(self) -> list:
         selection = self._dataframe.loc[:, ["Amount", "key"]].to_dict(orient="records")
         return [{x["key"]: x["Amount"]} for x in selection]
+
+    def check_activities(self, db):
+        databases = [list(k.keys())[0][0] for k in self.activities]
+        if db in databases:
+            self.sync()
 
     def get_key(self, proxy: QModelIndex) -> tuple:
         idx = self.proxy_to_source(proxy)

--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -4,14 +4,67 @@ from typing import Iterable
 import brightway2 as bw
 from bw2data.backends.peewee import ActivityDataset
 import pandas as pd
-from PySide2.QtCore import QModelIndex, Slot
+import numpy as np
+from PySide2.QtCore import QModelIndex, Slot, Qt
 
 from activity_browser.bwutils import commontasks as bc
 from activity_browser.signals import signals
 from .base import EditablePandasModel, PandasModel
 
 
-class CSActivityModel(EditablePandasModel):
+class CSGenericModel(EditablePandasModel):
+    """ Intermediate class to enable internal move functionality for the
+    reference flows and impact categories tables. The below flags and relocate functions
+    are required to enable internal move.
+
+    Technically, CSMethodsModel is not editable, but as no editing delegates are set in the
+    tables, no editing is possible.
+    """
+
+    def flags(self, index):
+        """ Returns flags
+        """
+        if not index.isValid():
+            return super().flags(index) | Qt.ItemIsDropEnabled
+        if index.row() < len(self._dataframe):
+            return super().flags(index) | Qt.ItemIsDragEnabled
+        return super().flags(index)
+
+    def relocateRow(self, row_source, row_target) -> None:
+        """ Relocate a row.
+        Move a row in the table to another position and store the new dataframe
+        """
+        row_a, row_b = max(row_source, row_target), min(row_source, row_target)
+        self.beginMoveRows(QModelIndex(), row_a, row_a, QModelIndex(), row_b)
+        # copy data
+        data_source = self._dataframe.iloc[row_source].copy()
+        if row_source > row_target:  # the row needs to be moved up
+            pass
+            # delete old row
+            self._dataframe = self._dataframe.drop(row_source, axis=0).reset_index(drop=True)
+            # insert data
+            self._dataframe = pd.DataFrame(np.insert(self._dataframe.values,
+                                                     row_target,
+                                                     values=data_source,
+                                                     axis=0),
+                                           columns=self.HEADERS)
+        elif row_source < row_target:  # the row needs to be moved down
+            pass
+            # insert data
+            self._dataframe = pd.DataFrame(np.insert(self._dataframe.values,
+                                                     row_target,
+                                                     values=data_source,
+                                                     axis=0),
+                                           columns=self.HEADERS)
+            # delete old row
+            self._dataframe = self._dataframe.drop(row_source, axis=0).reset_index(drop=True)
+
+        self.updated.emit()
+        signals.calculation_setup_changed.emit()
+        self.endMoveRows()
+
+
+class CSActivityModel(CSGenericModel):
     HEADERS = [
         "Amount", "Unit", "Product", "Activity", "Location", "Database"
     ]
@@ -20,6 +73,9 @@ class CSActivityModel(EditablePandasModel):
         super().__init__(parent=parent)
         self.current_cs = None
         self.key_col = 0
+
+        self.HEADERS = self.HEADERS + ["key"]
+
         signals.calculation_setup_selected.connect(self.sync)
         signals.databases_changed.connect(self.sync)
         # after editing the model, signal that the calculation setup has changed.
@@ -46,7 +102,7 @@ class CSActivityModel(EditablePandasModel):
         df = pd.DataFrame([
             self.build_row(key, amount) for func_unit in fus
             for key, amount in func_unit.items()
-        ], columns=self.HEADERS + ["key"])
+        ], columns=self.HEADERS)
         # Drop rows where the fu key was invalid in some way.
         self._dataframe = df.dropna().reset_index(drop=True)
         self.key_col = self._dataframe.columns.get_loc("key")
@@ -59,7 +115,7 @@ class CSActivityModel(EditablePandasModel):
                 raise TypeError("Activity is not of type 'process'")
             row = {
                 key: act.get(bc.AB_names_to_bw_keys[key], "")
-                for key in self.HEADERS
+                for key in self.HEADERS[:-1]
             }
             row.update({"Amount": amount, "key": key})
             return row
@@ -87,7 +143,7 @@ class CSActivityModel(EditablePandasModel):
             signals.calculation_setup_changed.emit()
 
 
-class CSMethodsModel(PandasModel):
+class CSMethodsModel(CSGenericModel):
     HEADERS = ["Name", "Unit", "# CFs", "method"]
 
     def __init__(self, parent=None):

--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -98,6 +98,10 @@ class CSActivityModel(CSGenericModel):
 
     @Slot(str, name="syncModel")
     def sync(self, name: str = None):
+        if len(bw.calculation_setups) == 0:
+            self._dataframe = pd.DataFrame(columns=self.HEADERS)
+            self.updated.emit()
+            return
         if self.current_cs is None and name is None:
             raise ValueError("'name' cannot be None if no name is set")
         if name:


### PR DESCRIPTION
Fixes for minor calculation setup issues:
Let me know what you think of the below, mostly the Features are up to what you like -or not-. 

**Features:**
Vertical splitter: c248a3dd53920ca818c25966a5e54174e4677ccc
This adds a spliter between the `Reference flows:` and `Impact categories:` tables.
![image](https://user-images.githubusercontent.com/34626062/154490203-b9dd5414-8746-45e6-aa0b-e2e66485a47d.png)
![image](https://user-images.githubusercontent.com/34626062/154490268-739e177a-cdc7-41b8-8d4e-8f4630f0d0f5.png)
#532

 Reordering items: 00b2a66d182aff226b8378b765046231b961deab
(I cant screenshot things my mouse is holding, so no examples here)
This allows users to move reference flows or features around. When user holds `CTRL`, they can select multiple rows, which is useful for opening items or removing them from the calculation setup.
The new order is stored in BW Calculation setup, so this is also represented in the order of LCA results.
Additionally, this adds tooltips to both tables explaining the use of CTRL.
#571
#524 (Dont close issue: partial fix of issue)

Implement new display when no calc setups exist: d294df1b98001cb66bba4643398a74a09a4b5723
This adds a blank page with instructions to start a new setup, instead of the old empty `Reference flows:` and `Impact categories:` fields. 
Additionally, the `Copy` button is now also hidden.
![image](https://user-images.githubusercontent.com/34626062/154490760-58aff994-fd16-430f-8acf-090fbd91b516.png)
#620 

**Bugs:**
Problem with signals for activity changes not updating items in reference flow table: 83ca59fa19c8909f181461ad2405bbb7b967d737
#533

Edgecase bug with signals: 7a04b46d2f282fe75dd9fe5fb5ae12b570e53c75
#699
