### PR TITLE
Build and upload activity-browser-arm with github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -132,3 +132,49 @@ jobs:
           anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --force \
           /usr/share/miniconda/envs/build/conda-bld/noarch/*.tar.bz2
           anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload ci/conda-envs/ab_dev.yml
+
+
+  deploy-arm:
+    # Make sure to only run a deploy if all tests pass.
+    needs:
+      - tests
+    # And only on a push event, not a pull_request.
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      PKG_NAME: "activity-browser-arm"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and deploy 3.8
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.8
+          activate-environment: build
+          environment-file: ci/conda-envs/build.yml
+      - name: Export version
+        run: |
+          echo "VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
+      - name: Patch recipe with run requirements from stable
+        uses: mikefarah/yq@master
+        # Adds the run dependencies from the stable recipe to the arm recipe
+        # drop brightway2, but add brightway2_nosolver and scikit-umfpack
+        # Also adds the dependecies to the ab_arm environment file
+        with:
+          cmd: |
+            yq e '.requirements.run.[] | select(. != "brightway2*") | [.]' ci/recipe/stable/meta.yaml > arm_requirements.yaml
+            yq e -i '. += ["brightway2_nosolver", "scikit-umfpack"]' arm_requirements.yaml
+            yq eval-all -i 'select(fi == 0).requirements.run += select(fi == 1) | select(fi == 0)' ci/recipe/arm/meta.yaml arm_requirements.yaml
+            yq eval-all -i 'select(fi == 0).dependencies += select(fi == 1) | select(fi == 0)' ci/conda-envs/ab_arm.yml arm_requirements.yaml
+      - name: Show patched arm recipe
+        run: cat ci/recipe/arm/meta.yaml
+      - name: Build development package
+        run: |
+          conda build ci/recipe/arm
+      - name: Upload the activity-browser-arm package and env
+        run: |
+          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --force \
+          /usr/share/miniconda/envs/build/conda-bld/noarch/*.tar.bz2
+          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload ci/conda-envs/ab_arm.yml

--- a/ci/conda-envs/ab_arm.yml
+++ b/ci/conda-envs/ab_arm.yml
@@ -1,0 +1,7 @@
+name: ab_arm
+channels:
+  - conda-forge
+  - bsteubing
+  - cmutel
+dependencies:
+  - activity-browser-arm

--- a/ci/recipe/arm/meta.yaml
+++ b/ci/recipe/arm/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: activity-browser-arm
+  version: "{{ os.environ.get('VERSION', 'dev') }}"
+
+source:
+  path: ../../..
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt"
+  script_env:
+    - PKG_NAME
+    - VERSION
+  entry_points:
+    - activity-browser = activity_browser:run_activity_browser
+    - activity-browser-cleanup = activity_browser.bwutils:cleanup
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:  # dependencies are added via github action from ci/recipe/stable/meta.yaml
+
+about:
+  home: https://github.com/LCA-ActivityBrowser/activity-browser
+  license: LGPL3+
+  license_family: LGPL
+  license_file: LICENSE.txt
+  summary: "{{ os.environ.get('SUMMARY', 'Development version of the Activity Browser') }}"
+  description: |
+    The Activity Browser is a graphical user interface for the [brightway2](https://brightway.dev/)
+    advanced life cycle assessment framework. More details and installation instructions can be found
+    on [github](https://github.com/LCA-ActivityBrowser/activity-browser).
+    This is the development version. For the stable release install the `activity-browser` package.


### PR DESCRIPTION
The PR adds the the required steps in the github actions to build and upload the activity-browser-arm package. It is based on the development version of the AB, i.e. it is uploaded together with the development version. In my opinion this is makes more sense than basing it on stable, because otherwise we'd have to make a new stable release everytime there's a dependency problem for arm.

This is not strictly required yet, as there is https://anaconda.org/cmutel/activity-browser-arm. But it automates the release and then @cmutel doesn't have to manually build a new version for activity-browser-arm. See also #874
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
