### PR TITLE
Issue 565

### DIFF
--- a/activity_browser/signals.py
+++ b/activity_browser/signals.py
@@ -53,6 +53,8 @@ class Signals(QObject):
     # Activity editing
     edit_activity = Signal(str)  # db_name
     activity_modified = Signal(tuple, str, object)
+    relink_activity = Signal(tuple)
+
 
     # Exchanges
     exchanges_deleted = Signal(list)

--- a/activity_browser/ui/tables/activity.py
+++ b/activity_browser/ui/tables/activity.py
@@ -39,7 +39,6 @@ class BaseExchangeTable(ABDataFrameView):
         self.copy_exchanges_for_SDF_action = QtWidgets.QAction(
             qicons.superstructure, "Exchanges for scenario difference file", None
         )
-
         self.key = getattr(parent, "key", None)
         self.model = self.MODEL(self.key, self)
         self.downstream = False
@@ -63,6 +62,7 @@ class BaseExchangeTable(ABDataFrameView):
         )
         self.model.updated.connect(self.update_proxy_model)
         self.model.updated.connect(self.custom_view_sizing)
+
 
     @Slot(name="resizeView")
     def custom_view_sizing(self) -> None:

--- a/activity_browser/ui/tables/inventory.py
+++ b/activity_browser/ui/tables/inventory.py
@@ -119,7 +119,6 @@ class ActivitiesBiosphereTable(ABFilterableDataFrameView):
         self.copy_exchanges_for_SDF_action = QtWidgets.QAction(
             qicons.superstructure, "Exchanges for scenario difference file", None
         )
-
         self.connect_signals()
 
     @property
@@ -147,6 +146,10 @@ class ActivitiesBiosphereTable(ABFilterableDataFrameView):
         menu.addAction(self.duplicate_activity_action)
         menu.addAction(self.delete_activity_action)
         menu.addAction(
+            qicons.edit, "Relink the activity exchanges",
+            self.relink_activity_exchanges
+        )
+        menu.addAction(
             qicons.duplicate_to_other_database, "Duplicate to other database",
             self.duplicate_activities_to_db
         )
@@ -162,7 +165,6 @@ class ActivitiesBiosphereTable(ABFilterableDataFrameView):
 
     def connect_signals(self):
         signals.database_read_only_changed.connect(self.update_activity_table_read_only)
-
         self.new_activity_action.triggered.connect(
             lambda: signals.new_activity.emit(self.database_name)
         )
@@ -195,6 +197,11 @@ class ActivitiesBiosphereTable(ABFilterableDataFrameView):
         for key in (self.model.get_key(p) for p in self.selectedIndexes()):
             signals.safe_open_activity_tab.emit(key)
             signals.add_activity_to_history.emit(key)
+
+    @Slot(name="relinkActivityExchanges")
+    def relink_activity_exchanges(self) -> None:
+        for key in (self.model.get_key(a) for a in self.selectedIndexes()):
+            signals.relink_activity.emit(key)
 
     @Slot(name="deleteActivities")
     def delete_activities(self) -> None:

--- a/activity_browser/ui/widgets/__init__.py
+++ b/activity_browser/ui/widgets/__init__.py
@@ -7,7 +7,8 @@ from .database_copy import CopyDatabaseDialog
 from .dialog import (
     ForceInputDialog, TupleNameDialog, ExcelReadDialog,
     DatabaseLinkingDialog, DefaultBiosphereDialog,
-    DatabaseLinkingResultsDialog, ProjectDeletionDialog
+    DatabaseLinkingResultsDialog, ActivityLinkingDialog,
+    ActivityLinkingResultsDialog, ProjectDeletionDialog
 )
 from .line_edit import (SignalledPlainTextEdit, SignalledComboEdit,
                         SignalledLineEdit)

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -277,7 +277,6 @@ class DatabaseLinkingResultsDialog(QtWidgets.QDialog):
     some of the exchanges in the database fail to be linked to the new
     database.
     Up to five of the unlinked activities are printed on the screen,
