### PR TITLE
Always close thread-specific SQLite connections

### DIFF
--- a/.github/workflows/install-canary.yaml
+++ b/.github/workflows/install-canary.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/activity_browser/ui/threading.py
+++ b/activity_browser/ui/threading.py
@@ -4,9 +4,25 @@ import brightway2 as bw
 
 class ABThread(QThread):
 
-    def exit(self, retcode: int = ...) -> None:
-        # cleaning up the DB connections in this thread
+    def run(self):
+        """Reimplemented from QThread to close any database connections before finishing."""
+        # call run_safely and finish by closing the connections
+        try:
+            self.run_safely()
+            self.close_connections()
+        # also close the connections if any exception occurs
+        except Exception as e:
+            self.close_connections()
+            raise e
+
+    def close_connections(self):
+        """
+        Closes all connections for this thread
+        todo: move to an appropriate controller
+        """
         for _, SubstitutableDatabase in bw.config.sqlite3_databases:
             if not SubstitutableDatabase.db.is_closed():
                 SubstitutableDatabase.db.close()
-        return super().exit(retcode)
+
+    def run_safely(self):
+        raise NotImplementedError

--- a/activity_browser/ui/threading.py
+++ b/activity_browser/ui/threading.py
@@ -1,0 +1,12 @@
+from PySide2.QtCore import QThread
+import brightway2 as bw
+
+
+class ABThread(QThread):
+
+    def exit(self, retcode: int = ...) -> None:
+        # cleaning up the DB connections in this thread
+        for _, SubstitutableDatabase in bw.config.sqlite3_databases:
+            if not SubstitutableDatabase.db.is_closed():
+                SubstitutableDatabase.db.close()
+        return super().exit(retcode)

--- a/activity_browser/ui/widgets/biosphere_update.py
+++ b/activity_browser/ui/widgets/biosphere_update.py
@@ -52,7 +52,7 @@ class UpdateBiosphereThread(ABThread):
 
         self.total_patches = len(self.PATCHES)
 
-    def run(self):
+    def run_safely(self):
         try:
             for i, patch in enumerate(self.PATCHES):
                 self.progress.emit(i)

--- a/activity_browser/ui/widgets/biosphere_update.py
+++ b/activity_browser/ui/widgets/biosphere_update.py
@@ -61,3 +61,6 @@ class UpdateBiosphereThread(QtCore.QThread):
         except ValidityError as e:
             log.error(f'Could not patch biosphere: {str(e)}')
             self.exit(1)
+        for _, db in bw.config.sqlite3_databases:
+            if not db._database.is_closed():
+                db._database.close()

--- a/activity_browser/ui/widgets/biosphere_update.py
+++ b/activity_browser/ui/widgets/biosphere_update.py
@@ -8,6 +8,7 @@ from ...signals import signals
 
 import logging
 from activity_browser.logger import ABHandler
+from ..threading import ABThread
 
 logger = logging.getLogger('ab_logs')
 log = ABHandler.setup_with_logger(logger, __name__)
@@ -40,7 +41,7 @@ class BiosphereUpdater(QtWidgets.QProgressDialog):
         self.setValue(current)
 
 
-class UpdateBiosphereThread(QtCore.QThread):
+class UpdateBiosphereThread(ABThread):
     PATCHES = [patch for patch in dir(data) if patch.startswith('add_ecoinvent') and patch.endswith('biosphere_flows')]
     progress = Signal(int)
     def __init__(self, ei_versions, parent=None):
@@ -61,6 +62,3 @@ class UpdateBiosphereThread(QtCore.QThread):
         except ValidityError as e:
             log.error(f'Could not patch biosphere: {str(e)}')
             self.exit(1)
-        for _, db in bw.config.sqlite3_databases:
-            if not db._database.is_closed():
-                db._database.close()

--- a/activity_browser/ui/widgets/database_copy.py
+++ b/activity_browser/ui/widgets/database_copy.py
@@ -3,6 +3,7 @@ import brightway2 as bw
 from PySide2 import QtCore, QtWidgets
 
 from ...signals import signals
+from ..threading import ABThread
 
 
 class CopyDatabaseDialog(QtWidgets.QProgressDialog):
@@ -36,7 +37,7 @@ class CopyDatabaseDialog(QtWidgets.QProgressDialog):
         signals.databases_changed.emit()
 
 
-class CopyDatabaseThread(QtCore.QThread):
+class CopyDatabaseThread(ABThread):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.copy_from = None
@@ -46,5 +47,5 @@ class CopyDatabaseThread(QtCore.QThread):
         self.copy_from = copy_from
         self.copy_to = copy_to
 
-    def run(self):
+    def run_safely(self):
         bw.Database(self.copy_from).copy(self.copy_to)

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -4,11 +4,12 @@ from typing import List, Tuple
 
 import brightway2 as bw
 from PySide2 import QtGui, QtWidgets
-from PySide2.QtCore import QRegExp, QThread, Qt, Signal, Slot
+from PySide2.QtCore import Qt, Signal, Slot
 
 from activity_browser.bwutils.superstructure import get_sheet_names
 from activity_browser.settings import project_settings
 from activity_browser.signals import signals
+from ..threading import ABThread
 from ..style import style_group_box, vertical_line
 from ...ui.icons import qicons
 from ...ui.widgets import BiosphereUpdater
