### PR TITLE
Adding user ability to resize the space allocated to the activity exchange tables

### DIFF
--- a/activity_browser/layouts/tabs/activity.py
+++ b/activity_browser/layouts/tabs/activity.py
@@ -159,9 +159,11 @@ class ActivityTab(QtWidgets.QWidget):
         layout.addWidget(toolbar)
         layout.addWidget(self.activity_data_grid)
         layout.addWidget(self.activity_description)
+        grouped_tables = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        # TODO Include a Qt.QSplitter object for allowing users to redefine the space between tables
         for group_box in self.grouped_tables:
-            layout.addWidget(group_box)
-
+            grouped_tables.addWidget(group_box)
+        layout.addWidget(grouped_tables)
         self.exchange_tables_read_only_changed()
 
         layout.addStretch()

--- a/activity_browser/layouts/tabs/activity.py
+++ b/activity_browser/layouts/tabs/activity.py
@@ -166,7 +166,7 @@ class ActivityTab(QtWidgets.QWidget):
         layout.addWidget(grouped_tables)
         self.exchange_tables_read_only_changed()
 
-        layout.addStretch()
+#        layout.addStretch() # Commented out so that the grouped_tables splitter can utilize the entire window
         layout.setAlignment(QtCore.Qt.AlignTop)
         self.setLayout(layout)
 


### PR DESCRIPTION
Related to the issue #758 on the splitters for the activity exchange tables

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
