### PR TITLE
Create unique version string for AB dev package

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -109,6 +109,8 @@ jobs:
       PKG_NAME: "activity-browser-dev"
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
       - name: Build and deploy 3.11
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -117,7 +119,7 @@ jobs:
           environment-file: .github/conda-envs/build.yml
       - name: Export version
         run: |
-          echo "VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --tags --always | cut -d- -f1,2 | sed 's/-/dev/')" >> $GITHUB_ENV
       - name: Patch recipe with run requirements from stable
         uses: mikefarah/yq@master
         # Adds the run dependencies from the stable recipe to the dev recipe (inplace)
@@ -131,5 +133,5 @@ jobs:
           conda build .github/dev-recipe/
       - name: Upload the activity-browser-dev package
         run: |
-          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --force \
+          anaconda -t ${{ secrets.CONDA_UPLOAD_TOKEN }} upload \
           /usr/share/miniconda/envs/build/conda-bld/noarch/*.tar.bz2


### PR DESCRIPTION
Fixes #1193

Instead of using the date for the dev version, we create a version string from the latest tag and the number of commits since the latest tag. Eg. `2.9.4dev2`. Like this there should be no more problems with conflicts for multiple dev releases on the same day. Also this versioning conveys more useful information than the date. The release date itself can always be checked on https://anaconda.org/bsteubing/activity-browser-dev/files

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
