### PR TITLE
ensure method tree is updated when project is changed

### DIFF
--- a/activity_browser/ui/tables/models/impact_categories.py
+++ b/activity_browser/ui/tables/models/impact_categories.py
@@ -179,12 +179,16 @@ class MethodsTreeModel(BaseTreeModel):
 
         self.setup_model_data()
 
-        signals.project_selected.connect(self.sync)
+        signals.project_selected.connect(self.setup_and_sync)
         signals.new_method.connect(self.setup_model_data)
         signals.new_method.connect(self.filter_on_method)
 
     def flags(self, index):
         return super().flags(index) | Qt.ItemIsDragEnabled
+
+    def setup_and_sync(self) -> None:
+        self.setup_model_data()
+        self.sync()
 
     @Slot(name="clearSyncModel")
     @Slot(str, name="syncModel")


### PR DESCRIPTION
This PR fixes a bug in the Impact Categories Tree View model.

# Bug description

When having projects with different impact categories, AB's tree view does not correctly display the existing methods. Furthermore, adding methods to a calculation setup is not possible from the tree view after changing projects.

# Bug explanation and fix
Currently, the method tree is built *once* at the startup of the activity browser while the project `default` is loaded. The `tree_data` is never updated again. This is a problem because each project can have different methods. Therefore, `tree_data` should be updated each time the project is changed. 

# Notes
The problem does not occur in the list view because it's `sync` function calls `bw.methods` directly instead of relying on buffered data.