### PR TITLE
Fix #841 flow scenario bug

### DIFF
--- a/activity_browser/bwutils/superstructure/excel.py
+++ b/activity_browser/bwutils/superstructure/excel.py
@@ -72,12 +72,6 @@ def import_from_excel(document_path: Union[str, Path], import_sheet: int = 1):
         engine="openpyxl"
     )
     diff = SUPERSTRUCTURE.difference(data.columns)
-    # 'flow type' is not yet a required column
-    if "flow type" in diff:
-        print("Missing the 'flow type' column, ignoring for now.")
-        diff = diff.drop(["flow type"])
-        cols = data.columns.append(pd.Index(["flow type"]))
-        data = data.reindex(cols, axis="columns")
     if not diff.empty:
         raise ValueError("Missing required column(s) for superstructure: {}".format(diff.to_list()))
 


### PR DESCRIPTION
Fixes #841 

This PR fixes the issue where flow scenarios with both `production` and `technosphere` flows to and from the same key broke.
The solution is to check for `technosphere` flows to self and merge them with `production` flows to self -and in case `production didn't exist, to generate such a flow-. An example of a 'flow to self'  would be any market for electricity in ecoinvent, where the process has itself as input to represent an efficiency loss, e.g. producing 1kWh elec and using 0.02kWh from itself.

I've also changed some things around so it's now easier to add more 'formatting' functions like this one or `remove_duplicates` later on if that would ever be needed.

I'm including the database and scenario file I used for texting here too:
The scenario file has 3 tabs with different cases, all should run.
`no_pr` omits a `production` flow, which AB then fetches itself
`std` has both a `production` and `technosphere` flow
`rev` has the order of `production` and `technosphere` swapped for reading the file. This should give the same result as `std` `scen 1`.
[841_db.xlsx](https://github.com/LCA-ActivityBrowser/activity-browser/files/9692220/841_db.xlsx)
[841_test_scen.xlsx](https://github.com/LCA-ActivityBrowser/activity-browser/files/9692162/841_test_scen.xlsx)

@romainsacchi, if you have the time, could you pull this branch and test it with your problematic files? I created some tester files which all worked, but haven't tried with larger files. Could you also let us know if there is a large performance impact if the files are large? It's unavoidable we have to check every line to see whether they are a 'flow to self' so performance may be impacted in larger files.

@Zoophobus I hope the PR together with the issue description is clear. If neither Romain or you find issues then please merge, otherwise this will need to wait until after my holiday. -Or if you know how to fix things I may have done wrong in the PR also just go for it of course!-

