### PR TITLE
Add pipeline to test dependency resolution every 24h

### DIFF
--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -1,4 +1,4 @@
-name: tests and development release
+name: canary installation
 on:
   schedule:
     # Run the tests once every 24 hours to catch dependency problems early

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   canary-installs:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -1,0 +1,39 @@
+name: tests and development release
+on:
+  schedule:
+    # Run the tests once every 24 hours to catch dependency problems early
+    - cron: '0 7 * * *'
+  push:
+    branches:
+      - install-canary
+
+jobs:
+  canary-installs:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9']
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Setup python ${{ matrix.python-version }} conda environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install activity-browser
+        run: |
+          conda create -y -n ab -c conda-forge activity-browser python=${{ matrix.python-version }}
+      - name: Environment info
+        run: |
+          conda activate ab
+          conda list
+          conda env export
+          conda env export -f env.yaml
+      - name: Upload final environment as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: env-${{ matrix.os }}-${{ matrix.python-version }}
+          path: env.yaml


### PR DESCRIPTION
This PR adds a github action pipeline that creates a conda environment according to the AB installation instructions every 24 hours. This a kind of early warning system which alerts when the conda dependency solver fails. It also helps in cases like #953 so developers don't have to manually run the installation on different operating systems.

You can check the pipeline in my personal fork: https://github.com/haasad/activity-browser/actions/runs/4575760502
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
