### PR TITLE
Fix duplicate entries when copying with multiple columns selected

### DIFF
--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -103,7 +103,15 @@ class BaseExchangeModel(EditablePandasModel):
 
     @Slot(list, name="copyFlowInformation")
     def copy_exchanges_for_SDF(self, proxies: list) -> None:
-        exchanges = [self.get_exchange(p) for p in proxies]
+        exchanges = []
+        prev = None
+        for p in proxies:
+            e = self.get_exchange(p)
+            if e is prev:
+                continue  # exact duplicate entry into clipboard
+            prev = e
+            exchanges.append(e)
+            print(exchanges)
         data = bc.get_exchanges_in_scenario_difference_file_notation(exchanges)
         df = pd.DataFrame(data)
         df.to_clipboard(excel=True, index=False)


### PR DESCRIPTION
The issue was that self.selectedIndexes() returned a list of duplicate entries, whenever multiple columns were selected.
Simply checking if an entry was the same as the previous one is able to filter out these duplicates.

This fixes issue #806.

Note that, since duplicates are always consecutive, there is no need to check `if e in exchanges` in general. This makes the code more efficient, and also evades the issue that the `==` operator between two exchanges is not implemented (whereas checking object (pointer) equality using the `is` operator does work). Since the `in` operator uses `==` to check if something is in a list, we can't simply use `in`.