### PR TITLE
Minor changes in ActivityTab __init__ routine

### DIFF
--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -485,7 +485,6 @@ class InventoryTab(NewAnalysisTab):
         self.clear_tables()
         super().update_tab()
 
-
     def elementary_flows_contributing_to_IA_methods(self, contributary: bool = True, bios: pd.DataFrame = None) -> pd.DataFrame:
         """Returns a biosphere dataframe filtered for the presence in the impact assessment methods
         Requires a boolean argument for whether those flows included in the impact assessment method

--- a/activity_browser/layouts/tabs/activity.py
+++ b/activity_browser/layouts/tabs/activity.py
@@ -112,8 +112,6 @@ class ActivityTab(QtWidgets.QWidget):
         )
         self.toggle_activity_description_visibility()
 
-        self.db_read_only_changed(db_name=self.db_name, db_read_only=self.db_read_only)
-
         # Reveal/hide uncertainty columns
         self.checkbox_uncertainty = QtWidgets.QCheckBox("Uncertainty")
         self.checkbox_uncertainty.setToolTip("Show/hide the uncertainty columns")
@@ -137,10 +135,6 @@ class ActivityTab(QtWidgets.QWidget):
         toolbar.addWidget(self.checkbox_uncertainty)
         toolbar.addWidget(self.checkbox_comment)
 
-
-        # activity-specific data displayed and editable near the top of the tab
-        self.activity_data_grid = ActivityDataGrid(read_only=self.read_only, parent=self)
-
         # 4 data tables displayed after the activity data
         self.production = ProductExchangeTable(self)
         self.technosphere = TechnosphereExchangeTable(self)
@@ -154,6 +148,10 @@ class ActivityTab(QtWidgets.QWidget):
             ("Downstream Consumers:", self.downstream),
         ]
         self.grouped_tables = [DetailsGroupBox(l, t) for l, t in self.exchange_tables]
+
+        # activity-specific data displayed and editable near the top of the tab
+        self.activity_data_grid = ActivityDataGrid(read_only=self.read_only, parent=self)
+        self.db_read_only_changed(db_name=self.db_name, db_read_only=self.db_read_only)
 
         # arrange activity data and exchange data into vertical layout
         layout = QtWidgets.QVBoxLayout()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->
This features minor corrections to the changes for issue #597. These changes correct the order of execution for object initialization that would previously fail because of two variables `exchange_tables` and `activity_data_grid`.
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
