### PR TITLE
Fixed scenario excel import for numbered scenarios

### DIFF
--- a/activity_browser/bwutils/superstructure/excel.py
+++ b/activity_browser/bwutils/superstructure/excel.py
@@ -52,7 +52,7 @@ def get_header_index(document_path: Union[str, Path], import_sheet: int):
 
 def valid_cols(name: str) -> bool:
     """Callable which evaluates if a specific column should be used."""
-    return False if name.startswith("#") else True
+    return False if str(name).startswith("#") else True
 
 def import_from_excel(document_path: Union[str, Path], import_sheet: int = 1) -> pd.DataFrame:
     """Import all of the exchanges and their scenario amounts from a given


### PR DESCRIPTION
Fixes a bug where AB throws an error when importing an excel scenario file that contains scenarios that are called numbers. This only fails for .xlsx imports, not .csv imports.

![image](https://github.com/LCA-ActivityBrowser/activity-browser/assets/103424764/a0d67e39-075f-467a-b787-4192ec7a5ff9)


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
