### PR TITLE
Use micromamba instead of miniconda to speed up tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,16 +44,17 @@ jobs:
         with:
           name: patched-environment
       - name: Setup python ${{ matrix.python-version }} conda environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: ${{ matrix.python-version }}
-          activate-environment: test
+          environment-name: test
           environment-file: patched-environment.yml
+          create-args: >-
+            python=${{ matrix.python-version }}
       - name: Environment info
         run: |
-          conda list
-          conda env export
-          conda env export -f env.yaml
+          micromamba list
+          micromamba env export
+          micromamba env export > env.yaml
       - name: Upload final environment as artifact
         uses: actions/upload-artifact@v3
         with:
@@ -72,7 +73,7 @@ jobs:
       - name: Install coveralls and coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          conda install -q -y coveralls=3.3.1 coverage pytest-cov
+          micromamba install -q -y coveralls=3.3.1 coverage pytest-cov
       - name: Run linux tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:


### PR DESCRIPTION
If we use micromamba instead of miniconda to run the tests in the github actions, we can bring down the time from ~20min to ~6min. This is still far from ideal, but at least the initial feedback is much faster with linux tests only taking ~2min.

relates: #1094 + #1097 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
