### PR TITLE
Overhaul dependency pins

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: ['3.8', '3.9']
     defaults:
       run:
         shell: bash -l {0}

--- a/ci/recipe/stable/meta.yaml
+++ b/ci/recipe/stable/meta.yaml
@@ -21,25 +21,15 @@ requirements:
     - python
     - setuptools
   run:
-    - python >=3.8
-    - numpy >=1.20.2
+    - python >=3.8,<3.10
     - arrow
-    - brightway2 >=2.1.2
-    - bw2io >=0.8.6, <0.8.9
-    - bw2data >=3.6.1, <3.9.9
-    - bw2calc =1.8.0
-    - eidl >=1.3.2
-    - fuzzywuzzy
-    - matplotlib-base >=2.2.2
+    - brightway2 >=2.4.2
+    - eidl >=1.4
     - networkx
-    - pandas >=0.24.1
     - pyside2 >=5.13.1
     - salib >=1.4
-    - scipy <1.8  # due to scipy incompatibility with bw2calc <1.8.1
     - seaborn
     - presamples
-    - openpyxl
-    - xlrd <2.0  # https://github.com/brightway-lca/brightway2-io/issues/86
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser


### PR DESCRIPTION
Fixes #716 

There are still some issues with python 3.10 (not related to brightway2), I'll open a separate issue for that. I pinned to `python >=3.8,<3.10` for the time being.