### PR TITLE
Similar activities excel import fix

### DIFF
--- a/activity_browser/bwutils/strategies.py
+++ b/activity_browser/bwutils/strategies.py
@@ -21,6 +21,8 @@ log = ABHandler.setup_with_logger(logger, __name__)
 TECHNOSPHERE_TYPES = {"technosphere", "substitution", "production"}
 BIOSPHERE_TYPES = {"economic", "emission", "natural resource", "social"}
 
+RELINK_FIELDS = ("name", "database", "categories", "unit", "reference product", "location")
+
 
 def relink_exchanges_dbs(data: Collection, relink: dict) -> Collection:
     """Use this to relink exchanges during an actual import."""
@@ -62,7 +64,7 @@ def _relink_exchanges(data: list, other: str) -> list:
     act = other.random()
     is_technosphere = act.get("type", "process") == "process"
     kind = TECHNOSPHERE_TYPES if is_technosphere else BIOSPHERE_TYPES
-    return link_iterable_by_fields(data, other=other, kind=kind)
+    return link_iterable_by_fields(data, other=other, kind=kind, fields=RELINK_FIELDS, relink=True)
 
 
 def relink_exchanges_bw2package(data: dict, relink: dict) -> dict:


### PR DESCRIPTION
Solves a bug where the excel importer wrongly links activities when their name and other fields were not unique across databases. In this fix the database is also used as a comparing field during relinking, which fixes this problem.

- fixes #1081 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
