### PR TITLE
Fixed threading issue in Biosphere patcher

### DIFF
--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -524,7 +524,7 @@ class DefaultBiosphereDialog(QtWidgets.QProgressDialog):
         self.biosphere_thread.start()
 
         # finally, check if patches are available for this version and apply them
-        self.biosphere_thread.finished.connect(self.check_patches)
+        #self.biosphere_thread.finished.connect(self.check_patches)
 
     @Slot(int, str, name='updateThread')
     def update_progress(self, current: int, text: str) -> None:
@@ -534,6 +534,7 @@ class DefaultBiosphereDialog(QtWidgets.QProgressDialog):
     def finished(self, result: int = None) -> None:
         self.biosphere_thread.exit(result or 0)
         self.setValue(3)
+        self.check_patches()
         signals.change_project.emit(bw.projects.current)
         signals.project_selected.emit()
 

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -524,7 +524,7 @@ class DefaultBiosphereDialog(QtWidgets.QProgressDialog):
         self.biosphere_thread.start()
 
         # finally, check if patches are available for this version and apply them
-        self.check_patches()
+        self.biosphere_thread.finished.connect(self.check_patches)
 
     @Slot(int, str, name='updateThread')
     def update_progress(self, current: int, text: str) -> None:

--- a/tests/test_add_default_data.py
+++ b/tests/test_add_default_data.py
@@ -24,7 +24,7 @@ def test_add_default_data(qtbot, ab_app, monkeypatch):
     assert bw.projects.current == 'pytest_project'
 
     # The biosphere3 import finishes with a 'change_project' signal.
-    with qtbot.waitSignal(signals.change_project, timeout=10*60*1000):  # allow 10 mins for biosphere install
+    with qtbot.waitSignal(signals.database_changed, timeout=10*60*1000):  # allow 10 mins for biosphere install
 
         # fake the accepting of the dialog when started
         monkeypatch.setattr(EcoinventVersionDialog, 'exec_', lambda self: EcoinventVersionDialog.Accepted)

--- a/tests/test_add_default_data.py
+++ b/tests/test_add_default_data.py
@@ -24,7 +24,7 @@ def test_add_default_data(qtbot, ab_app, monkeypatch):
     assert bw.projects.current == 'pytest_project'
 
     # The biosphere3 import finishes with a 'change_project' signal.
-    with qtbot.waitSignal(signals.database_changed, timeout=10*60*1000):  # allow 10 mins for biosphere install
+    with qtbot.waitSignal(signals.change_project, timeout=10*60*1000):  # allow 10 mins for biosphere install
 
         # fake the accepting of the dialog when started
         monkeypatch.setattr(EcoinventVersionDialog, 'exec_', lambda self: EcoinventVersionDialog.Accepted)
@@ -34,6 +34,10 @@ def test_add_default_data(qtbot, ab_app, monkeypatch):
             project_tab.databases_widget.add_default_data_button,
             QtCore.Qt.LeftButton
         )
+
+    # The biosphere3 update finishes with a 'database_changed' signal.
+    with qtbot.waitSignal(signals.database_changed, timeout=2 * 60 * 1000):  # allow 2 mins for biosphere update
+        pass
 
     # biosphere was installed
     assert 'biosphere3' in bw.databases


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->
This PR fixes an issue where patches are being applied while the biosphere is still being installed, causing the patches to fail and the final biosphere DB to be unpatched.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
