### PR TITLE
Fix AB crash after two calculations

### DIFF
--- a/activity_browser/ui/web/base.py
+++ b/activity_browser/ui/web/base.py
@@ -36,9 +36,9 @@ class BaseNavigatorWidget(QtWidgets.QWidget):
 
         # Setup JS / Qt interactions
         self.bridge = Bridge(self)
-        self.channel = QtWebChannel.QWebChannel()
+        self.channel = QtWebChannel.QWebChannel(self)
         self.channel.registerObject('bridge', self.bridge)
-        self.view = QtWebEngineWidgets.QWebEngineView()
+        self.view = QtWebEngineWidgets.QWebEngineView(self)
         self.view.loadFinished.connect(self.load_finished_handler)
         self.view.setContextMenuPolicy(Qt.PreventContextMenu)
         self.view.page().setWebChannel(self.channel)


### PR DESCRIPTION
Fixes an issue where the AB crashes after you've done two LCA calculations and then start another QThread. By supplying parents to `QtWebEngine` objects the issue is fixed, probably because they are now properly cleaned up after their parent widget has been closed.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
