### PR TITLE
Adding the user ability to adjust the heights of the different parameter tables

### DIFF
--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -283,7 +283,7 @@ can be used within the formula!</p>
         tables.addWidget(self.activity_table)
 
         layout.addWidget(tables)
-        layout.addStretch(1)
+#        layout.addStretch(1)
         self.setLayout(layout)
 
     @Slot(name="rebuildParameterTables")
@@ -291,7 +291,7 @@ can be used within the formula!</p>
         """ Read parameters from brightway and build dataframe tables
         """
         self.hide_uncertainty_columns()
-#        self.activity_order_column()
+        self.activity_order_column()
         # Cannot create database parameters without databases
         if not bw.databases:
             self.database_table.set_enabled(False)
@@ -309,27 +309,27 @@ can be used within the formula!</p>
         show = self.comment_column.isChecked()
         for table in self.tables.values():
             table.comment_column(show)
-#
-#    @Slot()
-#    def activity_order_column(self) -> None:
-#        col = self.activity_table.model.order_col
-#        state = self.show_order.isChecked()
-#        if not state:
-#            self.activity_table.setColumnHidden(col, True)
-#        else:
-#            self.activity_table.setColumnHidden(col, False)
-#            self.activity_table.resizeColumnToContents(col)
+
+    @Slot()
+    def activity_order_column(self) -> None:
+        col = self.activity_table.get_table().model.order_col
+        state = self.activity_table.parameter.isChecked()
+        if not state:
+            self.activity_table.get_table().setColumnHidden(col, True)
+        else:
+            self.activity_table.get_table().setColumnHidden(col, False)
+            self.activity_table.get_table().resizeColumnToContents(col)
 
     @Slot(bool, name="hideDatabaseParameterTable")
     def hide_database_parameter(self, toggled: bool) -> None:
-#        self.database_header.setHidden(not toggled)
-#        self.database_table.se.setHidden(not toggled)
+        self.database_header.setHidden(not toggled)
+        self.database_table.se.setHidden(not toggled)
         self.database_table.setHidden(not toggled)
 
     @Slot(bool)
     def hide_activity_parameter(self, toggled: bool) -> None:
-#        self.activity_header.setHidden(not toggled)
-#        self.show_order.setHidden(not toggled)
+        self.activity_header.setHidden(not toggled)
+        self.show_order.setHidden(not toggled)
         self.activity_table.setHidden(not toggled)
 
 

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -328,12 +328,14 @@ can be used within the formula!</p>
         self.database_table.header.setHidden(not toggled)
         self.database_table.newParameter.setHidden(not toggled)
         self.database_table.table.setHidden(not toggled)
+        self.database_table.setHidden(not toggled)
 
     @Slot(bool)
     def hide_activity_parameter(self, toggled: bool) -> None:
         self.activity_table.header.setHidden(not toggled)
         self.activity_table.parameter.setHidden(not toggled)
         self.activity_table.table.setHidden(not toggled)
+        self.activity_table.setHidden(not toggled)
 
 
 class ParameterExchangesTab(BaseRightTab):

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -63,10 +63,13 @@ class ABParameterTable(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.table = None
+        self.header = None
 
     def create_layout(self, title: str = None, bttn: QAbstractButton = None, table: BaseParameterTable = None):
         headerLayout = QHBoxLayout()
-        headerLayout.addWidget(header(title))
+        self.header = header(title)
+
+        headerLayout.addWidget(self.header)
         headerLayout.addWidget(bttn)
         headerLayout.addStretch(1)
 
@@ -322,15 +325,15 @@ can be used within the formula!</p>
 
     @Slot(bool, name="hideDatabaseParameterTable")
     def hide_database_parameter(self, toggled: bool) -> None:
-        self.database_header.setHidden(not toggled)
-        self.database_table.se.setHidden(not toggled)
-        self.database_table.setHidden(not toggled)
+        self.database_table.header.setHidden(not toggled)
+        self.database_table.newParameter.setHidden(not toggled)
+        self.database_table.table.setHidden(not toggled)
 
     @Slot(bool)
     def hide_activity_parameter(self, toggled: bool) -> None:
-        self.activity_header.setHidden(not toggled)
-        self.show_order.setHidden(not toggled)
-        self.activity_table.setHidden(not toggled)
+        self.activity_table.header.setHidden(not toggled)
+        self.activity_table.parameter.setHidden(not toggled)
+        self.activity_table.table.setHidden(not toggled)
 
 
 class ParameterExchangesTab(BaseRightTab):

--- a/activity_browser/ui/tables/__init__.py
+++ b/activity_browser/ui/tables/__init__.py
@@ -7,7 +7,7 @@ from .inventory import ActivitiesBiosphereTable, DatabasesTable
 from .lca_results import ContributionTable, InventoryTable, LCAResultsTable
 from .LCA_setup import CSActivityTable, CSList, CSMethodsTable, ScenarioImportTable
 from .parameters import (ActivityParameterTable, DataBaseParameterTable,
-                         ExchangesTable, ProjectParameterTable)
+                         ExchangesTable, ProjectParameterTable, BaseParameterTable)
 from .projects import ProjectListWidget
 from .scenarios import ScenarioTable
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -101,10 +101,10 @@ def test_create_database_params(qtbot):
     table = project_db_tab.database_table.get_table()
 
     # Open the database foldout
