### PR TITLE
Explicitly delete database parameters on database delete 

### DIFF
--- a/activity_browser/controllers/database.py
+++ b/activity_browser/controllers/database.py
@@ -121,6 +121,7 @@ class DatabaseController(QObject):
                 name, bc.count_database_records(name))
         )
         if ok == QtWidgets.QMessageBox.Yes:
+            signals.delete_database_confirmed.emit(name)
             project_settings.remove_db(name)
             del bw.databases[name]
             Group.delete().where(Group.name == name).execute()

--- a/activity_browser/signals.py
+++ b/activity_browser/signals.py
@@ -23,6 +23,7 @@ class Signals(QObject):
     # Database
     add_database = Signal()
     delete_database = Signal(str)
+    delete_database_confirmed = Signal(str)
     copy_database = Signal(str)
     install_default_data = Signal()
     import_database = Signal()


### PR DESCRIPTION
fix #823, #756 and #614
Adds additional signal to trigger explicit delete of parameters that belong to (activities in) a database. Previous parameter delete was unreliable and gave no errors when it failed, but broke all parameters until offending parameters were deleted manually.

**This PR needs testing by someone who understands parameters very well.**