### PR TITLE
Resolve issue with heatmap color scaling with negative results

### DIFF
--- a/activity_browser/ui/figures.py
+++ b/activity_browser/ui/figures.py
@@ -5,7 +5,6 @@ import brightway2 as bw
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
-import matplotlib.ticker as mtick
 import numpy as np
 import pandas as pd
 from PySide2 import QtWidgets

--- a/activity_browser/ui/figures.py
+++ b/activity_browser/ui/figures.py
@@ -5,6 +5,7 @@ import brightway2 as bw
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
+import matplotlib.ticker as mtick
 import numpy as np
 import pandas as pd
 from PySide2 import QtWidgets
@@ -126,7 +127,7 @@ class LCAResultsPlot(Plot):
         # avoid figures getting too large horizontally
         dfp.index = [wrap_text(i, max_length=40) for i in dfp.index]
         dfp.columns = [wrap_text(i, max_length=20) for i in dfp.columns]
-        prop = dfp.divide(dfp.max(axis=0)).multiply(100)
+        prop = dfp.divide(dfp.abs().max(axis=0)).multiply(100)
         dfp.replace(np.nan, 0, inplace=True)
         if invert_plot:
             dfp = dfp.T
@@ -135,7 +136,8 @@ class LCAResultsPlot(Plot):
         sns.heatmap(
             prop, ax=self.ax, cmap="Blues", annot=dfp, linewidths=0.05,
             annot_kws={"size": 11 if dfp.shape[1] <= 8 else 9,
-                       "rotation": 0 if dfp.shape[1] <= 8 else 60}
+                       "rotation": 0 if dfp.shape[1] <= 8 else 60},
+            cbar_kws={'format': '%.0f%%'}
         )
         self.ax.tick_params(labelsize=8)
         if dfp.shape[1] > 5:

--- a/activity_browser/ui/figures.py
+++ b/activity_browser/ui/figures.py
@@ -132,8 +132,14 @@ class LCAResultsPlot(Plot):
             dfp = dfp.T
             prop = prop.T
 
+        # set different color palette depending on whether all values are positive or not
+        if dfp.min(axis=None) < 0 and dfp.max(axis=None) > 0:  # has both negative AND positive values
+            sns.color_palette("vlag_r", as_cmap=True)
+        else:  # has only positive OR negative values
+            sns.color_palette("Blues", as_cmap=True)
+
         sns.heatmap(
-            prop, ax=self.ax, cmap="Blues", annot=dfp, linewidths=0.05,
+            prop, ax=self.ax, annot=dfp, linewidths=0.05,
             annot_kws={"size": 11 if dfp.shape[1] <= 8 else 9,
                        "rotation": 0 if dfp.shape[1] <= 8 else 60},
             cbar_kws={'format': '%.0f%%'}


### PR DESCRIPTION
- Resolve #1210 
- Was due to scaling being based on `max`, while it should have been based on the `max` of the `absolute` values.

Previous:
![image](https://github.com/LCA-ActivityBrowser/activity-browser/assets/34626062/8a0364c4-4b66-4822-b2ff-ba4d06442808)

Current:
![image](https://github.com/LCA-ActivityBrowser/activity-browser/assets/34626062/d9a5847e-c162-422b-91aa-a730e2f22a13)

And when positive and negative results are present:
![image](https://github.com/LCA-ActivityBrowser/activity-browser/assets/34626062/6aaffc50-358e-43c0-9414-5c2e679c96aa)



<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
