### PR TITLE
Fixed EF & Process contribution tables not switching scenarios

### DIFF
--- a/activity_browser/bwutils/multilca.py
+++ b/activity_browser/bwutils/multilca.py
@@ -592,7 +592,7 @@ class Contributions(object):
         return data.take(index, axis=axis)
 
     def get_contributions(self, contribution, functional_unit=None,
-                          method=None) -> np.ndarray:
+                          method=None, **kwargs) -> np.ndarray:
         """Return a contribution matrix given the type and fu / method."""
         if all([functional_unit, method]) or not any([functional_unit, method]):
             raise ValueError(
@@ -703,7 +703,7 @@ class Contributions(object):
         Annotated top-contribution dataframe
 
         """
-        contributions = self.get_contributions(self.EF, functional_unit, method)
+        contributions = self.get_contributions(self.EF, functional_unit, method, **kwargs)
 
         x_fields = self._contribution_rows(self.EF, aggregator)
         index, y_fields = self._contribution_index_cols(
@@ -746,7 +746,7 @@ class Contributions(object):
         Annotated top-contribution dataframe
 
         """
-        contributions = self.get_contributions(self.ACT, functional_unit, method)
+        contributions = self.get_contributions(self.ACT, functional_unit, method, **kwargs)
 
         x_fields = self._contribution_rows(self.ACT, aggregator)
         index, y_fields = self._contribution_index_cols(

--- a/activity_browser/bwutils/superstructure/mlca.py
+++ b/activity_browser/bwutils/superstructure/mlca.py
@@ -286,7 +286,7 @@ class SuperstructureContributions(Contributions):
         return data[fu_index, m_index, :]
 
     def get_contributions(self, contribution, functional_unit=None,
-                          method=None) -> np.ndarray:
+                          method=None, scenario=0) -> np.ndarray:
         """Return a contribution matrix given the type and fu / method
 
         Allow for both fu and method to exist.
@@ -305,6 +305,7 @@ class SuperstructureContributions(Contributions):
                 dataset[contribution], self.mlca.func_key_dict[functional_unit],
                 self.mlca.method_index[method]
             )
+        self.mlca.current = scenario
         return super().get_contributions(contribution, functional_unit, method)
 
     def _contribution_index_cols(self, **kwargs) -> (dict, Optional[Iterable]):

--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -873,24 +873,35 @@ class ContributionTab(NewAnalysisTab):
         combobox objects to be read out (which comparison, drop-down indexes,
         etc.) and fed into update calls.
         """
-        if self.combobox_menu.agg.currentText() != 'none':
-            compare_fields = {"aggregator": self.combobox_menu.agg.currentText()}
-        else:
-            compare_fields = {"aggregator": None}
+        # gather the combobox values
+        method = self.parent.method_dict[self.combobox_menu.method.currentText()]
+        functional_unit = self.combobox_menu.func.currentText()
+        scenario = self.combobox_menu.scenario.currentIndex()
+        aggregator = self.combobox_menu.agg.currentText()
+
+        # catch uninitiated scenario combobox
+        if scenario < 0: scenario = 0
+        # set aggregator to None if unwanted
+        if aggregator == 'none': aggregator = None
+
+        # initiate dict with the field we want to compare
+        compare_fields = {"aggregator": aggregator}
 
         # Determine which comparison is active and update the comparison.
         if self.switches.currentIndex() == self.switches.indexes.func:
             compare_fields.update({
-                "method": self.parent.method_dict[self.combobox_menu.method.currentText()],
+                "method": method,
+                "scenario": scenario
             })
         elif self.switches.currentIndex() == self.switches.indexes.method:
             compare_fields.update({
-                "functional_unit": self.combobox_menu.func.currentText(),
+                "functional_unit": functional_unit,
+                "scenario": scenario
             })
         elif self.switches.currentIndex() == self.switches.indexes.scenario:
             compare_fields.update({
-                "method": self.parent.method_dict[self.combobox_menu.method.currentText()],
-                "functional_unit": self.combobox_menu.func.currentText(),
+                "method": method,
+                "functional_unit": functional_unit,
             })
 
         # Determine the unit for the figure, update the filenames and the
@@ -906,6 +917,7 @@ class ContributionTab(NewAnalysisTab):
         self.combobox_menu.method.currentIndexChanged.connect(self.update_tab)
         self.combobox_menu.func.currentIndexChanged.connect(self.update_tab)
         self.combobox_menu.agg.currentIndexChanged.connect(self.update_tab)
+        self.combobox_menu.scenario.currentIndexChanged.connect(self.update_tab)
 
     def update_tab(self):
         """Update the tab."""

--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -880,9 +880,11 @@ class ContributionTab(NewAnalysisTab):
         aggregator = self.combobox_menu.agg.currentText()
 
         # catch uninitiated scenario combobox
-        if scenario < 0: scenario = 0
+        if scenario < 0:
+            scenario = 0
         # set aggregator to None if unwanted
-        if aggregator == 'none': aggregator = None
+        if aggregator == 'none':
+            aggregator = None
 
         # initiate dict with the field we want to compare
         compare_fields = {"aggregator": aggregator}


### PR DESCRIPTION
Fixes a bug where the EF Contributions and Process contributions result tabs do not update their tables and graphs when selecting another scenario. This PR fixes this by passing the scenario index as kwarg when updating the table.

## Demo
![contribution-tables-fix](https://github.com/LCA-ActivityBrowser/activity-browser/assets/103424764/65a01fd3-adca-44be-bbfe-dbd56ae1083e)
## Checklist


<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
