### PR TITLE
Table updates (double click)

### DIFF
--- a/activity_browser/ui/tables/activity.py
+++ b/activity_browser/ui/tables/activity.py
@@ -42,9 +42,14 @@ class BaseExchangeTable(ABDataFrameView):
         self.key = getattr(parent, "key", None)
         self.model = self.MODEL(self.key, self)
         self.downstream = False
+        self.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers |
+                             QtWidgets.QAbstractItemView.DoubleClicked)
         self._connect_signals()
 
     def _connect_signals(self):
+        self.doubleClicked.connect(
+            lambda: self.model.edit_cell(self.currentIndex())
+        )
         self.delete_exchange_action.triggered.connect(
             lambda: self.model.delete_exchanges(self.selectedIndexes())
         )

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -71,6 +71,13 @@ class BaseExchangeModel(EditablePandasModel):
         exchange = self.get_exchange(proxy)
         return exchange.input.key
 
+    def edit_cell(self, proxy: QModelIndex) -> None:
+        col = proxy.column()
+        if self._dataframe.columns[col] in {'Uncertainty', 'pedigree', 'loc', 'scale',
+                                            'shape', 'minimum', 'maximum'}:
+            self.modify_uncertainty(proxy)
+
+
     @Slot(list, name="deleteExchanges")
     def delete_exchanges(self, proxies: list) -> None:
         """ Remove all of the selected exchanges from the activity."""

--- a/activity_browser/ui/tables/models/parameters.py
+++ b/activity_browser/ui/tables/models/parameters.py
@@ -103,6 +103,13 @@ class BaseParameterModel(EditablePandasModel):
         param = self.get_parameter(proxy)
         signals.parameter_uncertainty_modified.emit(param, uc.EMPTY_UNCERTAINTY)
 
+    def handle_double_click(self, proxy: QModelIndex) -> None:
+        column = proxy.column()
+        if self._dataframe.columns[column] in BaseParameterModel.UNCERTAINTY:
+            self.modify_uncertainty(proxy)
+        elif self._dataframe.columns[column] == 'name':
+            self.handle_parameter_rename(proxy)
+
 
 class ProjectParameterModel(BaseParameterModel):
     COLUMNS = ["name", "amount", "formula", "comment"]

--- a/activity_browser/ui/tables/parameters.py
+++ b/activity_browser/ui/tables/parameters.py
@@ -23,7 +23,9 @@ class BaseParameterTable(ABDataFrameView):
         self.setSelectionMode(ABDataFrameView.SingleSelection)
 
         self.model = self.MODEL(self)
-
+        self.doubleClicked.connect(
+            lambda: self.model.handle_double_click(self.currentIndex())
+        )
         self.delete_action = QAction(qicons.delete, "Delete parameter", None)
         self.delete_action.triggered.connect(
             lambda: self.model.delete_parameter(self.currentIndex())


### PR DESCRIPTION
Updates the response to use of the double click for table editing. Provides responses to uncertainty as specified in #570 and for the parameter tables. With the changes made to the Impact categories the extension of double click functionality is extended across all major tables within the AB #999.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
