### PR TITLE
Resolve scenario calculation bug

### DIFF
--- a/activity_browser/bwutils/montecarlo.py
+++ b/activity_browser/bwutils/montecarlo.py
@@ -50,26 +50,11 @@ class MonteCarloLCA(object):
         self.activity_keys = [list(fu.keys())[0] for fu in self.func_units]
         self.activity_index = {key: index for index, key in enumerate(self.activity_keys)}
         self.rev_activity_index = {index: key for index, key in enumerate(self.activity_keys)}
-        # previously: self.rev_activity_index = {v: k for k, v in self.activity_keys}
-        # self.fu_index = {k: i for i, k in enumerate(self.activity_keys)}
 
         # methods
         self.methods = self.cs['ia']
         self.method_index = {m: i for i, m in enumerate(self.methods)}
         self.rev_method_index = {i: m for i, m in enumerate(self.methods)}
-        # previously: self.rev_method_index = {v: k for k, v in self.method_index.items()}
-        # self.rev_method_index = {v: k for k, v in self.method_index.items()}
-
-        # todo: get rid of the below
-        self.func_unit_translation_dict = {str(bw.get_activity(list(func_unit.keys())[0])): func_unit
-                                           for func_unit in self.func_units}
-        if len(self.func_unit_translation_dict) != len(self.func_units):
-            self.func_unit_translation_dict = {}
-            for fu in self.func_units:
-                act = bw.get_activity(next(iter(fu)))
-                self.func_unit_translation_dict["{} {}".format(act, act[0])] = fu
-        self.func_key_dict = {m: i for i, m in enumerate(self.func_unit_translation_dict.keys())}
-        self.func_key_list = list(self.func_key_dict.keys())
 
         # GSA calculation variables
         self.A_matrices = list()

--- a/activity_browser/bwutils/multilca.py
+++ b/activity_browser/bwutils/multilca.py
@@ -170,17 +170,17 @@ class MLCA(object):
         self.process_contributions = np.zeros(
             (len(self.func_units), len(self.methods), self.lca.technosphere_matrix.shape[0]))
 
-        # TODO: get rid of the below
-        self.func_unit_translation_dict = {
-            str(bw.get_activity(list(func_unit.keys())[0])): func_unit for func_unit in self.func_units
-        }
-        if len(self.func_unit_translation_dict) != len(self.func_units):
-            self.func_unit_translation_dict = {}
-            for fu in self.func_units:
-                act = bw.get_activity(next(iter(fu)))
-                self.func_unit_translation_dict["{} {}".format(act, act[0])] = fu
+        name = 'name'
+        ref_prod = 'reference product'
+        db = 'database'
+        self.func_unit_translation_dict = {}
+        for fu in self.func_units:
+            key = next(iter(fu))
+            amt = fu[key]
+            act = bw.get_activity(key)
+            self.func_unit_translation_dict[f'{act[name]} | {act[ref_prod]} | {act[db]} | {amt}'] = fu
         self.func_key_dict = {m: i for i, m in enumerate(self.func_unit_translation_dict.keys())}
-        self.func_key_list = list(self.func_key_dict.keys())
+        self.func_key_list = list(self.func_unit_translation_dict.keys())
 
     def _construct_lca(self):
         return bw.LCA(demand=self.func_units_dict, method=self.methods[0])


### PR DESCRIPTION
AB created keys for the pandas dataframe where results are stored and dropdowns for users to select different combinations of FU/IC/scenario. The keys were not unique of processes had the same name and database. They are now unique on: name, reference product, database and amount. The last one is also required for #920

- Resolve #1103
- Resolve #1122 


<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
