### PR TITLE
Updates to the functions get_relevant_flows and get_relevant_activities

### DIFF
--- a/activity_browser/bwutils/superstructure/activities.py
+++ b/activity_browser/bwutils/superstructure/activities.py
@@ -91,7 +91,8 @@ def get_relevant_activities(df: pd.DataFrame, part: str = "from") -> dict:
     if sub.empty:
         return {}
 
-    names, products, locations, dbs = sub.iloc[:, 0:4].apply(set, axis=0)
+    names, products, locations, dbs = list(map(set, sub.iloc[:, 0:4].values.T))
+#    names, products, locations, dbs = sub.iloc[:, 0:4].apply(set, axis=0)
     query = (ActivityDataset
              .select(ActivityDataset.name, ActivityDataset.product,
                      ActivityDataset.location, ActivityDataset.database,
@@ -113,7 +114,8 @@ def get_relevant_flows(df: pd.DataFrame, part: str = "from") -> dict:
     if sub.empty:
         return {}
 
-    names, categories, dbs = sub.iloc[:, 0:3].apply(set, axis=0)
+    names, categories, dbs = list(map(set, sub.iloc[:, 0:3].values.T))
+#    names, categories, dbs = sub.iloc[:, 0:3].apply(set, axis=0)
     query = (ActivityDataset
              .select(ActivityDataset.name, ActivityDataset.data,
                      ActivityDataset.database, ActivityDataset.code)

--- a/activity_browser/bwutils/superstructure/excel.py
+++ b/activity_browser/bwutils/superstructure/excel.py
@@ -83,7 +83,7 @@ def import_from_excel(document_path: Union[str, Path], import_sheet: int = 1) ->
 
         # Convert specific columns that may have tuples as strings
         columns = ["from categories", "from key", "to categories", "to key"]
-        data.loc[:, columns] = data[columns].applymap(convert_tuple_str)
+        data.loc[:, columns] = data[columns].map(convert_tuple_str)
     except:
         # skip the error checks here, these now occur in the calling layout.tabs.LCA_setup module
         pass


### PR DESCRIPTION
Use of the pandas apply method for extracting the dataframe columns as set objects failed with an Exception related to the use of unordered sets. This can be avoided by using the python standard map functionality to split the pandas dataframes.

resolve #1062 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
