### PR TITLE
Fix for the issue #838 & direct management of excel files

### DIFF
--- a/activity_browser/bwutils/montecarlo.py
+++ b/activity_browser/bwutils/montecarlo.py
@@ -322,7 +322,7 @@ def perform_MonteCarlo_LCA(project='default', cs_name=None, iterations=10):
 
     # perform Monte Carlo simulation
     mc = MonteCarloLCA(cs_name)
-    mc.calculate(iterations=iterations) # FOR issue #850
+    mc.calculate(iterations=iterations)
     return mc
 
 

--- a/activity_browser/bwutils/montecarlo.py
+++ b/activity_browser/bwutils/montecarlo.py
@@ -322,7 +322,7 @@ def perform_MonteCarlo_LCA(project='default', cs_name=None, iterations=10):
 
     # perform Monte Carlo simulation
     mc = MonteCarloLCA(cs_name)
-    mc.calculate(iterations=iterations)
+    mc.calculate(iterations=iterations) # FOR issue #850
     return mc
 
 

--- a/activity_browser/bwutils/superstructure/excel.py
+++ b/activity_browser/bwutils/superstructure/excel.py
@@ -66,11 +66,12 @@ def import_from_excel(document_path: Union[str, Path], import_sheet: int = 1):
     'comment' is used to exclude specific rows from the excel document.
     """
     header_idx = get_header_index(document_path, import_sheet)
-    data = pd.read_excel(
-        document_path, sheet_name=import_sheet, header=header_idx,
-        usecols=valid_cols, comment="*", na_values="", keep_default_na=False,
-        engine="openpyxl"
-    )
+    with open(path,'rb') as xcl:
+        data = pd.read_excel(
+            document_path, sheet_name=import_sheet, header=header_idx,
+            usecols=valid_cols, comment="*", na_values="", keep_default_na=False,
+            engine="openpyxl"
+        )
     diff = SUPERSTRUCTURE.difference(data.columns)
     # 'flow type' is not yet a required column
     if "flow type" in diff:

--- a/activity_browser/layouts/main.py
+++ b/activity_browser/layouts/main.py
@@ -101,12 +101,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.stacked.currentWidget() != self.debug_widget:
             self.last_widget = self.stacked.currentWidget()
             self.stacked.setCurrentWidget(self.debug_widget)
-            # print("Switching to debug window")
+            print("Switching to debug window")
         else:
-            # print("Switching back to last widget")
+            print("Switching back to last widget")
             if self.last_widget:
                 try:
-                    self.stacked.setCurrentWidget(self.last_widget)
+                    self.stacked.setCurrentWidget(self.main_widget)
                 except:
                     print("Previous Widget has been deleted in the meantime. Switching to main window.")
                     self.stacked.setCurrentWidget(self.main_widget)

--- a/activity_browser/layouts/tabs/LCA_results_tab.py
+++ b/activity_browser/layouts/tabs/LCA_results_tab.py
@@ -26,7 +26,7 @@ class LCAResultsTab(ABTab):
         self.connect_signals()
 
     def connect_signals(self):
-        signals.lca_calculation.connect(self.generate_setup)
+        signals.lca_calculation.connect(self.generate_setup) # NEED TO FIND HOW THE DATA IS ADDED
         signals.delete_calculation_setup.connect(self.remove_setup)
         self.tabCloseRequested.connect(self.close_tab)
         signals.project_selected.connect(self.close_all)

--- a/activity_browser/layouts/tabs/LCA_results_tab.py
+++ b/activity_browser/layouts/tabs/LCA_results_tab.py
@@ -26,7 +26,7 @@ class LCAResultsTab(ABTab):
         self.connect_signals()
 
     def connect_signals(self):
-        signals.lca_calculation.connect(self.generate_setup) # NEED TO FIND HOW THE DATA IS ADDED
+        signals.lca_calculation.connect(self.generate_setup)
         signals.delete_calculation_setup.connect(self.remove_setup)
         self.tabCloseRequested.connect(self.close_tab)
         signals.project_selected.connect(self.close_all)

--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -439,7 +439,8 @@ class ScenarioImportWidget(QtWidgets.QWidget):
             except (IndexError, ValueError) as e:
                 # Try and read as parameter scenario file.
                 print("Superstructure: {}\nAttempting to read as parameter scenario file.".format(e))
-                df = pd.read_excel(path, sheet_name=idx, engine="openpyxl")
+                with open(path,'rb') as xcl:
+                    df = pd.read_excel(xcl, sheet_name=idx, engine="openpyxl")
                 include_default = True
                 if "default" not in df.columns:
                     query = QtWidgets.QMessageBox.question(

--- a/activity_browser/ui/menu_bar.py
+++ b/activity_browser/ui/menu_bar.py
@@ -79,14 +79,33 @@ class MenuBar(QtWidgets.QMenuBar):
 
     def update_windows_menu(self):
         """Clear and rebuild the menu for switching between tabs."""
-        self.windows_menu.clear()
-        for index in range(self.window.stacked.count()):  # iterate over widgets in QStackedWidget
-            widget = self.window.stacked.widget(index)
-            self.windows_menu.addAction(
-                widget.icon,
-                widget.name,
-                lambda: self.window.stacked.setCurrentWidget(widget),
+#        self.windows_menu.clear()
+        ## TODO This method doesn't work,
+        # it appears that the action is actually associated with the menu object
+        # not the object in the menu
+        main_window = self.window.stacked.widget(0)
+        self.windows_menu.addAction(
+            main_window.icon,
+            main_window.name,
+            lambda : self.window.stacked.setCurrentWidget(main_window)
             )
+        debug_window = self.window.stacked.widget(1)
+        self.windows_menu.addAction(
+            debug_window.icon,
+            debug_window.name,
+            lambda : self.window.stacked.setCurrentWidget(debug_window)
+            )
+        
+        
+        
+#        for index in range(self.window.stacked.count()):  # iterate over widgets in QStackedWidget
+#            widget = self.window.stacked.widget(index)
+#            print('{} - {}'.format(widget.name,index))
+#            self.windows_menu.addAction(
+#                widget.icon,
+#                widget.name,
+#                lambda: self.window.stacked.setCurrentWidget(widget),
+#            )
 
     def setup_help_menu(self) -> None:
         """Build the help menu for the menubar."""

--- a/activity_browser/ui/tables/delegates/formula.py
+++ b/activity_browser/ui/tables/delegates/formula.py
@@ -208,7 +208,7 @@ class FormulaDelegate(QtWidgets.QStyledItemDelegate):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-    def createEditor(self, parent, option, index):
+    def createEditor(self, parent, option, index) -> QtWidgets.QWidget:
         editor = QtWidgets.QWidget(parent)
         dialog = FormulaDialog(editor, QtCore.Qt.Window)
         dialog.accepted.connect(lambda: self.commitData.emit(editor))

--- a/activity_browser/ui/tables/models/base.py
+++ b/activity_browser/ui/tables/models/base.py
@@ -188,7 +188,7 @@ class BaseTreeModel(QAbstractItemModel):
     def columnCount(self, parent: QModelIndex = None, *args, **kwargs) -> int:
         return len(self.HEADERS)
 
-    def data(self, index, role: int = Qt.DisplayRole):
+    def data(self, index : QModelIndex, role: int = Qt.DisplayRole):
         if not index.isValid():
             return None
 
@@ -238,7 +238,7 @@ class BaseTreeModel(QAbstractItemModel):
         parent = parent.internalPointer() if parent.isValid() else self.root
         return parent.childCount()
 
-    def flags(self, index):
+    def flags(self, index : QModelIndex):
         if not index.isValid():
             return Qt.NoItemFlags
 


### PR DESCRIPTION
The two aspects of these changes are minor:

- The first addresses changes to issue #838 and partially addresses the issue #558. The main aspect of this issue, the failure to be able to switch back from the debug window, appears to arise from difficulties (or more accurately the complexity involved in ...) binding the actions to the forms. In this case a change in syntax appears to allow for the correct binding. The previous syntax is commented out to retain a record of the previous approach.

- The second aspect of this request involves changes to the excel importing, whereas previously importing excel sheets was entirely managed by the pandas library the approach promoted here involves the context managing `with` statement. This is to ensure that the file streams are closed and that user manipulation of files is not interfered with by the AB. These changes are committed in the `superstructure/excel.py` and `layouts/tabs/LCA_setup.py` modules, other cases may yet exist in the code.