### PR TITLE
Add tooltip to table cells with content overflow

### DIFF
--- a/activity_browser/ui/tables/models/base.py
+++ b/activity_browser/ui/tables/models/base.py
@@ -45,7 +45,9 @@ class PandasModel(QAbstractTableModel):
         if not index.isValid():
             return None
 
-        if role == Qt.DisplayRole:
+        #Instantiate value only in case of DisplayRole or ToolTipRole       
+        value = None
+        if role == Qt.DisplayRole or role == Qt.ToolTipRole:
             value = self._dataframe.iat[index.row(), index.column()]
             if isinstance(value, np.float64):
                 value = float(value)
@@ -55,7 +57,23 @@ class PandasModel(QAbstractTableModel):
                 value = value.item()
             elif isinstance(value, tuple):
                 value = str(value)
+        
+        #Immediately return value in case of DisplayRole
+        if role == Qt.DisplayRole:
             return value
+        
+        #In case of ToolTipRole, check whether content fits the cell
+        if role == Qt.ToolTipRole:
+            parent = self.parent()
+            fontMetrics = parent.fontMetrics()
+
+            #Get the width of both the cell, and the text
+            column_width = parent.columnWidth(index.column())
+            text_width = fontMetrics.horizontalAdvance(value)
+            margin = 10
+
+            #Only show tooltip if the text is wider then the cell minus the margin
+            if text_width > column_width - margin: return value
 
         if role == Qt.ForegroundRole:
             col_name = self._dataframe.columns[index.column()]

--- a/activity_browser/ui/tables/models/base.py
+++ b/activity_browser/ui/tables/models/base.py
@@ -42,6 +42,10 @@ class PandasModel(QAbstractTableModel):
         return 0 if self._dataframe is None else self._dataframe.shape[1]
 
     def data(self, index, role=Qt.DisplayRole):
+        """
+        Returns value for table index based on a certain DisplayRole enum.
+        More on DisplayRole enums: https://doc.qt.io/qt-5/qt.html#ItemDataRole-enum
+        """
         if not index.isValid():
             return None
 

--- a/activity_browser/ui/tables/models/base.py
+++ b/activity_browser/ui/tables/models/base.py
@@ -43,13 +43,14 @@ class PandasModel(QAbstractTableModel):
 
     def data(self, index, role=Qt.DisplayRole):
         """
-        Returns value for table index based on a certain DisplayRole enum.
+        Return value for table index based on a certain DisplayRole enum.
+        
         More on DisplayRole enums: https://doc.qt.io/qt-5/qt.html#ItemDataRole-enum
         """
         if not index.isValid():
             return None
 
-        #Instantiate value only in case of DisplayRole or ToolTipRole       
+        # instantiate value only in case of DisplayRole or ToolTipRole       
         value = None
         if role == Qt.DisplayRole or role == Qt.ToolTipRole:
             value = self._dataframe.iat[index.row(), index.column()]
@@ -62,21 +63,20 @@ class PandasModel(QAbstractTableModel):
             elif isinstance(value, tuple):
                 value = str(value)
         
-        #Immediately return value in case of DisplayRole
-        if role == Qt.DisplayRole:
-            return value
+        # immediately return value in case of DisplayRole
+        if role == Qt.DisplayRole: return value
         
-        #In case of ToolTipRole, check whether content fits the cell
+        # in case of ToolTipRole, check whether content fits the cell
         if role == Qt.ToolTipRole:
             parent = self.parent()
             fontMetrics = parent.fontMetrics()
 
-            #Get the width of both the cell, and the text
+            # get the width of both the cell, and the text
             column_width = parent.columnWidth(index.column())
             text_width = fontMetrics.horizontalAdvance(value)
             margin = 10
 
-            #Only show tooltip if the text is wider then the cell minus the margin
+            # only show tooltip if the text is wider then the cell minus the margin
             if text_width > column_width - margin: return value
 
         if role == Qt.ForegroundRole:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->
Enables users to view a table cell's contents by hovering their pointer over the table cell. If there is an overflow in said cell (i.e. the text is wrapped / cut short with a ...) the full text is shown in a tooltip.

- closes #1101 

## Screenshot of Feature
![tooltipscreenshot](https://github.com/LCA-ActivityBrowser/activity-browser/assets/103424764/d75e44e1-507c-43c3-9988-85418f2ddf22)

## Notes
- This doesn't apply to headers of tables.
- This will overrule other tooltips set higher in the qt hierarchy, but only if there is an overflow of the table cell in question.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
