### PR TITLE
Fix production flows from parameter scenario's

### DIFF
--- a/activity_browser/bwutils/manager.py
+++ b/activity_browser/bwutils/manager.py
@@ -183,7 +183,7 @@ class ParameterManager(object):
         https://presamples.readthedocs.io/en/latest/index.html"""
         result = np.zeros(len(self.indices), dtype=object)
         for i, idx in enumerate(self.indices):
-            result[i] = (idx.input, idx.output, idx.input.database_type)
+            result[i] = (idx.input, idx.output, idx.flow_type)
         return result
 
     def arrays_from_scenarios(self, scenarios) -> (np.ndarray, np.ndarray):


### PR DESCRIPTION
Parameter scenario's were giving unexpected results because all the flows that were being extracted from them were labeled as 'Technosphere'-types even though they could also be 'Production'-types. This lead to erroneous outcomes whenever the output flow of an activity has a formula.

- fixes #1231

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
