### PR TITLE
Wizard actually destroyed, any threads safely exited

### DIFF
--- a/activity_browser/bwutils/importers.py
+++ b/activity_browser/bwutils/importers.py
@@ -81,7 +81,7 @@ class ABExcelImporter(ExcelImporter):
             obj.project_parameters, obj.database_parameters,
             any("parameters" in ds for ds in obj.data)
         ])
-        obj.apply_strategies()
+        obj.apply_strategies(verbose=False)
         if any(obj.unlinked) and relink:
             for db, new_db in relink.items():
                 if db == "(name missing)":

--- a/activity_browser/ui/wizards/db_import_wizard.py
+++ b/activity_browser/ui/wizards/db_import_wizard.py
@@ -54,6 +54,8 @@ class DatabaseImportWizard(QtWidgets.QWizard):
         self.setWindowTitle("Database Import Wizard")
         self.setWindowModality(QtCore.Qt.ApplicationModal)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setWindowFlags(QtCore.Qt.Sheet)
+        self.setOption(self.NoCancelButton, False)
 
         # Construct and bind pages.
         self.import_type_page = ImportTypePage(self)

--- a/activity_browser/ui/wizards/db_import_wizard.py
+++ b/activity_browser/ui/wizards/db_import_wizard.py
@@ -53,6 +53,7 @@ class DatabaseImportWizard(QtWidgets.QWizard):
         self.downloader = ABEcoinventDownloader()
         self.setWindowTitle("Database Import Wizard")
         self.setWindowModality(QtCore.Qt.ApplicationModal)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         # Construct and bind pages.
         self.import_type_page = ImportTypePage(self)
@@ -85,10 +86,6 @@ class DatabaseImportWizard(QtWidgets.QWizard):
         # db import is done when finish button becomes active
         self.button(QtWidgets.QWizard.FinishButton).clicked.connect(self.cleanup)
 
-        # thread management
-        self.button(QtWidgets.QWizard.CancelButton).clicked.connect(self.cancel_thread)
-        self.button(QtWidgets.QWizard.CancelButton).clicked.connect(self.cancel_extraction)
-
         import_signals.connection_problem.connect(self.show_info)
         import_signals.import_failure.connect(self.show_info)
         import_signals.import_failure_detailed.connect(self.show_detailed)
@@ -104,20 +101,54 @@ class DatabaseImportWizard(QtWidgets.QWizard):
     def update_downloader(self):
         self.downloader.version = self.version
         self.downloader.system_model = self.system_model
+    
+    def done(self, result: int):
+        """
+        Reimplementation of the QWizard.done method which is called when the wizard is done
+        or when the user cancels.
+        """
+        # indicate to the user that the click was succesful
+        self.button(QtWidgets.QWizard.CancelButton).setDisabled(True)
+
+        # cancel any running tasks
+        self.cancel_extraction()
+        self.cancel_thread()
+
+        # else just call done on super()
+        super().done(result)
 
     def closeEvent(self, event):
         """ Close event now behaves similarly to cancel, because of self.reject.
 
         This allows the import wizard to be reused, ie starts from the beginning
         """
-        self.cancel_thread()
         self.cancel_extraction()
+        self.cancel_thread()
         event.accept()
 
     def cancel_thread(self):
-        log.info('\nDatabase import interrupted!')
-        import_signals.cancel_sentinel = True
-        self.cleanup()
+        """Cancels the worker thread initiated by the import page"""
+        thread = self.import_page.main_worker_thread
+        dispatcher = self.thread().eventDispatcher()
+
+        # show the user we're working on something within the wizard
+        self.setCursor(QtCore.Qt.WaitCursor)
+
+        if thread.isRunning():
+            # flag an abort through the sentinel
+            import_signals.cancel_sentinel = True
+            # make sure the import page doesn't receive any last signals by the thread
+            import_signals.disconnect(self.import_page)
+            # signal the thread to exit when it can do so safely
+            thread.exit(1)
+
+        # block while the thread is still running
+        while thread.isRunning():
+            # make sure we stay responsive
+            dispatcher.processEvents(QtCore.QEventLoop.AllEvents)
+        
+        # return to normal
+        self.setCursor(QtCore.Qt.ArrowCursor)
 
     def cancel_extraction(self):
         process = getattr(self.downloader, "extraction_process", None)


### PR DESCRIPTION
The database import wizard was not properly deleted at first, leading to multiple wizard instances reacting to signals, causing mayhem. The wizard is now properly closed, and threads are safely finished.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.
- [x] Check-out on Linux because of #44
  - test: 
    - Linux working
    - Linux not 2 wizards open at 1 time

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
