### PR TITLE
Add - copy on impact category copy

### DIFF
--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -216,12 +216,12 @@ class ImpactCategoryController(QObject):
         else:
             methods = [bw.Method(method)]
         dialog = TupleNameDialog.get_combined_name(
-            self.window, "Impact category name", "Combined name:", method, "Copy"
+            self.window, "Impact category name", "Combined name:", method, " - Copy"
         )
         if dialog.exec_() == TupleNameDialog.Accepted:
             new_name = dialog.result_tuple
             for mthd in methods:
-                new_method = new_name + mthd.name[len(new_name)-1:]
+                new_method = new_name + mthd.name[len(new_name):]
                 if new_method in bw.methods:
                     warn = "Impact Category with name '{}' already exists!".format(new_method)
                     QtWidgets.QMessageBox.warning(self.window, "Copy failed", warn)

--- a/activity_browser/ui/tables/impact_categories.py
+++ b/activity_browser/ui/tables/impact_categories.py
@@ -154,17 +154,22 @@ class MethodsTree(ABDictTreeView):
         if self.indexAt(event.pos()).row() == -1:
             return
         menu = QtWidgets.QMenu(self)
+
+        if self.tree_level()[0] == 'leaf':
+            menu.addAction(qicons.edit, "Inspect Impact Category", self.method_selected)
+        else:
+            menu.addAction(qicons.forward, "Expand all sub levels", self.expand_branch)
+            menu.addAction(qicons.backward, "Collapse all sub levels", self.collapse_branch)
+        
+        menu.addSeparator()
+
         menu.addAction(qicons.copy, "Duplicate Impact Category",
                        lambda: self.copy_method()
                        )
         menu.addAction(qicons.delete, "Delete Impact Category",
                        lambda: self.delete_method()
                        )
-        if self.tree_level()[0] == 'leaf':
-            menu.addAction(qicons.edit, "Inspect Impact Category", self.method_selected)
-        else:
-            menu.addAction(qicons.forward, "Expand all sub levels", self.expand_branch)
-            menu.addAction(qicons.backward, "Collapse all sub levels", self.collapse_branch)
+
         menu.exec_(event.globalPos())
 
     def selected_methods(self) -> Iterable:

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -108,12 +108,22 @@ class TupleNameDialog(QtWidgets.QDialog):
     @classmethod
     def get_combined_name(cls, parent: QtWidgets.QWidget, title: str, label: str,
                           fields: tuple, extra: str = "Extra") -> 'TupleNameDialog':
+        """
+        Set-up a TupleNameDialog pop-up with supplied title + label. Construct fields
+        for each field of the supplied tuple. Last field of the tuple is appended with
+        the extra string, to avoid duplicates.
+        """
         obj = cls(parent)
         obj.setWindowTitle(title)
         obj.name_label.setText(label)
-        for field in fields:
-            obj.add_input_field(str(field))
-        obj.add_input_field("", extra)
+
+        # set up a field for each tuple element
+        for i, field in enumerate(fields):
+            field_content = str(field)
+
+            # if it's the last element, add extra to the string
+            if i + 1 == len(fields): field_content += extra
+            obj.add_input_field(field_content)
         obj.input_box.updateGeometry()
         obj.changed()
         return obj


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

Instead of adding another field, `TupleNameDialog` now appends ` - Copy` to the last tuple item, which is more intuitive for the end-user. If the name ends up not being unique, an error dialogue is displayed (this was already implemented)

Closes #1133 

## Demo
![impact-categories](https://github.com/LCA-ActivityBrowser/activity-browser/assets/103424764/06e1ddf5-3eac-4813-91af-ea6ef104cc83)


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
