### PR TITLE
Include pyperclip dependency for copy/paste in Linux

### DIFF
--- a/ci/recipe/stable/meta.yaml
+++ b/ci/recipe/stable/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python >=3.8,<3.10
     - arrow
     - brightway2 >=2.4.2
+    - pyperclip
     - eidl >=1.4.2
     - networkx
     - pyside2 >=5.13.1


### PR DESCRIPTION
Copying in Linux required installing Pyperclip, otherwise errors were
thrown when attempting to copy.

refs #802