### PR TITLE
Fix empty database missing 'modified' time causing table to not show

### DIFF
--- a/activity_browser/controllers/database.py
+++ b/activity_browser/controllers/database.py
@@ -117,6 +117,7 @@ class DatabaseController(QObject):
         if ok and name:
             if name not in bw.databases:
                 bw.Database(name).register()
+                bw.Database(name).write({})  # write nothing to the database so we set a modified time
                 project_settings.add_db(name, False)
                 signals.databases_changed.emit()
                 signals.database_selected.emit(name)

--- a/activity_browser/ui/tables/models/base.py
+++ b/activity_browser/ui/tables/models/base.py
@@ -54,6 +54,7 @@ class PandasModel(QAbstractTableModel):
 
         # instantiate value only in case of DisplayRole or ToolTipRole       
         value = None
+        tt_date_flag = False  # flag to indicate if value is datetime object and role is ToolTipRole
         if role == Qt.DisplayRole or role == Qt.ToolTipRole or role == 'sorting':
             value = self._dataframe.iat[index.row(), index.column()]
             if isinstance(value, np.float64):
@@ -69,6 +70,7 @@ class PandasModel(QAbstractTableModel):
                 time_shift = - tz.utcoffset().total_seconds()
                 if role == Qt.ToolTipRole:
                     value = arrow.get(value).shift(seconds=time_shift).format('YYYY-MM-DD HH:mm:ss')
+                    tt_date_flag = True
                 elif role == Qt.DisplayRole:
                     value = arrow.get(value).shift(seconds=time_shift).humanize()
 
@@ -76,8 +78,8 @@ class PandasModel(QAbstractTableModel):
         if role == Qt.DisplayRole or role == 'sorting':
             return value
 
-        # in case of ToolTipRole and value is datetime object
-        if role == Qt.ToolTipRole and isinstance(value, datetime.datetime):
+        # in case of ToolTipRole and date, always show the full date
+        if tt_date_flag and role == Qt.ToolTipRole:
             return value
 
         # in case of ToolTipRole, check whether content fits the cell

--- a/activity_browser/ui/tables/models/inventory.py
+++ b/activity_browser/ui/tables/models/inventory.py
@@ -34,13 +34,10 @@ class DatabasesModel(PandasModel):
         return self._dataframe.iat[idx.row(), 0]
 
     def sync(self):
-        # code below is based on the assumption that bw uses utc timestamps
-        tz = datetime.datetime.now(datetime.timezone.utc).astimezone()
-        time_shift = - tz.utcoffset().total_seconds()
-
         data = []
         for name in natural_sort(bw.databases):
-            dt = datetime.datetime.strptime(bw.databases[name].get("modified", ""), '%Y-%m-%dT%H:%M:%S.%f')
+            # get the modified time, in case it doesn't exist, just write 'now' in the correct format
+            dt = bw.databases[name].get("modified", datetime.datetime.now().isoformat())
             # final column includes interactive checkbox which shows read-only state of db
             database_read_only = project_settings.db_is_readonly(name)
             data.append({

--- a/activity_browser/ui/tables/models/inventory.py
+++ b/activity_browser/ui/tables/models/inventory.py
@@ -38,6 +38,8 @@ class DatabasesModel(PandasModel):
         for name in natural_sort(bw.databases):
             # get the modified time, in case it doesn't exist, just write 'now' in the correct format
             dt = bw.databases[name].get("modified", datetime.datetime.now().isoformat())
+            dt = datetime.datetime.strptime(dt, '%Y-%m-%dT%H:%M:%S.%f')
+
             # final column includes interactive checkbox which shows read-only state of db
             database_read_only = project_settings.db_is_readonly(name)
             data.append({


### PR DESCRIPTION
- resolve #1179


changes:
- Creating a new database now adds `modified` time by writing nothing (empty dict) to the new database.
- In case `modified` is still missing (e.g. user created empty database in Brightway), we just write current time to the `modified` column in AB.
- Also removed some tz shifting code that's unused since #1151.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
