### PR TITLE
Install correct version of biosphere when choosing most recent

### DIFF
--- a/activity_browser/bwutils/ecoinvent_biosphere_versions/ecospold2biosphereimporter.py
+++ b/activity_browser/bwutils/ecoinvent_biosphere_versions/ecospold2biosphereimporter.py
@@ -20,10 +20,12 @@ def create_default_biosphere3(version) -> None:
     # format version number to only Major/Minor
     version = version[:3]
 
-    if version == sort_semantic_versions(__ei_versions__)[0]:
+    if version == sort_semantic_versions(__ei_versions__)[0][:3]:
+        log.debug(f'Installing biosphere version >{version}<')
         # most recent version
         eb = Ecospold2BiosphereImporter()
     else:
+        log.debug(f'Installing legacy biosphere version >{version}<')
         # not most recent version, import legacy biosphere from AB
         eb = ABEcospold2BiosphereImporter(version=version)
     eb.apply_strategies()

--- a/activity_browser/bwutils/ecoinvent_biosphere_versions/ecospold2biosphereimporter.py
+++ b/activity_browser/bwutils/ecoinvent_biosphere_versions/ecospold2biosphereimporter.py
@@ -15,6 +15,7 @@ from activity_browser.logger import ABHandler
 logger = logging.getLogger('ab_logs')
 log = ABHandler.setup_with_logger(logger, __name__)
 
+
 def create_default_biosphere3(version) -> None:
     """Reimplementation of bw.create_default_biosphere3 to allow import from older biosphere versions."""
     # format version number to only Major/Minor

--- a/activity_browser/controllers/database.py
+++ b/activity_browser/controllers/database.py
@@ -85,9 +85,9 @@ class DatabaseController(QObject):
         # warn user of consequences of updating
         warn_dialog = QtWidgets.QMessageBox.question(
             self.window, "Update biosphere3?",
-            'Newer versions of the biosphere database may not\n'
-            'always be compatible with older ecoinvent versions.\n'
-            '\nUpdating the biosphere3 database cannot be undone!\n',
+            'Newer versions of the biosphere database may not'
+            'always be compatible with older ecoinvent versions.'
+            '\nUpdating the biosphere3 database cannot be undone!',
             QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Abort,
             QtWidgets.QMessageBox.Abort
         )


### PR DESCRIPTION
Beryllium issue we were notified of over email

There are multiple problems:
- AB would not properly take the correct version user selected and would instead use an older version and apply patches to the newest version
- bw2io has patches, but does apparently not properly update the naming of an unknown amount of flows between unknown versions. The flow from which we found the problem is `berillium`, which is now called `beryllium II` in biosphere 3.9. The patches do not update these flownames properly when used. There is an unknown amount of flows that will have similar problems. 

It is likely all installs of ecoinvent 3.9 since AB version 2.9.3 have this problem. I don't know why these versions will have installed, as AB usually notifies the user that ecoinvent could not be installed if biosphere flows are unmatched.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
