### PR TITLE
Small fixes to correct the placement of the ignore_index argument req…

### DIFF
--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -148,7 +148,7 @@ class CSActivityModel(CSGenericModel):
             k, v = zip(*fu.items())
             data.append(self.build_row(k[0], v[0]))
         if data:
-            self._dataframe = pd.concat([self._dataframe,pd.DataFrame(data, ignore_index=True)])
+            self._dataframe = pd.concat([self._dataframe,pd.DataFrame(data)], ignore_index=True)
             self.updated.emit()
             signals.calculation_setup_changed.emit()
 
@@ -198,7 +198,7 @@ class CSMethodsModel(CSGenericModel):
         old_methods = set(self.methods)
         data = [self.build_row(m) for m in new_methods if m not in old_methods]
         if data:
-            self._dataframe = pd.concat([self._dataframe, pd.DataFrame(data, ignore_index=True)])
+            self._dataframe = pd.concat([self._dataframe, pd.DataFrame(data)], ignore_index=True)
             self.updated.emit()
             signals.calculation_setup_changed.emit()
 


### PR DESCRIPTION
…uired for the pandas.concat method. From the fix to avoid using the deprecated pandas.DataFrame.append method (issue #709). This also includes a fix to the ContributionModel code to drop the "Rest" category when these values sum to zero (Issue #635), previously this was also including some text based inputs, now this should be avoided.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