-    TODO Provide links so that the activities can be opened
 
     """
     def __init__(self, parent=None):
@@ -327,6 +326,135 @@ class DatabaseLinkingResultsDialog(QtWidgets.QDialog):
 
     def open_activity(self):
         return self.activityToOpen
+
+
+class ActivityLinkingDialog(QtWidgets.QDialog):
+    """
+    Displays the possible databases for relinking the exchanges for a given activity
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Activity linking")
+
+        self.db_label = QtWidgets.QLabel()
+        self.label_choices = []
+        self.grid_box = QtWidgets.QGroupBox("Database links:")
+        self.grid = QtWidgets.QGridLayout()
+        self.grid_box.setLayout(self.grid)
+
+        self.buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
+        )
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.db_label)
+        layout.addWidget(self.grid_box)
+        layout.addWidget(self.buttons)
+        self.setLayout(layout)
+
+    @property
+    def relink(self) -> dict:
+        """Returns a dictionary of str -> str key/values, showing which keys
+        should be linked to which values.
+
+        Only returns key/value pairs if they differ.
+        """
+        return {
+            label.text(): combo.currentText() for label, combo in self.label_choices
+            if label.text() != combo.currentText()
+        }
+
+    @property
+    def links(self) -> dict:
+        """Returns a dictionary of str -> str key/values, showing which keys
+        should be linked to which values.
+        """
+        return {
+            label.text(): combo.currentText() for label, combo in self.label_choices
+        }
+
+    @classmethod
+    def construct_dialog(cls, label: str, options: List[Tuple[str, List[str]]],
+                         parent: QtWidgets.QWidget = None) -> 'ActivityLinkingDialog':
+        obj = cls(parent)
+        obj.db_label.setText(label)
+        # Start at 1 because row 0 is taken up by the db_label
+        for i, item in enumerate(options):
+            label = QtWidgets.QLabel(item[0])
+            combo = QtWidgets.QComboBox()
+            combo.addItems(item[1])
+            combo.setCurrentText(item[0])
+            obj.label_choices.append((label, combo))
+            obj.grid.addWidget(label, i, 0, 1, 2)
+            obj.grid.addWidget(combo, i, 2, 1, 2)
+        obj.updateGeometry()
+        return obj
+
+    @classmethod
+    def relink_sqlite(cls, act: str, options: List[Tuple[str, List[str]]],
+                      parent=None) -> 'ActivityLinkingDialog':
+        label = "Relinking exchanges from activity '{}'.".format(act)
+        return cls.construct_dialog(label, options, parent)
+
+
+class ActivityLinkingResultsDialog(QtWidgets.QDialog):
+    """
+    Provides a summary from a relinking of activity exchanges for the relinking of a
+    single activity.
+    A simple design layout based on the DatabaseLinkingResultsDialog
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setWindowTitle("Relinking database results")
+
+        button = QtWidgets.QDialogButtonBox.Ok
+        self.buttonBox = QtWidgets.QDialogButtonBox(button)
+        self.buttonBox.accepted.connect(self.accept)
+        self.databases_relinked = QtWidgets.QVBoxLayout()
+
+        self.activityToOpen = set()
+
+        self.exchangesUnlinked = QtWidgets.QVBoxLayout()
+
+        self.layout = QtWidgets.QVBoxLayout()
+        self.layout.addLayout(self.databases_relinked)
+        self.layout.addLayout(self.exchangesUnlinked)
+        self.layout.addWidget(self.buttonBox)
+        self.setLayout(self.layout)
+
+    @classmethod
+    def construct_results_dialog(cls, parent: QtWidgets.QWidget = None, link_results: dict = None,
+                                 unlinked_exchanges: dict = None) -> 'ActivityLinkingResultsDialog':
+        obj = cls(parent)
+        for k, results in link_results.items():
+            obj.databases_relinked.addWidget(QtWidgets.QLabel(f"{k} = {results[1]} successfully linked"))
+            obj.databases_relinked.addWidget(QtWidgets.QLabel(f"{k} = {results[0]} flows failed to link"))
+
+        obj.exchangesUnlinked.addWidget(QtWidgets.QLabel("Up to 5 unlinked exchanges (click to open)"))
+        for act, key in unlinked_exchanges.items():
+            button = QtWidgets.QPushButton(act.as_dict()['name'])
+            button.clicked.connect(lambda: signals.unsafe_open_activity_tab.emit(act.key))
+            obj.exchangesUnlinked.addWidget(button)
+        obj.updateGeometry()
+
+        return obj
+
+    @classmethod
+    def present_relinking_results(cls, parent: QtWidgets.QWidget = None, link_results: dict = None,
+                                  unlinked_exchanges: dict = None) -> 'ActivityLinkingResultsDialog':
+        return cls.construct_results_dialog(parent, link_results, unlinked_exchanges)
+
+    def select_activity_to_open(self, actvty: tuple) -> None:
+        if actvty in self.activityToOpen:
+            self.activityToOpen.discard(actvty)
+        self.activityToOpen.add(actvty)
+
+    def open_activity(self):
+        return self.activityToOpen
+
 
 class DefaultBiosphereDialog(QtWidgets.QProgressDialog):
     def __init__(self, parent=None):


### PR DESCRIPTION
This PR deals with adding additional relinking functionality, allowing users to relink the activity exchanges per activity. (Issue #565)

Changes in the Strategies:
- Added two new functions relink_exchanges and relink_activity_exchanges
    - relink_activity_exchanges handles the relinking from individual activities
    - relink_exchanges handles the actual relinking done in the relink_activity_exchanges and relink_exchanges_existing_db  Changes in Dialogs
- Added two new QDialog classes for Activity linking: ActivityLinkingResultsDialog and  ActivityLinkingDialog
- Used in ActivityController in a new relink_activity_exchange method

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
