### PR TITLE
Enable Parameter comments + show/hide activity parameters table

### DIFF
--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -87,9 +87,18 @@ class ParameterDefinitionTab(BaseRightTab):
         self.database_header = header("Database:")
         self.new_database_param = QPushButton(qicons.add, "New")
         self.show_order = QCheckBox("Show order column", self)
-        self.show_database_params = QCheckBox("Show database parameters", self)
+        self.show_database_params = QCheckBox("Database parameters", self)
+        self.show_database_params.setToolTip("Show/hide the database parameters")
         self.show_database_params.setChecked(True)
-        self.uncertainty_columns = QCheckBox("Show uncertainty columns", self)
+        self.activity_header = header("Activity:")
+        self.show_activity_params = QCheckBox("Activity parameters", self)
+        self.show_activity_params.setToolTip("Show/hide the activity parameters")
+        self.show_activity_params.setChecked(True)
+        self.comment_column = QCheckBox("Comments", self)
+        self.comment_column.setToolTip("Show/hide the comment column")
+        self.hide_comment_column()
+        self.uncertainty_columns = QCheckBox("Uncertainty", self)
+        self.uncertainty_columns.setToolTip("Show/hide the uncertainty columns")
 
         self._construct_layout()
         self._connect_signals()
@@ -135,12 +144,19 @@ can be used within the formula!</p>
             lambda: signals.add_parameter.emit(("db", ""))
         )
         self.show_order.stateChanged.connect(self.activity_order_column)
-        self.uncertainty_columns.stateChanged.connect(
-            self.hide_uncertainty_columns
-        )
         self.show_database_params.toggled.connect(
             self.hide_database_parameter
         )
