### PR TITLE
Fix: worflow fails due to external libraries

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 \
             libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 \
-            libxcb-xfixes0 xvfb x11-utils;
+            libxcb-xfixes0 xvfb x11-utils glibc-tools;
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid \
           --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 \
           1920x1200x24 -ac +extension GLX +render -noreset;

--- a/ci/recipe/stable/meta.yaml
+++ b/ci/recipe/stable/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pyperclip
     - eidl >=1.4.2
     - networkx
-    - pyside2 >=5.13.1
+    - pyside2 >=5.15.5
     - salib >=1.4
     - seaborn
 


### PR DESCRIPTION
Two problems fixed :

- missing catchsegv dependency in ubuntu-22.04
- missing libQt5WebEngineWidgets in pyside2-5.15.6 last conda update

The second one should be temporary as I expect this to be solved in a future pyside2 update on conda.