-    assert not table.isHidden()
+    assert not project_db_tab.database_table.isHidden()
     with qtbot.waitSignal(project_db_tab.show_database_params.stateChanged, timeout=1000):
         qtbot.mouseClick(project_db_tab.show_database_params, QtCore.Qt.LeftButton)
-    assert table.isHidden()
+    assert project_db_tab.database_table.isHidden()
     project_db_tab.show_database_params.toggle()
 
     # Generate a few database parameters
@@ -159,7 +159,7 @@ def test_delete_database_params(qtbot):
     project_db_tab = ParameterDefinitionTab()
     qtbot.addWidget(project_db_tab)
     project_db_tab.build_tables()
-    table = project_db_tab.database_table
+    table = project_db_tab.database_table.get_table()
 
     # Check that we can delete the parameter and remove it.
     proxy = table.proxy_model.index(1, 0)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -25,7 +25,7 @@ def test_create_project_param(qtbot):
     project_db_tab = ParameterDefinitionTab()
     qtbot.addWidget(project_db_tab)
     project_db_tab.build_tables()
-    table = project_db_tab.project_table
+    table = project_db_tab.project_table.get_table()
 
     bw.parameters.new_project_parameters([
         {"name": "param_1", "amount": 1.0},
@@ -98,7 +98,7 @@ def test_create_database_params(qtbot):
     project_db_tab = ParameterDefinitionTab()
     qtbot.addWidget(project_db_tab)
     project_db_tab.build_tables()
-    table = project_db_tab.database_table
+    table = project_db_tab.database_table.get_table()
 
     # Open the database foldout
     assert not table.isHidden()
@@ -195,7 +195,7 @@ def test_create_activity_param(qtbot):
     project_db_tab = ParameterDefinitionTab()
     qtbot.addWidget(project_db_tab)
     project_db_tab.build_tables()
-    table = project_db_tab.activity_table
+    table = project_db_tab.activity_table.get_table()
 
     # Open the order column just because we can
     col = table.model.order_col
@@ -298,7 +298,7 @@ def test_open_activity_tab(qtbot, ab_app):
 
     # Select an activity
     tab = param_tab.tabs["Definitions"]
-    table = tab.activity_table
+    table = tab.activity_table.get_table()
     rect = table.visualRect(table.proxy_model.index(0, 3))
     qtbot.mouseClick(table.viewport(), QtCore.Qt.LeftButton, pos=rect.center())
 
@@ -319,7 +319,7 @@ def test_delete_activity_param(qtbot):
     project_db_tab = ParameterDefinitionTab()
     qtbot.addWidget(project_db_tab)
     project_db_tab.build_tables()
-    table = project_db_tab.activity_table
+    table = project_db_tab.activity_table.get_table()
 
     rect = table.visualRect(table.proxy_model.index(0, 0))
     qtbot.mouseClick(table.viewport(), QtCore.Qt.LeftButton, pos=rect.center())

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -200,8 +200,8 @@ def test_create_activity_param(qtbot):
     # Open the order column just because we can
     col = table.model.order_col
     assert table.isColumnHidden(col)
-    with qtbot.waitSignal(project_db_tab.activity_table.parameter.show_order.stateChanged, timeout=1000):
-        qtbot.mouseClick(project_db_tab.activity_table.parameter.show_order, QtCore.Qt.LeftButton)
+    with qtbot.waitSignal(project_db_tab.activity_table.parameter.stateChanged, timeout=1000):
+        qtbot.mouseClick(project_db_tab.activity_table.parameter, QtCore.Qt.LeftButton)
     assert not table.isColumnHidden(col)
 
     # Create multiple parameters for a single activity

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -200,8 +200,8 @@ def test_create_activity_param(qtbot):
     # Open the order column just because we can
     col = table.model.order_col
     assert table.isColumnHidden(col)
-    with qtbot.waitSignal(project_db_tab.show_order.stateChanged, timeout=1000):
-        qtbot.mouseClick(project_db_tab.show_order, QtCore.Qt.LeftButton)
+    with qtbot.waitSignal(project_db_tab.activity_table.parameter.show_order.stateChanged, timeout=1000):
+        qtbot.mouseClick(project_db_tab.activity_table.parameter.show_order, QtCore.Qt.LeftButton)
     assert not table.isColumnHidden(col)
 
     # Create multiple parameters for a single activity


### PR DESCRIPTION
Users can define the amount of vertical space assigned to presenting the activity, database and project tables
as per issue #475
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [X] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [X] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
