### PR TITLE
Impact Category Duplication Fixes

### DIFF
--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -243,17 +243,19 @@ class ImpactCategoryController(QObject):
         dialog = TupleNameDialog.get_combined_name(
             self.window, "Impact category name", "Combined name:", method, " - Copy"
         )
-        if dialog.exec_() == TupleNameDialog.Accepted:
-            new_name = dialog.result_tuple
-            for mthd in methods:
-                new_method = new_name + mthd.name[len(new_name):]
-                if new_method in bw.methods:
-                    warn = "Impact Category with name '{}' already exists!".format(new_method)
-                    QtWidgets.QMessageBox.warning(self.window, "Copy failed", warn)
-                    return
-                mthd.copy(new_method)
-                log.info("Copied method {} into {}".format(str(mthd.name), str(new_method)))
-            signals.new_method.emit()
+        if dialog.exec_() != TupleNameDialog.Accepted: return
+
+        new_name = dialog.result_tuple
+        for mthd in methods:
+            new_method = new_name + mthd.name[len(new_name):]
+            print('+', mthd)
+            if new_method in bw.methods:
+                warn = f"Impact Category with name '{new_method}' already exists!"
+                QtWidgets.QMessageBox.warning(self.window, "Copy failed", warn)
+                return
+            mthd.copy(new_method)
+            log.info("Copied method {} into {}".format(str(mthd.name), str(new_method)))
+        signals.new_method.emit()
 
     @Slot(tuple, name="deleteMethod")
     def delete_method(self, method_: tuple, level:str = None) -> None:

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -87,10 +87,7 @@ class TupleNameDialog(QtWidgets.QDialog):
 
     @property
     def result_tuple(self) -> tuple:
-        result = [f.text() for f in self.input_fields if f.text()]
-        if not self.input_fields[-1].text():
-            result.append(self.input_fields[-1].placeholderText())
-        return tuple(result)
+        return tuple([f.text() for f in self.input_fields if f.text()])
 
     @Slot(name="inputChanged")
     def changed(self) -> None:
@@ -98,7 +95,7 @@ class TupleNameDialog(QtWidgets.QDialog):
         Actions when the text within the TupleNameDialog is edited by the user
         """
         # rebuild the combined name example 
-        self.view_name.setText("'({})'".format(self.combined_names))
+        self.view_name.setText(f"'({self.combined_names})'")
 
         # disable the button (and its outline) when all fields are empty
         if self.combined_names == "":
@@ -109,9 +106,8 @@ class TupleNameDialog(QtWidgets.QDialog):
             self.buttons.buttons()[0].setDisabled(False)
             self.buttons.buttons()[0].setDefault(True)
 
-    def add_input_field(self, text: str, placeholder: str = None) -> None:
+    def add_input_field(self, text: str) -> None:
         edit = QtWidgets.QLineEdit(text, self)
-        edit.setPlaceholderText(placeholder or "")
         edit.textChanged.connect(self.changed)
         self.input_fields.append(edit)
         self.input_box.layout().addWidget(edit)
@@ -133,7 +129,8 @@ class TupleNameDialog(QtWidgets.QDialog):
             field_content = str(field)
 
             # if it's the last element, add extra to the string
-            if i + 1 == len(fields): field_content += extra
+            if i + 1 == len(fields):
+                field_content += extra
             obj.add_input_field(field_content)
         obj.input_box.updateGeometry()
         obj.changed()

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -59,7 +59,7 @@ class TupleNameDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.name_label = QtWidgets.QLabel("New name")
         self.view_name = QtWidgets.QLabel()
-        self.no_comma_validator = QtGui.QRegExpValidator(QRegExp("[^,]+"))
+
         self.input_fields = []
         self.buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
@@ -94,13 +94,24 @@ class TupleNameDialog(QtWidgets.QDialog):
 
     @Slot(name="inputChanged")
     def changed(self) -> None:
-        """Rebuild the view_name with text from all of the input fields."""
+        """
+        Actions when the text within the TupleNameDialog is edited by the user
+        """
+        # rebuild the combined name example 
         self.view_name.setText("'({})'".format(self.combined_names))
+
+        # disable the button (and its outline) when all fields are empty
+        if self.combined_names == "":
+            self.buttons.buttons()[0].setDefault(False)
+            self.buttons.buttons()[0].setDisabled(True)
+        # enable when that's not the case (anymore)
+        else:
+            self.buttons.buttons()[0].setDisabled(False)
+            self.buttons.buttons()[0].setDefault(True)
 
     def add_input_field(self, text: str, placeholder: str = None) -> None:
         edit = QtWidgets.QLineEdit(text, self)
         edit.setPlaceholderText(placeholder or "")
-        edit.setValidator(self.no_comma_validator)
         edit.textChanged.connect(self.changed)
         self.input_fields.append(edit)
         self.input_box.layout().addWidget(edit)


### PR DESCRIPTION
Some of the fixes @marc-vdm mentioned in #1164 

- Comma's are now accepted during IC duplication
- At least one field must be filled during IC duplication, or the button is disabled

I wouldn't close the issue as there's still a lot to fix about IC duplication, but this at least makes it a little better in time for the next release.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
