### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,11 +6,17 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
+  - type: checkboxes
+    id: has-updated
+    attributes:
+      label: Updating AB
+      options:
+        - label: "Yes, I have [updated AB](https://github.com/LCA-ActivityBrowser/activity-browser#updating-the-ab) and still experience this issue"
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: Also tell us, what did you expect to happen?
+      description: Also tell us, what did you expect to happen? You can share relevant files (e.g. screenshots/databases) here too.
       placeholder: Tell us what happened
     validations:
       required: true
@@ -21,12 +27,17 @@ body:
       description: Please copy and paste any relevant errors from the terminal.
       placeholder: This will be automatically formatted into code, so no need to worry about the formatting.
       render: python
-  - type: textarea
-    id: files
+  - type: dropdown
+    id: os
     attributes:
-      label: Relevant files
-      description: Drag any relevant files into the box below like screenshots or relevant databases
-      placeholder: Share your files
+      label: Operating system
+      multiple: false
+      options:
+        - Windows 10
+        - Windows 11
+        - MacOS
+        - Linux/Other (please specify above)
+      default: 0
   - type: textarea
     id: conda-env
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: File a bug report for AB.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what happened
+    validations:
+      required: true
+  - type: textarea
+    id: errors
+    attributes:
+      label: Relevant errors
+      description: Please copy and paste any relevant errors from the terminal.
+      placeholder: This will be automatically formatted into code, so no need to worry about the formatting.
+      render: python
+  - type: textarea
+    id: files
+    attributes:
+      label: Relevant files
+      description: Drag any relevant files into the box below like screenshots or relevant databases
+      placeholder: Share your files
+  - type: textarea
+    id: conda-env
+    attributes:
+      label: Conda environment
+      description: Please copy and paste the output from `conda list`.
+      placeholder: This will be automatically formatted into code, so no need to worry about the formatting.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Using AB
+    url: https://github.com/LCA-ActivityBrowser/activity-browser/discussions
+    about: Ask AB user questions on our discussions page.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Using AB
+  - name: How to use AB
     url: https://github.com/LCA-ActivityBrowser/activity-browser/discussions
     about: Ask AB user questions on our discussions page.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,15 @@
+name: Feature request
+description: File a feature request for AB.
+labels: ["feature request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature request
+      description: A clear description of your idea and what problem it should resolve. Please share examples or images if relevant.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: File a feature request for AB.
-labels: ["feature request"]
+labels: ["feature"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/something_else.yml
+++ b/.github/ISSUE_TEMPLATE/something_else.yml
@@ -1,0 +1,14 @@
+name: Something else
+description: Open an issue for AB.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing this issue with us! In case you want help with using AB, please use the [discussions page](https://github.com/LCA-ActivityBrowser/activity-browser/discussions) instead.
+  - type: textarea
+    id: issue
+    attributes:
+      label: Issue
+      description: Please share the issue you're experiencing.
+    validations:
+      required: true


### PR DESCRIPTION
Add templates for opening new issues. (resolves #772, resolves #679).

Adds:
1. new [issue choosing page](https://github.com/marc-vdm/activity-browser/issues/new/choose)
2. 3 issue templates:
  a. [bug report](https://github.com/marc-vdm/activity-browser/issues/new?assignees=&labels=bug&projects=&template=bug_report2.yml) template
  b. [feature request](https://github.com/marc-vdm/activity-browser/issues/new?assignees=&labels=feature+request&projects=&template=feature-request.yml) template
  c. [something else](https://github.com/marc-vdm/activity-browser/issues/new?assignees=&labels=&projects=&template=something_else.yml) template
3. a redirector for user questions to the [discussions page](https://github.com/LCA-ActivityBrowser/activity-browser/discussions)

An example of a filled out bug report can be found [here](https://github.com/marc-vdm/activity-browser/issues/4)

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
