### PR TITLE
Fix: QtWebEngine on arch linux and nixos (see #946)

### DIFF
--- a/activity_browser/__init__.py
+++ b/activity_browser/__init__.py
@@ -21,6 +21,9 @@ if QSysInfo.productType() == "osx":
         os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-gpu"
         print("Info: GPU hardware acceleration disabled")
 
+if QSysInfo.productType() in ["arch","nixos"]:
+    os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--no-sandbox"
+    print("Info: QtWebEngine sandbox disabled")
 
 def run_activity_browser():
     qapp = QApplication(sys.argv)


### PR DESCRIPTION
Fix QWebEngine pages (Welcom and Sankey diagrams) not showing up on Arch Linux and Nixos (see #946).