### PR TITLE
add database name to sankey reference flow dropdown

### DIFF
--- a/activity_browser/ui/web/sankey_navigator.py
+++ b/activity_browser/ui/web/sankey_navigator.py
@@ -197,7 +197,8 @@ class SankeyNavigatorWidget(BaseNavigatorWidget):
         ]
         self.methods = bw.calculation_setups[self.cs]['ia']
         self.func_unit_cb.clear()
-        self.func_unit_cb.addItems([repr(list(fu.keys())[0]) for fu in self.func_units])
+        fu_acts = [list(fu.keys())[0] for fu in self.func_units]
+        self.func_unit_cb.addItems([f"{repr(a)} | {a._data.get('database')}" for a in fu_acts])
         self.configure_scenario()
         self.method_cb.clear()
         self.method_cb.addItems([repr(m) for m in self.methods])


### PR DESCRIPTION
This PR adds the database name to the reference flow description in the sankey dropdown:

![grafik](https://user-images.githubusercontent.com/52913510/188468056-210c9434-e069-4db4-b1f9-909ae041538d.png)

The necessity for this is described in https://github.com/LCA-ActivityBrowser/activity-browser/issues/511