@@ -549,7 +550,7 @@ class DefaultBiosphereDialog(QtWidgets.QProgressDialog):
         dialog.show()
 
 
-class DefaultBiosphereThread(QThread):
+class DefaultBiosphereThread(ABThread):
     update = Signal(int, str)
 
     def __init__(self, version, parent=None):
@@ -568,10 +569,6 @@ class DefaultBiosphereThread(QThread):
         if not len(bw.migrations):
             self.update.emit(2, "Creating core data migrations for {}".format(project))
             bw.create_core_migrations()
-        # cleaning up the DB connections in this thread
-        for _, db in bw.config.sqlite3_databases:
-            if not db._database.is_closed():
-                db._database.close()
 
 
 class FilterManagerDialog(QtWidgets.QDialog):

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -557,7 +557,7 @@ class DefaultBiosphereThread(ABThread):
         super().__init__(parent=parent)
         self.version = version
 
-    def run(self):
+    def run_safely(self):
         project = "<b>{}</b>".format(bw.projects.current)
         if "biosphere3" not in bw.databases:
             self.update.emit(0, "Creating default biosphere for {}".format(project))

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -568,6 +568,10 @@ class DefaultBiosphereThread(QThread):
         if not len(bw.migrations):
             self.update.emit(2, "Creating core data migrations for {}".format(project))
             bw.create_core_migrations()
+        # cleaning up the DB connections in this thread
+        for _, db in bw.config.sqlite3_databases:
+            if not db._database.is_closed():
+                db._database.close()
 
 
 class FilterManagerDialog(QtWidgets.QDialog):

--- a/activity_browser/ui/wizards/db_import_wizard.py
+++ b/activity_browser/ui/wizards/db_import_wizard.py
@@ -730,7 +730,7 @@ class MainWorkerThread(ABThread):
         self.use_local = use_local
         self.relink = relink or {}
 
-    def run(self):
+    def run_safely(self):
         # Set the cancel sentinal to false whenever the thread (re-)starts
         import_signals.cancel_sentinel = False
         if self.use_forwast:

--- a/activity_browser/ui/wizards/db_import_wizard.py
+++ b/activity_browser/ui/wizards/db_import_wizard.py
@@ -912,6 +912,12 @@ class MainWorkerThread(QtCore.QThread):
             del bw.databases[self.db_name]
             log.info(f'Database {self.db_name} deleted!')
 
+    def exit(self, retcode: int = ...) -> None:
+        # cleaning up the DB connections in this thread
+        for _, db in bw.config.sqlite3_databases:
+            if not db._database.is_closed():
+                db._database.close()
+        return super().exit(retcode)
 
 class EcoinventLoginPage(QtWidgets.QWizardPage):
     def __init__(self, parent=None):

--- a/activity_browser/ui/wizards/db_import_wizard.py
+++ b/activity_browser/ui/wizards/db_import_wizard.py
@@ -16,6 +16,7 @@ from bw2data.backends import SQLiteBackend
 from PySide2 import QtWidgets, QtCore
 from PySide2.QtCore import Signal, Slot
 
+from ..threading import ABThread
 from ...bwutils.errors import ImportCanceledError, LinkingFailed
 from ...bwutils.importers import ABExcelImporter, ABPackage
 from ...signals import signals
@@ -707,7 +708,7 @@ class ImportPage(QtWidgets.QWizardPage):
         return
 
 
-class MainWorkerThread(QtCore.QThread):
+class MainWorkerThread(ABThread):
     def __init__(self, downloader, parent=None):
         super().__init__(parent)
         self.downloader = downloader
@@ -912,12 +913,6 @@ class MainWorkerThread(QtCore.QThread):
             del bw.databases[self.db_name]
             log.info(f'Database {self.db_name} deleted!')
 
-    def exit(self, retcode: int = ...) -> None:
-        # cleaning up the DB connections in this thread
-        for _, db in bw.config.sqlite3_databases:
-            if not db._database.is_closed():
-                db._database.close()
-        return super().exit(retcode)
 
 class EcoinventLoginPage(QtWidgets.QWizardPage):
     def __init__(self, parent=None):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,20 +24,20 @@ requirements:
     - python
     - setuptools
   run:
-    - python >=3.8,<=3.11,!=3.10
+    - python >=3.8,<3.12
     - arrow
     - brightway2 =2.4.4
-    - pyperclip
     - eidl >=2.0.1
+    - libxml2 <=2.10.4
     - networkx
+    - numpy >=1.23.5
+    - pandas <=2.1.4
+    - pint <=0.21
+    - pyperclip
     - pyside2 >=5.15.5
     - qt-webengine
-    - numpy >=1.23.5
     - salib >=1.4
     - seaborn
-    - libxml2 <=2.10.4
-    - pint <=0.21
-    - pandas <=2.1.4
 
 about:
   home: https://github.com/LCA-ActivityBrowser/activity-browser


### PR DESCRIPTION
Fixes an issue where thread-specific SQLite database connections persisted even after said thread was finished, resulting in undeletable projects and segmentation faults. Now, by using `run_safely()` instead of `run()` within a reimplemented ABThread, all connections are closed after a thread finishes work.

Probably interesting to you @haasad , as this relates to #1124 and enables us to use Python 3.10 as well.

- [x] Update the CopyDatabaseThread as well

- closes #1078 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
