### PR TITLE
Bug 607 - fixes to changes made to managing multiple brightway environments

### DIFF
--- a/activity_browser/bwutils/commontasks.py
+++ b/activity_browser/bwutils/commontasks.py
@@ -82,7 +82,8 @@ def update_and_shorten_label(label, text, length=15, enable=True) -> None:
 
 # Switch brightway directory
 def switch_brightway2_dir(dirpath):
-    if dirpath == bw.projects._base_data_dir:
+    bw_base = bw.projects._base_data_dir
+    if dirpath == bw_base:
         print('dirpath already loaded')
         return False
     try:

--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -106,10 +106,14 @@ class ProjectController(QObject):
             self.window,
             'Confirm project deletion',
             ("Are you sure you want to delete project '{}'? It has {} databases" +
-             " and {} LCI methods").format(
+             " and {} LCI methods.\n\n" +
+             "Note the actual data will not be removed from the hard disk.\n" +
+             "Delete dir: {}\n" +
+             "To delete the data from your hard disk.").format(
                 bw.projects.current,
                 len(bw.databases),
-                len(bw.methods)
+                len(bw.methods),
+                bw.projects.dir
             )
         )
         if reply == QtWidgets.QMessageBox.Yes:

--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -47,14 +47,15 @@ class ProjectController(QObject):
         the current project.
         """
 #        assert name, "No project name given."
+        name = "default" if not name else name
         if name not in bw.projects:
-            print("Project does not exist: {}".format(name))
-            return
+            print("Project does not exist: {}, creating!".format(name))
+            bw.projects.create_project(name)
 
         if name != bw.projects.current or reload:
             bw.projects.set_current(name)
-            signals.project_selected.emit()
-            print("Loaded project:", name)
+        signals.project_selected.emit()
+        print("Loaded project:", name)
 
     @Slot(name="createProject")
     def new_project(self, name=None):

--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -46,7 +46,7 @@ class ProjectController(QObject):
         """Change the project, this clears all tabs and metadata related to
         the current project.
         """
-        assert name, "No project name given."
+#        assert name, "No project name given."
         if name not in bw.projects:
             print("Project does not exist: {}".format(name))
             return

--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -138,7 +138,7 @@ class ABSettings(BaseSettings):
         project = self.settings.get(
             "startup_project", self.get_default_project_name()
         )
-        if project or project not in bw.projects:
+        if project and project not in bw.projects:
             project = self.get_default_project_name()
         return project
 

--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -138,7 +138,7 @@ class ABSettings(BaseSettings):
         project = self.settings.get(
             "startup_project", self.get_default_project_name()
         )
-        if project not in bw.projects:
+        if project or project not in bw.projects:
             project = self.get_default_project_name()
         return project
 

--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -72,7 +72,6 @@ class ABSettings(BaseSettings):
         with the old settings file and can be removed in a future release
         """
         file = os.path.join(directory, filename)
-        json_settings = None
         if not os.path.exists(file):
             package_dir = Path(__file__).resolve().parents[1]
             old_settings = os.path.join(package_dir, "ABsettings.json")

--- a/activity_browser/ui/wizards/settings_wizard.py
+++ b/activity_browser/ui/wizards/settings_wizard.py
@@ -33,8 +33,9 @@ class SettingsWizard(QtWidgets.QWizard):
             print("Saved startup brightway directory as: ", custom_bw_dir)
 
         # project
+        field_project = self.field("startup_project")
         current_startup_project = ab_settings.startup_project
-        if self.field('startup_project') != current_startup_project:
+        if self.field('startup_project') and self.field('startup_project') != current_startup_project:
             new_startup_project = self.field('startup_project')
             ab_settings.startup_project = new_startup_project
             print("Saved startup project as: ", new_startup_project)
@@ -166,7 +167,7 @@ class SettingsPage(QtWidgets.QWizardPage):
                 self.bwdir_name.setText(path)
                 self.registerField('current_bw_dir', self.bwdir_name)
                 self.combobox_add_dir(self.bwdir, path)
-                ab_settings.current_bw_dir = path
+#                ab_settings.current_bw_dir = path
                 ab_settings.startup_project = ""
                 self.bwdir.blockSignals(True)
                 self.bwdir.setCurrentText(self.bwdir_name.text())
@@ -184,13 +185,14 @@ class SettingsPage(QtWidgets.QWizardPage):
             if reply == QtWidgets.QMessageBox.Yes:
                 self.bwdir_name.setText(path)
                 self.registerField('current_bw_dir', self.bwdir_name)
-                ab_settings.current_bw_dir = path
+#                ab_settings.current_bw_dir = path
                 self.update_project_combo()
             else:
                 prev_env_index = self.bwdir.findText(self.bwdir_name.text(), QtCore.Qt.MatchFixedString)
                 self.bwdir.blockSignals(True)
                 self.bwdir.setCurrentIndex(prev_env_index)
                 self.bwdir.blockSignals(False)
+                self.changed()
 
     def update_project_combo(self):
         """
@@ -202,12 +204,13 @@ class SettingsPage(QtWidgets.QWizardPage):
             self.startup_project_combobox.addItems(self.project_names)
         else:
             print("Warning: No projects found in this directory.")
-            return
+#            return
         if ab_settings.startup_project in self.project_names:
             self.startup_project_combobox.setCurrentText(ab_settings.startup_project)
         else:
             ab_settings.startup_project = ""
             self.startup_project_combobox.setCurrentIndex(-1)
+        self.changed()
 
 
     def combobox_add_dir(self, box: QtWidgets.QComboBox, path: str) -> None:

--- a/activity_browser/ui/wizards/settings_wizard.py
+++ b/activity_browser/ui/wizards/settings_wizard.py
@@ -140,9 +140,22 @@ class SettingsPage(QtWidgets.QWizardPage):
         ab_settings.remove_custom_bw_dir(removed_dir)
 
     def bwdir_change(self, path: str):
+        """
+        Executes on emission of a signal from changes to the QComboBox holding bw2 environments
+        Scope: Limited to
+            SettingsPage class - can create new environments and bw.projects (exceptions are permitted), will update
+                contents of the Project QComboBox
+            settings::ABSettings - uses but doesn't set bw2 variables, sets variables in the settings file
+        """
         self.change_bw_dir(path)
 
     def bwdir_browse(self):
+        """
+        Executes on emission of a signal from the browse button
+        Scope: Limited to
+            SettingsPage class - provides a file path as a string to the QComboBox holding
+                bw2 environments
+        """
         path = QtWidgets.QFileDialog.getExistingDirectory(
             self, "Select a brightway2 database folder"
         )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->
Issue #607 was related to making changes to the AB so that it would be easier to change between different bw2 environments

These changes are stored using the ABsettings.json file that now contains three elements
- a default environment
- a list of different environments
- a default project

These changes to the ABsettings file were fine, however with the automatic loading procedures of bw2 this led to some issues as bw2 environments "require" a valid project in order for these to be loaded. This led to the case of the user changing the environment successfully, but still being provided with the bw2 settings being used to load an alternative environment including projects.

The procedure for creating an environment is now relatively "simplified" and includes the possibility of unsetting the default project variable


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
