### PR TITLE
fix svg arrowhead urls (path end-markers)

### DIFF
--- a/activity_browser/static/javascript/navigator.js
+++ b/activity_browser/static/javascript/navigator.js
@@ -545,6 +545,12 @@ const cartographer = function() {
              // re-scale arrowheads to fit into edge (they become really big otherwise)
             markers = d3.selectAll("marker")
                 .attr("viewBox", "0 0 60 60");  // basically zoom out on the arrowhead
+
+            // fix arrowhead urls
+            d3.selectAll("path").attr("marker-end", function(data) {
+                if (!this.attributes["marker-end"]) return null;
+                else return "url(" + /url\(.*?(#.*?)\)/.exec(this.attributes["marker-end"].textContent)[1] + ")";
+            });
         }
     };
 


### PR DESCRIPTION
The edges in exported SVG sankey diagrams do currently not show arrowheads:

![Unbenannt](https://user-images.githubusercontent.com/52913510/188155687-4b486274-6128-4f32-a430-b3d04ea5eaab.PNG)

The error occurs because the `marker-end` attribute of the `path` references a HTML file, which is located in the install directory of the activity-browser. This file cannot be accessed from the browser due to security restrictions:

```svg
<path xmlns="http://www.w3.org/2000/svg" class="path" d="..." marker-end="url(file:///C:/Users/user/programs/miniconda/envs/ab_new/lib/site-packages/activity_browser/static/sankey_navigator.html#arrowhead224)" style="fill: none;"/>
```

```
Security Error: Content at file:///C:/some.svg may not load data from file:///C:/Users/user/programs/miniconda/envs/ab_new/lib/site-packages/activity_browser/static/sankey_navigator.html.
```

This PR fixes the issue by making sure that the attribute references the arrow definitions within the svg file:

```svg
<path xmlns="http://www.w3.org/2000/svg" class="path" d="..." marker-end="url(#arrowhead224)" style="fill: none;"/>
```

![Unbenannt](https://user-images.githubusercontent.com/52913510/188157005-bf85fc40-2ed8-495a-8674-781fdf9daa90.PNG)
