### PR TITLE
resolve sankey caching bug

### DIFF
--- a/activity_browser/ui/web/sankey_navigator.py
+++ b/activity_browser/ui/web/sankey_navigator.py
@@ -206,8 +206,8 @@ class SankeyNavigatorWidget(BaseNavigatorWidget):
         cutoff = self.cutoff_sb.value()
         max_calc = self.max_calc_sb.value()
         self.update_sankey(demand, method,
-                           demand_index=demand_index, method_index=method_index, scenario_lca=scenario_lca,
-                           scenario_index=scenario_index, cut_off=cutoff, max_calc=max_calc)
+                           demand_index=demand_index, method_index=method_index, scenario_index=scenario_index,
+                           scenario_lca=scenario_lca, cut_off=cutoff, max_calc=max_calc)
 
     def update_sankey(self, demand: dict, method: tuple,
                       demand_index: int = None, method_index: int = None, scenario_index: int = None,

--- a/activity_browser/ui/web/sankey_navigator.py
+++ b/activity_browser/ui/web/sankey_navigator.py
@@ -206,34 +206,44 @@ class SankeyNavigatorWidget(BaseNavigatorWidget):
             scenario_index = self.scenario_cb.currentIndex()
         cutoff = self.cutoff_sb.value()
         max_calc = self.max_calc_sb.value()
-        self.update_sankey(demand, method, scenario_lca=scenario_lca, scenario_index=scenario_index,
-                           method_index=method_index, cut_off=cutoff, max_calc=max_calc)
+        self.update_sankey(demand, method,
+                           demand_index=demand_index, method_index=method_index, scenario_lca=scenario_lca,
+                           scenario_index=scenario_index, cut_off=cutoff, max_calc=max_calc)
 
-    def update_sankey(self, demand, method, scenario_index: int = None, method_index: int = None,
-                      scenario_lca: bool = False, cut_off=0.05,
-                      max_calc=100) -> None:
+    def update_sankey(self, demand: dict, method: tuple,
+                      demand_index: int = None, method_index: int = None, scenario_index: int = None,
+                      scenario_lca: bool = False, cut_off=0.05, max_calc=100) -> None:
         """Calculate LCA, do graph traversal, get JSON graph data for this, and send to javascript."""
-        log.info("Demand / Method: {} {}".format(demand, method))
 
-        cache_key = (str(demand), method_index, scenario_index, cut_off, max_calc)
+        # the cache key consists of demand/method/scenario indices (index of item in the relevant tables),
+        # the cutoff, max_calc and finally the demand amount.
+        # together, these are unique.
+        cache_key = (demand_index, method_index, scenario_index, cut_off, max_calc, list(demand.values())[0])
         if data := self.cache.get(cache_key, False):
             # this Sankey is already cached, generate the Sankey with the cached data
+            log.debug(f'CACHED sankey for: {demand}, {method}, key: {cache_key}')
             self.graph.new_graph(data)
             self.has_sankey = bool(self.graph.json_data)
             self.send_json()
             return
 
         start = time.time()
+        log.debug(f'CALCULATE sankey for: {demand}, {method}, key: {cache_key}')
         try:
             if scenario_lca:
                 self.parent.mlca.update_lca_calculation_for_sankey(scenario_index, demand, method_index)
                 data = GraphTraversalWithScenario(self.parent.mlca).calculate(demand, method, cutoff=cut_off, max_calc=max_calc)
             else:
                 data = bw.GraphTraversal().calculate(demand, method, cutoff=cut_off, max_calc=max_calc)
+            # store the metadata from this calculation
+            data['metadata'] = {'demand': list(data["lca"].demand.items())[0],
+                                'score': data["lca"].score,
+                                'unit': bw.Method(data["lca"].method).metadata["unit"],
+                                'act_dict': data["lca"].activity_dict.items()}
 
         except (ValueError, ZeroDivisionError) as e:
             QtWidgets.QMessageBox.information(None, "Not possible.", str(e))
-        log.info("Completed graph traversal ({:.2g} seconds, {} iterations)".format(time.time() - start, data["counter"]))
+        log.debug(f"Completed graph traversal ({round(time.time() - start, 2)} seconds, {data['counter']} iterations)")
 
         # cache the generated Sankey data
         self.cache[cache_key] = data
@@ -272,11 +282,11 @@ class Graph(BaseGraph):
     @staticmethod
     def get_json_data(data) -> str:
         """Transform bw.Graphtraversal() output to JSON data."""
-        lca = data["lca"]
-        lca_score = lca.score
-        lcia_unit = bw.Method(lca.method).metadata["unit"]
-        demand = list(lca.demand.items())[0]
-        reverse_activity_dict = {v: k for k, v in lca.activity_dict.items()}
+        meta = data["metadata"]
+        lca_score = meta['score']
+        lcia_unit = meta['unit']
+        demand = meta['demand']
+        reverse_activity_dict = {v: k for k, v in meta['act_dict']}
 
         build_json_node = Graph.compose_node_builder(lca_score, lcia_unit, demand[0])
         build_json_edge = Graph.compose_edge_builder(reverse_activity_dict, lca_score, lcia_unit)

--- a/activity_browser/ui/web/sankey_navigator.py
+++ b/activity_browser/ui/web/sankey_navigator.py
@@ -239,7 +239,7 @@ class SankeyNavigatorWidget(BaseNavigatorWidget):
             # store the metadata from this calculation
             data['metadata'] = {'demand': list(data["lca"].demand.items())[0],
                                 'score': data["lca"].score,
-                                'unit': bw.Method(data["lca"].method).metadata["unit"],
+                                'unit': bw.Method(method).metadata["unit"],
                                 'act_dict': data["lca"].activity_dict.items()}
             # drop LCA object as it's useless from now on
             del data["lca"]


### PR DESCRIPTION
- Bug created in #1117
- Resolve #1178 

Sankey caching had 2 bugs:
1. Reference flows with same activity name would fall under same cache item, despite potentially being different activities (e.g. different product/location/database). 
   - The `cache_key` is now updated to not be activity name but rather the index number in the reference flow table, this should also suffice for #920
2. Caching did not cache static `lca` object, meaning it would keep updating when other items were selected (and new graph traversal calculation was started). While the graph was static, items like lca score, reference flow name and unit were updated to the last calculated sankey. 
   - This data is now cached as `metadata`.
   - LCA object is now dropped from the cache as it serves no purpose but did increase size of the cache

Also; some log data was moved to `debug`, function call was re-ordered and explanation of items in the `cache_key` was added.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
