### PR TITLE
CS Controller updates all calculation setups when a database is deleted

### DIFF
--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -85,6 +85,7 @@ class CSActivityModel(CSGenericModel):
         signals.calculation_setup_selected.connect(self.sync)
         signals.databases_changed.connect(self.sync)
         signals.database_changed.connect(self.check_activities)
+        signals.delete_database_confirmed.connect(self.check_activities)
         # after editing the model, signal that the calculation setup has changed.
         self.dataChanged.connect(lambda: signals.calculation_setup_changed.emit())
 


### PR DESCRIPTION
When a database and their activities are deleted, calculation setups should reflect this by removing any affected functional units. This does already happen automatically (?) for removing individual flows. With this PR this also happens for database deletions by connecting the CS Controller to the `delete_database_confirmed` signal.

- Closes #1238 
Though without @marc-vdm 's information suggestions. I suggest adding them later after the controller rework. 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
