### PR TITLE
Install canary updates

### DIFF
--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -38,3 +38,34 @@ jobs:
         with:
           name: env-${{ matrix.os }}-${{ matrix.python-version }}
           path: env.yaml
+
+  # also run install with micromamba instead of conda to have a timining comparison
+  canary-installs-mamba:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.9']
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Setup python ${{ matrix.python-version }} conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: ab
+          create-args: >-
+            python=${{ matrix.python-version }}
+            activity-browser
+      - name: Environment info
+        run: |
+          micromamba list
+          micromamba env export
+          micromamba env export > env.yaml
+      - name: Upload final environment as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: env-${{ matrix.os }}-${{ matrix.python-version }}-mamba
+          path: env.yaml

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
         python-version: ['3.8', '3.9']
     defaults:
       run:
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
         python-version: ['3.9']
     defaults:
       run:
@@ -82,13 +82,15 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v3
       - name: show files
-        run: ls -la
+        run: |
+          ls -la
+          ls | grep mamba
       - name: correct yaml formatting
         # add correct indentation to make diffing possible
         uses: mikefarah/yq@master
         with:
           cmd: |
-            ls | grep mamba | while read yaml; do yq -i $yaml; done
+            ls | grep mamba | while read yaml; do echo $yaml; yq -i $yaml; done
       - name: diff ubuntu
         run: |
           diff -u env-ubuntu-latest-3.9*

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -85,12 +85,13 @@ jobs:
         run: |
           ls -la
           ls | grep mamba
+          cat env-ubuntu-latest-3.9-mamba
       - name: correct yaml formatting
         # add correct indentation to make diffing possible
         uses: mikefarah/yq@master
         with:
           cmd: |
-            yq -i env-ubuntu-latest-3.9-mamba
+            yq env-ubuntu-latest-3.9-mamba
       - name: diff ubuntu
         run: |
           diff -u env-ubuntu-latest-3.9*

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -92,10 +92,10 @@ jobs:
             ls | grep mamba | while read d; do yq -i $d/env.yaml; done
       - name: diff ubuntu
         run: |
-          diff -u env-ubuntu-latest-3.9*
+          diff -u env-ubuntu-latest-3.9* || :
       - name: diff windows
         run: |
-          diff -u env-windows-latest-3.9*
+          diff -u env-windows-latest-3.9* || :
       - name: diff macos
         run: |
-          diff -u env-macos-latest-3.9*
+          diff -u env-macos-latest-3.9* || :

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   canary-installs:
+    timeout-minutes: 12
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9']
+        python-version: ['3.8', '3.9']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd: |
-            ls | grep mamba | while read yaml; do echo $yaml; yq -i $yaml; done
+            yq -i env-ubuntu-latest-3.9-mamba
       - name: diff ubuntu
         run: |
           diff -u env-ubuntu-latest-3.9*

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -70,7 +70,7 @@ jobs:
           cmd: |
             yq -i env.yaml
       - name: Upload final environment as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: env-${{ matrix.os }}-${{ matrix.python-version }}-mamba
           path: env.yaml
@@ -85,7 +85,7 @@ jobs:
       - canary-installs-mamba
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: show files
         run: ls -la
       - name: diff

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           ls -la
           ls | grep mamba
-          cat env-ubuntu-latest-3.9-mamba
+          ls env-ubuntu-latest-3.9-mamba
       - name: correct yaml formatting
         # add correct indentation to make diffing possible
         uses: mikefarah/yq@master

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   canary-installs:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -84,14 +84,12 @@ jobs:
       - name: show files
         run: |
           ls -la
-          ls | grep mamba
-          ls env-ubuntu-latest-3.9-mamba
       - name: correct yaml formatting
         # add correct indentation to make diffing possible
         uses: mikefarah/yq@master
         with:
           cmd: |
-            yq env-ubuntu-latest-3.9-mamba
+            ls | grep mamba | while read d; do yq -i $d/env.yaml; done
       - name: diff ubuntu
         run: |
           diff -u env-ubuntu-latest-3.9*

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   canary-installs:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -69,3 +69,17 @@ jobs:
         with:
           name: env-${{ matrix.os }}-${{ matrix.python-version }}-mamba
           path: env.yaml
+
+  conda-micromamba-comparison:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    needs:
+      - canary-installs
+      - canary-installs-mamba
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+      - name: show files
+        run: ls -la

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install activity-browser
         run: |
-          conda create -y -n ab -c conda-forge activity-browser python=${{ matrix.python-version }}
+          conda create -y -n ab -c conda-forge --solver libmamba activity-browser python=${{ matrix.python-version }}
       - name: Environment info
         run: |
           conda activate ab

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -10,7 +10,6 @@ on:
 jobs:
   canary-installs:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -89,13 +89,12 @@ jobs:
         uses: actions/download-artifact@v3
       - name: show files
         run: ls -la
-      - name: diff
+      - name: diff ubuntu
         run: |
-          echo ubuntu
           diff -u env-ubuntu-latest-3.9*
-          echo #####################
-          echo windows
+      - name: diff windows
+        run: |
           diff -u env-windows-latest-3.9*
-          echo #####################
-          echo macos
+      - name: diff macos
+        run: |
           diff -u env-macos-latest-3.9*

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -64,12 +64,6 @@ jobs:
           micromamba list
           micromamba env export
           micromamba env export > env.yaml
-      - name: correct yaml formatting
-        # add correct indentation to make diffing possible
-        uses: mikefarah/yq@master
-        with:
-          cmd: |
-            yq -i env.yaml
       - name: Upload final environment as artifact
         uses: actions/upload-artifact@v3
         with:
@@ -89,6 +83,12 @@ jobs:
         uses: actions/download-artifact@v3
       - name: show files
         run: ls -la
+      - name: correct yaml formatting
+        # add correct indentation to make diffing possible
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            ls | grep mamba | while read yaml; do yq -i $yaml; done
       - name: diff ubuntu
         run: |
           diff -u env-ubuntu-latest-3.9*

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   canary-installs:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 12
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -63,6 +63,12 @@ jobs:
           micromamba list
           micromamba env export
           micromamba env export > env.yaml
+      - name: correct yaml formatting
+        # add correct indentation to make diffing possible
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq -i env.yaml
       - name: Upload final environment as artifact
         uses: actions/upload-artifact@v2
         with:
@@ -82,3 +88,13 @@ jobs:
         uses: actions/download-artifact@v2
       - name: show files
         run: ls -la
+      - name: diff
+        run: |
+          echo ubuntu
+          diff -u env-ubuntu-latest-3.9*
+          echo #####################
+          echo windows
+          diff -u env-windows-latest-3.9*
+          echo #####################
+          echo macos
+          diff -u env-macos-latest-3.9*

--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.9']
     defaults:
       run:
         shell: bash -l {0}
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9']
     defaults:
       run:


### PR DESCRIPTION
Relates: #1065 

- switch to libmamba solver which speeds up the install massively, keep the timeout at 12min
- add installation with micromamba job, this allows to compare installation timings on all OSs
- add a step that runs the diff on the environments created by conda vs mamba

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