+        self.show_activity_params.toggled.connect(
+            self.hide_activity_parameter
+        )
+        self.comment_column.stateChanged.connect(
+            self.hide_comment_column
+        )
+        self.uncertainty_columns.stateChanged.connect(
+            self.hide_uncertainty_columns
+        )
+
 
     def _construct_layout(self):
         """ Construct the widget layout for the variable parameters tab
@@ -151,6 +167,8 @@ can be used within the formula!</p>
         row = QToolBar()
         row.addWidget(header("Parameters "))
         row.addWidget(self.show_database_params)
+        row.addWidget(self.show_activity_params)
+        row.addWidget(self.comment_column)
         row.addWidget(self.uncertainty_columns)
         row.addAction(
             qicons.question, "About brightway parameters",
@@ -174,7 +192,7 @@ can be used within the formula!</p>
         layout.addWidget(self.database_table)
 
         row = QHBoxLayout()
-        row.addWidget(header("Activity:"))
+        row.addWidget(self.activity_header)
         row.addWidget(self.show_order)
         row.addStretch(1)
         layout.addLayout(row)
@@ -202,6 +220,12 @@ can be used within the formula!</p>
             table.uncertainty_columns(show)
 
     @Slot()
+    def hide_comment_column(self):
+        show = self.comment_column.isChecked()
+        for table in self.tables.values():
+            table.comment_column(show)
+
+    @Slot()
     def activity_order_column(self) -> None:
         col = self.activity_table.model.order_col
         state = self.show_order.isChecked()
@@ -216,6 +240,12 @@ can be used within the formula!</p>
         self.database_header.setHidden(not toggled)
         self.new_database_param.setHidden(not toggled)
         self.database_table.setHidden(not toggled)
+
+    @Slot(bool)
+    def hide_activity_parameter(self, toggled: bool) -> None:
+        self.activity_header.setHidden(not toggled)
+        self.show_order.setHidden(not toggled)
+        self.activity_table.setHidden(not toggled)
 
 
 class ParameterExchangesTab(BaseRightTab):

--- a/activity_browser/ui/tables/models/parameters.py
+++ b/activity_browser/ui/tables/models/parameters.py
@@ -25,6 +25,7 @@ class BaseParameterModel(EditablePandasModel):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.param_col = 0
+        self.comment_col = 0
         self.dataChanged.connect(self.edit_single_parameter)
         signals.project_selected.connect(self.sync)
         signals.parameters_changed.connect(self.sync)
@@ -53,6 +54,7 @@ class BaseParameterModel(EditablePandasModel):
         data = getattr(parameter, "data", {})
         row.update(cls.extract_uncertainty_data(data))
         row["parameter"] = parameter
+        row["comment"] = data.get("comment", "")
         return row
 
     @classmethod
@@ -103,7 +105,7 @@ class BaseParameterModel(EditablePandasModel):
 
 
 class ProjectParameterModel(BaseParameterModel):
-    COLUMNS = ["name", "amount", "formula"]
+    COLUMNS = ["name", "amount", "formula", "comment"]
 
     def sync(self) -> None:
         data = [
@@ -111,6 +113,7 @@ class ProjectParameterModel(BaseParameterModel):
         ]
         self._dataframe = pd.DataFrame(data, columns=self.columns())
         self.param_col = self._dataframe.columns.get_loc("parameter")
+        self.comment_col = self._dataframe.columns.get_loc("comment")
         self.updated.emit()
 
     @staticmethod
@@ -127,7 +130,7 @@ class ProjectParameterModel(BaseParameterModel):
 
 
 class DatabaseParameterModel(BaseParameterModel):
-    COLUMNS = ["name", "amount", "formula", "database"]
+    COLUMNS = ["name", "amount", "formula", "database", "comment"]
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -140,6 +143,7 @@ class DatabaseParameterModel(BaseParameterModel):
         self._dataframe = pd.DataFrame(data, columns=self.columns())
         self.db_col = self._dataframe.columns.get_loc("database")
         self.param_col = self._dataframe.columns.get_loc("parameter")
+        self.comment_col = self._dataframe.columns.get_loc("comment")
         self.updated.emit()
 
     def get_key(self, proxy: QModelIndex = None) -> tuple:
@@ -180,7 +184,7 @@ class DatabaseParameterModel(BaseParameterModel):
 class ActivityParameterModel(BaseParameterModel):
     COLUMNS = [
         "name", "amount", "formula", "product", "activity", "location",
-        "group", "order", "key"
+        "group", "order", "key", "comment"
     ]
 
     def __init__(self, parent=None):
@@ -207,6 +211,7 @@ class ActivityParameterModel(BaseParameterModel):
         self.param_col = self._dataframe.columns.get_loc("parameter")
         self.key_col = self._dataframe.columns.get_loc("key")
         self.order_col = self._dataframe.columns.get_loc("order")
+        self.comment_col = self._dataframe.columns.get_loc("comment")
         self.updated.emit()
 
     @classmethod

--- a/activity_browser/ui/tables/parameters.py
+++ b/activity_browser/ui/tables/parameters.py
@@ -89,6 +89,13 @@ class BaseParameterTable(ABDataFrameView):
         proxy = next(p for p in self.selectedIndexes())
         self.model.remove_uncertainty(proxy)
 
+    def comment_column(self, show: bool):
+        self.setColumnHidden(self.model.comment_col, not show)
+
+        super().custom_view_sizing()
+        self.resizeColumnsToContents()
+        self.resizeRowsToContents()
+
 
 class ProjectParameterTable(BaseParameterTable):
     MODEL = ProjectParameterModel
@@ -100,10 +107,11 @@ class ProjectParameterTable(BaseParameterTable):
         # Set delegates for specific columns
         self.setItemDelegateForColumn(1, FloatDelegate(self))
         self.setItemDelegateForColumn(2, FormulaDelegate(self))
-        self.setItemDelegateForColumn(3, ViewOnlyUncertaintyDelegate(self))
+        self.setItemDelegateForColumn(3, StringDelegate(self))
+        self.setItemDelegateForColumn(4, ViewOnlyUncertaintyDelegate(self))
 
     def uncertainty_columns(self, show: bool):
-        for i in range(3, 9):
+        for i in range(4, 10):
             self.setColumnHidden(i, not show)
 
     @staticmethod
@@ -126,10 +134,12 @@ class DataBaseParameterTable(BaseParameterTable):
         self.setItemDelegateForColumn(1, FloatDelegate(self))
         self.setItemDelegateForColumn(2, FormulaDelegate(self))
         self.setItemDelegateForColumn(3, DatabaseDelegate(self))
-        self.setItemDelegateForColumn(4, ViewOnlyUncertaintyDelegate(self))
+        self.setItemDelegateForColumn(4, StringDelegate(self))
+        self.setItemDelegateForColumn(5, ViewOnlyUncertaintyDelegate(self))
+
 
     def uncertainty_columns(self, show: bool):
-        for i in range(4, 10):
+        for i in range(5, 11):
             self.setColumnHidden(i, not show)
 
     def get_key(self) -> tuple:
@@ -158,7 +168,8 @@ class ActivityParameterTable(BaseParameterTable):
         self.setItemDelegateForColumn(2, FormulaDelegate(self))
         self.setItemDelegateForColumn(6, StringDelegate(self))
         self.setItemDelegateForColumn(7, ListDelegate(self))
-        self.setItemDelegateForColumn(9, ViewOnlyUncertaintyDelegate(self))
+        self.setItemDelegateForColumn(9, StringDelegate(self))
+        self.setItemDelegateForColumn(10, ViewOnlyUncertaintyDelegate(self))
 
         # Set dropEnabled
         self.setDragDropMode(ABDataFrameView.DropOnly)
@@ -228,7 +239,7 @@ class ActivityParameterTable(BaseParameterTable):
             signals.open_activity_tab.emit(key)
 
     def uncertainty_columns(self, show: bool):
-        for i in range(9, 15):
+        for i in range(10, 16):
             self.setColumnHidden(i, not show)
 
     def get_key(self, proxy=None) -> tuple:

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -23,12 +23,12 @@ def test_table_uncertainty_delegate(qtbot, bw2test, monkeypatch):
     bw.parameters.new_project_parameters([{"name": "project_1", "amount": 1.0}], False)
     table.model.sync()
 
-    assert isinstance(table.itemDelegateForColumn(3), UncertaintyDelegate)
+    assert isinstance(table.itemDelegateForColumn(4), UncertaintyDelegate)
 
     delegate = UncertaintyDelegate(table)
     option = QtWidgets.QStyleOptionViewItem()
     option.rect = QtCore.QRect(0, 0, 100, 100)
-    index = table.proxy_model.index(0, 3)
+    index = table.proxy_model.index(0, 4)
     rect = table.visualRect(index)
     qtbot.mouseClick(table.viewport(), QtCore.Qt.LeftButton, pos=rect.center())
     editor = delegate.createEditor(table, option, index)


### PR DESCRIPTION
This commit enables comments for parameters  as requested in #774 and #455 and enables functionality to show/hide the activity parameters table (making it easier to read the database parameters table).

The comments are stored in the parameters and can be imported/exported from BW excel files.