### PR TITLE
Activity details tables keep show/hide state when activity is updated

### DIFF
--- a/activity_browser/ui/widgets/activity.py
+++ b/activity_browser/ui/widgets/activity.py
@@ -15,7 +15,7 @@ class DetailsGroupBox(QtWidgets.QGroupBox):
         self.widget = widget
         self.setCheckable(True)
         self.toggled.connect(self.showhide)
-        self.setChecked(False)
+        self.setChecked(True)
         self.setStyleSheet("QGroupBox { border: none; }")
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(widget)
@@ -34,10 +34,7 @@ class DetailsGroupBox(QtWidgets.QGroupBox):
 
     @QtCore.Slot(name="toggleEmptyTable")
     def toggle_empty_table(self) -> None:
-        # Workaround so that the downstream table is only toggled by users.
-        if self.title() == "Downstream Consumers:":
-            return
-        self.setChecked(bool(self.widget.rowCount()))
+        self.setChecked(bool(self.widget.rowCount() and self.isChecked()))
 
 
 class ActivityDataGrid(QtWidgets.QWidget):


### PR DESCRIPTION
fix #757
Activity tables used to revert to their original show/hide states (shows all tables with >0 entries and hide downstream consumers) when the activity was updated. Tables now keep their show/hide states when the activity is updated. 

This makes sense when for example working on technosphere flows when user has many biosphere flows and wants to keep the biosphere table hidden.