### PR TITLE
Minimum height dbtable

### DIFF
--- a/activity_browser/layouts/tabs/project_manager.py
+++ b/activity_browser/layouts/tabs/project_manager.py
@@ -58,7 +58,6 @@ class ProjectTab(QtWidgets.QWidget):
         widgets = [self.databases_widget, self.activity_biosphere_widget]
         sizes = [x.sizeHint().height() for x in widgets]
         tabheight = self.height()
-        print(sizes, tabheight)
         if sum(sizes) > tabheight and sizes[1] > 0.75 * tabheight:
             sizes[0] = sizes[1] // 3
         self.splitter.setSizes(sizes)


### PR DESCRIPTION
Now, instead of purely relying on height hints, the Project tab will
give the databases/activities the recommended heights (as given by
height hints), unless that would not fit on the screen. If the total
does not fit the tab height, it instead assigns 1/4 of the height for
the databases table, and 3/4 of the height for the contents of the
database

refs #797