### PR TITLE
Manage exchange names between activities

### DIFF
--- a/activity_browser/controllers/activity.py
+++ b/activity_browser/controllers/activity.py
@@ -471,6 +471,21 @@ class ExchangeController(QObject):
     @staticmethod
     @Slot(object, str, object, name="editExchange")
     def modify_exchange(exchange: ExchangeProxyBase, field: str, value) -> None:
+        """
+        Modify or edit an exchange field.
+
+        Note that if a field does not exist, this function will create the field.
+
+        Parameters
+        ----------
+        exchange: the exchange
+        field: the name of the field
+        value: the new value
+
+        Returns
+        -------
+
+        """
         # The formula field needs special handling.
         if field == "formula":
             if field in exchange and (value == "" or value is None):

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -242,7 +242,7 @@ class TechnosphereExchangeModel(BaseExchangeModel):
         try:
             act = exchange.input
             row.update({
-                "Product": exchange.get("name") or act.get("name"),
+                "Product": exchange.get("name") or act.get("reference product") or act.get("name"),
                 "Activity": act.get("name"),
                 "Location": act.get("location", "Unknown"),
                 "Database": act.get("database"),

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -242,7 +242,7 @@ class TechnosphereExchangeModel(BaseExchangeModel):
         try:
             act = exchange.input
             row.update({
-                "Product": act.get("reference product") or act.get("name"),
+                "Product": exchange.get("name") or act.get("name"),
                 "Activity": act.get("name"),
                 "Location": act.get("location", "Unknown"),
                 "Database": act.get("database"),

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -285,7 +285,7 @@ class BiosphereExchangeModel(BaseExchangeModel):
         try:
             act = exchange.input
             row.update({
-                "Flow Name": act.get("name"),
+                "Flow Name": exchange.get("name") or act.get("name"),
                 "Compartments": " - ".join(act.get('categories', [])),
                 "Database": act.get("database"),
                 "Uncertainty": exchange.get("uncertainty type", 0),
@@ -318,7 +318,7 @@ class DownstreamExchangeModel(BaseExchangeModel):
         row = super().create_row(exchange)
         act = exchange.output
         row.update({
-            "Product": act.get("reference product") or act.get("name"),
+            "Product": exchange.get("name") or act.get("reference product") or act.get("name"),
             "Activity": act.get("name"),
             "Location": act.get("location", "Unknown"),
             "Database": act.get("database"),


### PR DESCRIPTION
Additional TODO:
- [ ] Write all fields:
  - 'name': 'market for water, completely softened', 
  - 'product': 'water, completely softened', 
  - 'unit': 'kilogram', 
  - 'location': 'RoW', 
  - 'categories': None, 
  - 'type': 'technosphere', 
  - 'amount': 0.0, 
  - 'input': ('ei39-remind-SSP2', '4c816450-1179-48fa-a590-ad295d60451c'), 
  - 'output': ('ei39-remind-SSP2', '48591ed0-5887-4bcc-b1d4-af14dde5aa47')
- [ ] Make sure all database imports in AB write exchanges properly


As discussed in #1242, AB give names to exchanges when they are created. Storing names in exchanges would be beneficial for:
- Interoperability with [lca_algebraic](https://github.com/oie-mines-paristech/lca_algebraic/)
- Multifunctionality when implemented in the future, as exchanges will have the name of their product, which will help identify which MF product is used in an exchange

Storing these names costs us virtually nothing in code complexity or time when in use.

This PR does:
- Writes source product name on exchange creation
- Updates exchange name when source product name is edited
- In the Exchanges tables in activity details, reads the product from the exchange instead of from the source activity, with appropriate fallbacks in case it doesn't exist yet
- Resolve #1242

Additional notes:
- I tested this with an activity that has downstream consumers (so is the source of an exchange)
  - I then edited the source product name, and the name is added to the exchange, even though it did not exist. This will not be a source of potential errors. I added this info into the docstring.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
