### PR TITLE
Fix: broken dependencie glibc

### DIFF
--- a/ci/recipe/stable/meta.yaml
+++ b/ci/recipe/stable/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - pyperclip
     - eidl >=1.4.2
     - networkx
-    - pyside2 >=5.15.5
-    - qt-webengine >=5.15.4
+    - pyside2 =5.15.5
+    - qt-webengine =5.15.4
     - numpy =1.23.5
     - salib >=1.4
     - seaborn


### PR DESCRIPTION
pyside and qt-webengine last version break glibc compatibility when installing conda package:

```
The following specifications were found to be incompatible with your system:

  - feature:/linux-64::__glibc==2.31=0
  - feature:|@/linux-64::__glibc==2.31=0
  - activity-browser -> pyside2[version='>=5.15.5'] -> __glibc[version='>=2.17,<3.0.a0']
```

Freezing versions solves the problem.

I am not sure if this could be considered a satisfactory solution but at the moment it is not possible to download AB so a patch should be pushed one way or another. 
I have not tested which version create the problem (between 5.15.5 and last one 5.15.8).