### PR TITLE
Resolve bug with switching project on delete

### DIFF
--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -51,8 +51,11 @@ class ProjectController(QObject):
         """Change the project, this clears all tabs and metadata related to
         the current project.
         """
-        if name not in bw.projects: return log.info(f"Project does not exist: {name}")
-
+        # check whether the project does exist, otherwise return
+        if name not in bw.projects: 
+            log.info(f"Project does not exist: {name}")
+            return
+        
         if name != bw.projects.current or reload:
             bw.projects.set_current(name)
         signals.project_selected.emit()
@@ -113,7 +116,7 @@ class ProjectController(QObject):
 
         # open a delete dialog for the user to confirm, return if user rejects
         delete_dialog = ProjectDeletionDialog.construct_project_deletion_dialog(self.window, bw.projects.current)
-        if delete_dialog.exec_() == ProjectDeletionDialog.Rejected: return
+        if delete_dialog.exec_() != ProjectDeletionDialog.Accepted: return
 
         # change from the project to be deleted, to the startup project
         self.change_project(ab_settings.startup_project, reload=True)
@@ -140,7 +143,8 @@ class ProjectController(QObject):
                 "Project succesfully deleted"
             )
 
-        # emit that the project list hast changed because of the deletion
+        # emit that the project list has changed because of the deletion,
+        # regardless of a possible exception (which may have deleted the project anyways) 
         signals.projects_changed.emit()
 
 class CSetupController(QObject):

--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -47,15 +47,11 @@ class ProjectController(QObject):
 
     @staticmethod
     @Slot(str, name="changeProject")
-    def change_project(name: str, reload: bool = False) -> None:
+    def change_project(name: str = "default", reload: bool = False) -> None:
         """Change the project, this clears all tabs and metadata related to
         the current project.
         """
-#        assert name, "No project name given."
-        name = "default" if not name else name
-        if name not in bw.projects:
-            log.info("Project does not exist: {}, creating!".format(name))
-            bw.projects.create_project(name)
+        if name not in bw.projects: return log.info(f"Project does not exist: {name}")
 
         if name != bw.projects.current or reload:
             bw.projects.set_current(name)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->
Updates to the project deletion workflow. Projects now get properly deleted. Notable changes:
- You can't delete your startup project anymore without first specifying another one in the settings. This reduces unexpected behaviour by AB.
- When a project is deleted, we first switch to said startup project to avoid "PermissionError"
- A succes/error dialogue is shown upon project deletion

Closes #1075 
## Demo
![Animation](https://github.com/LCA-ActivityBrowser/activity-browser/assets/103424764/140509fb-b7da-4198-bb28-cb7d9605c7b8)


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
