### PR TITLE
Issue 920

### DIFF
--- a/activity_browser/bwutils/montecarlo.py
+++ b/activity_browser/bwutils/montecarlo.py
@@ -54,7 +54,6 @@ class MonteCarloLCA(object):
         # previously: self.rev_method_index = {v: k for k, v in self.method_index.items()}
         # self.rev_method_index = {v: k for k, v in self.method_index.items()}
 
-        # todo: get rid of the below
         self.func_unit_translation_dict = {str(bw.get_activity(list(func_unit.keys())[0])): func_unit
                                            for func_unit in self.func_units}
         if len(self.func_unit_translation_dict) != len(self.func_units):

--- a/activity_browser/bwutils/strategies.py
+++ b/activity_browser/bwutils/strategies.py
@@ -122,14 +122,12 @@ def relink_exchanges(exchanges: list, candidates: dict, duplicates: dict) -> tup
             transaction.rollback()
     return (remainder, altered, unlinked_exchanges)
 
-
 def relink_exchanges_existing_db(db: bw.Database, old: str, other: bw.Database) -> tuple:
     """Relink exchanges after the database has been created/written.
 
     This means possibly doing a lot of sqlite update calls.
     """
     if old == other.name:
-        print("No point relinking to same database.")
         return
     assert db.backend == "sqlite", "Relinking only allowed for SQLITE backends"
     assert other.backend == "sqlite", "Relinking only allowed for SQLITE backends"
@@ -160,14 +158,12 @@ def relink_exchanges_existing_db(db: bw.Database, old: str, other: bw.Database) 
 
 def relink_activity_exchanges(act, old: str, other: bw.Database) -> tuple:
     if old == other.name:
-        print("No point relinking to same database.")
         return
     db = bw.Database(act.key[0])
     assert db.backend == "sqlite", "Relinking only allowed for SQLITE backends"
     assert other.backend == "sqlite", "Relinking only allowed for SQLITE backends"
 
     duplicates, candidates = {}, {}
-
     for ds in other:
         key = activity_hash(ds, DEFAULT_FIELDS)
         if key in candidates:

--- a/activity_browser/bwutils/superstructure/file_imports.py
+++ b/activity_browser/bwutils/superstructure/file_imports.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from abc import ABC, abstractmethod
 import pandas as pd
+import ast
+
 from .utils import _time_it_
 from typing import Optional, Union
 from ..errors import (
@@ -142,6 +144,8 @@ class ABFeatherImporter(ABFileImporter):
     def read_file(path: Optional[Union[str, Path]], **kwargs):
         df = pd.read_feather(path)
         # ... execute code
+        for i in ['to key', 'from key']:
+            df.loc[:, i] = df.loc[:, i].apply(ast.literal_eval)
         return df
 
 
@@ -155,6 +159,6 @@ class ABCSVImporter(ABFileImporter):
             separator = kwargs['separator']
         else:
             separator = ";"
-        df = pd.read_csv(path, compression='infer', sep=separator, index_col=False)
+        df = pd.read_csv(path, compression='infer', sep=separator, index_col=False, converters={'from key': ast.literal_eval, 'to key': ast.literal_eval})
         # ... execute code
         return df

--- a/activity_browser/ui/figures.py
+++ b/activity_browser/ui/figures.py
@@ -251,12 +251,11 @@ class MonteCarloPlot(Plot):
 
     def plot(self, df: pd.DataFrame, method: tuple):
         self.ax.clear()
-
-        for col in df.columns:
+        for col in range(len(df.columns)):
             color = self.ax._get_lines.get_next_color()
-            df[col].hist(ax=self.ax, figure=self.figure, label=col, density=True, color=color, alpha=0.5)  # , histtype="step")
+            df.iloc[:, col].hist(ax=self.ax, figure=self.figure, label=df.columns[col], density=True, color=color, alpha=0.5)  # , histtype="step")
             # self.ax.axvline(df[col].median(), color=color)
-            self.ax.axvline(df[col].mean(), color=color)
+            self.ax.axvline(df.iloc[:, col].mean(), color=color)
 
         self.ax.set_xlabel(bw.methods[method]["unit"])
         self.ax.set_ylabel('Probability')

--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -142,9 +142,8 @@ class CSActivityModel(CSGenericModel):
         signals.calculation_setup_changed.emit()  # Trigger update of CS in brightway
 
     def include_activities(self, new_activities: Iterable) -> None:
-        existing = set(self._dataframe.loc[:, "key"])
         data = []
-        for fu in (f for f in new_activities if existing.isdisjoint(f)):
+        for fu in (f for f in new_activities):
             k, v = zip(*fu.items())
             data.append(self.build_row(k[0], v[0]))
         if data:


### PR DESCRIPTION
#920 

This PR should pull the calculation stage of the AB closer to that of brightway. The changes result in the user being able to add the same activity multiple times to the calculation setup, including with the same "production amount". This alteration also includes the corresponding knock on alterations in the code base for user interactivity throughout the results section.

Changes include:
 - alterations to the CS table and model
 - alterations to the data structures holding the keys and indexes for the pandas dataframes storing the calculation results
 - alterations to the routines for further analysis (Monte Carlo)

Note:
Please clone the fork [@Zoophobus/activity-browser](https://github.com/Zoophobus/activity-browser/tree/issue_920) and use the issue_920 branch for reviewing the interface to test for bugs
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
