### PR TITLE
Tooltip integer fix

### DIFF
--- a/activity_browser/ui/tables/models/base.py
+++ b/activity_browser/ui/tables/models/base.py
@@ -73,7 +73,7 @@ class PandasModel(QAbstractTableModel):
 
             # get the width of both the cell, and the text
             column_width = parent.columnWidth(index.column())
-            text_width = fontMetrics.horizontalAdvance(value)
+            text_width = fontMetrics.horizontalAdvance(str(value))
             margin = 10
 
             # only show tooltip if the text is wider then the cell minus the margin


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->
Fixes a bug with the previous table overflow tooltip functionality where an error is thrown when the table cell data iss not of type String. 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
