### PR TITLE
Small updates to the loading and removal of plugins within the plugin…

### DIFF
--- a/activity_browser/controllers/plugin.py
+++ b/activity_browser/controllers/plugin.py
@@ -62,15 +62,22 @@ class PluginController(QObject):
         # Close plugin tabs
         self.close_plugin_tabs(self.plugins[name])
 
-    def add_plugin(self, name):
+    def add_plugin(self, name, select: bool = True):
         """ add or reload tabs of the given plugin
         """
-        plugin = self.plugins[name]
-        # Apply pluin load() function
-        plugin.load()
-        # Add plugins tabs
-        for tab in plugin.tabs:
-            self.window.add_tab_to_panel(tab, plugin.infos["name"], tab.panel)
+        if select:
+            plugin = self.plugins[name]
+            # Apply plugin load() function
+            plugin.load()
+            # Add plugins tabs
+            for tab in plugin.tabs:
+                self.window.add_tab_to_panel(tab, plugin.infos["name"], tab.panel)
+            return
+        print("Removing plugin {}".format(name))
+        # Apply plugin remove() function
+        self.plugins[name].remove()
+        # Close plugin tabs
+        self.close_plugin_tabs(self.plugins[name])
 
     def close_plugin_tabs(self, plugin):
         for panel in (self.window.left_panel, self.window.right_panel):

--- a/activity_browser/layouts/main.py
+++ b/activity_browser/layouts/main.py
@@ -113,6 +113,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Keyboard shortcuts
         self.shortcut_debug = QtWidgets.QShortcut(QtGui.QKeySequence("Ctrl+D"), self)
         self.shortcut_debug.activated.connect(self.toggle_debug_window)
+        signals.restore_cursor.connect(self.restore_user_control)
 
     def toggle_debug_window(self):
         """Toggle the bottom debug window"""
@@ -152,3 +153,6 @@ class MainWindow(QtWidgets.QMainWindow):
             QtWidgets.QMessageBox.No
         )
         return response == QtWidgets.QMessageBox.Yes
+
+    def restore_user_control(self):
+        QtWidgets.QApplication.restoreOverrideCursor()

--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -275,11 +275,17 @@ class ProjectSettings(BaseSettings):
         iterator = self.settings.get("read-only-databases", {}).items()
         return (name for name, ro in iterator if not ro and name != "biosphere3")
 
-    def add_plugin(self, name: str):
+    def add_plugin(self, name: str, select: bool = True):
         """ Add a plugin to settings
         """
-        self.settings["plugins_list"].append(name)
-        self.write_settings()
+        if select:
+            self.settings["plugins_list"].append(name)
+            self.write_settings()
+            return
+        if name in self.settings["plugins_list"]:
+            self.settings["plugins_list"].remove(name)
+            self.write_settings()
+
 
     def remove_plugin(self, name: str) -> None:
         """ When a plugin is deselected from a project, remove it from settings

--- a/activity_browser/signals.py
+++ b/activity_browser/signals.py
@@ -114,6 +114,7 @@ class Signals(QObject):
     # Qt Windows
     update_windows = Signal()
     new_statusbar_message = Signal(str)
+    restore_cursor = Signal()
 
     # Tabs
     toggle_show_or_hide_tab = Signal(str)
@@ -125,7 +126,7 @@ class Signals(QObject):
     metadata_changed = Signal(tuple)  # key
 
     # Plugins
-    plugin_selected = Signal(str)
+    plugin_selected = Signal(str, bool)
     plugin_deselected = Signal(str)
     manage_plugins = Signal()
 

--- a/activity_browser/ui/tables/plugins.py
+++ b/activity_browser/ui/tables/plugins.py
@@ -37,18 +37,18 @@ class PluginsTable(ABDataFrameView):
             proxy = self.indexAt(e.pos())
             if proxy.column() == 0:
                 new_value = not bool(proxy.data())  
-                plugin_name = self.model.get_plugin_name(proxy) #
+#                plugin_name = self.model.get_plugin_name(proxy)
                 if not new_value:
                     msgBox = QMessageBox()
                     msgBox.setText("Remove plugin from project ?")
-                    msgBox.setInformativeText("This will removed all data created by the plugin.")
+                    msgBox.setInformativeText("This will remove all data created by the plugin.")
                     msgBox.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
                     msgBox.setDefaultButton(QMessageBox.Cancel)
                     ret = msgBox.exec_()
                     if ret == QMessageBox.Cancel:
                         new_value = not new_value
-                self.model.sync(proxy, new_value) # TODO check this usage it is currently employed to ensure synchronization
-        super().mousePressEvent(e) # TODO but this may not be required
+                self.model.sync(proxy, new_value)
+        super().mousePressEvent(e)
 
     @property
     def selected_plugin(self) -> str:

--- a/activity_browser/ui/tables/plugins.py
+++ b/activity_browser/ui/tables/plugins.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from PySide2 import QtWidgets, QtCore
 from PySide2.QtWidgets import QMessageBox
+import pandas
 
 from ...signals import signals
 from .delegates import CheckboxDelegate
@@ -36,23 +37,24 @@ class PluginsTable(ABDataFrameView):
             proxy = self.indexAt(e.pos())
             if proxy.column() == 0:
                 new_value = not bool(proxy.data())  
-                plugin_name = self.model.get_plugin_name(proxy)
-                if new_value:
-                    signals.plugin_selected.emit(plugin_name)
-                else:
+                plugin_name = self.model.get_plugin_name(proxy) #
+                if not new_value:
                     msgBox = QMessageBox()
                     msgBox.setText("Remove plugin from project ?")
                     msgBox.setInformativeText("This will removed all data created by the plugin.")
                     msgBox.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
                     msgBox.setDefaultButton(QMessageBox.Cancel)
                     ret = msgBox.exec_()
-                    if ret == QMessageBox.Ok:
-                        signals.plugin_deselected.emit(plugin_name)
-                self.model.sync()
-        super().mousePressEvent(e)
+                    if ret == QMessageBox.Cancel:
+                        new_value = not new_value
+                self.model.sync(proxy, new_value) # TODO check this usage it is currently employed to ensure synchronization
+        super().mousePressEvent(e) # TODO but this may not be required
 
     @property
     def selected_plugin(self) -> str:
         """ Return the plugin name of the user-selected index.
         """
         return self.model.get_plugin_name(self.currentIndex())
+
+    def selected_plugins(self) -> pandas.DataFrame:
+        return self.model.selected()


### PR DESCRIPTION
… wizard. Internally the plugins are no longer loaded within the environment of the wizard, but on closing the window. This also contains the corresponding changes to reflect the time when control is reverted back to the user once the plugins have been (un)loaded.

Corresponds to the issue #993 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
