### PR TITLE
Corrections to allow the dynamic importing of the ecoinvent biosphere flows

### DIFF
--- a/activity_browser/ui/widgets/biosphere_update.py
+++ b/activity_browser/ui/widgets/biosphere_update.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 from bw2data.errors import ValidityError
-import bw2io.data as data
 from PySide2 import QtCore, QtWidgets
 from PySide2.QtCore import Signal, Slot
 
@@ -36,9 +35,9 @@ class BiosphereUpdater(QtWidgets.QProgressDialog):
 
 
 class UpdateBiosphereThread(QtCore.QThread):
+    data = __import__('bw2io.data')
     PATCHES = [patch for patch in dir(data) if patch.startswith('add_ecoinvent') and patch.endswith('biosphere_flows')]
     progress = Signal(int)
-    data = __import__('bw2io.data')
     def __init__(self, parent=None):
         super().__init__(parent)
         self.total_patches = len(self.PATCHES)

--- a/activity_browser/ui/widgets/biosphere_update.py
+++ b/activity_browser/ui/widgets/biosphere_update.py
@@ -3,7 +3,7 @@ import brightway2 as bw
 from bw2data.errors import ValidityError
 from PySide2 import QtCore, QtWidgets
 from PySide2.QtCore import Signal, Slot
-
+import bw2io.data as data
 from ...signals import signals
 
 
@@ -35,7 +35,6 @@ class BiosphereUpdater(QtWidgets.QProgressDialog):
 
 
 class UpdateBiosphereThread(QtCore.QThread):
-    data = __import__('bw2io.data')
     PATCHES = [patch for patch in dir(data) if patch.startswith('add_ecoinvent') and patch.endswith('biosphere_flows')]
     progress = Signal(int)
     def __init__(self, parent=None):
@@ -46,7 +45,7 @@ class UpdateBiosphereThread(QtCore.QThread):
         try:
             for i, patch in enumerate(self.PATCHES):
                 self.progress.emit(i)
-                update_bio = getattr(UpdateBiosphereThread.data, patch)
+                update_bio = getattr(data, patch)
                 update_bio()
         except ValidityError as e:
             print("Could not patch biosphere: {}".format(str(e)))


### PR DESCRIPTION
Avoids the use of having to update the biosphere_update module every time that the brightway ecoinvent code is updated for holding a new add_ecoinvent_xx_biosphere_flows function. As long as they don't change the name (excluding the versioning)

Might help in cases of #1013
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
