### PR TITLE
Fixed breaking bug in ABAction buttons

### DIFF
--- a/activity_browser/actions/base.py
+++ b/activity_browser/actions/base.py
@@ -35,7 +35,7 @@ class ABAction:
             cls.icon,
             cls.text
         )
-        button.clicked.connect(lambda x: cls.run(*args, **kwargs))
+        button.clicked.connect(lambda x: cls.triggered(*args, **kwargs))
         return button
 
 


### PR DESCRIPTION
The get_QButton method of ABActions did not run correctly on button activation as the getter method was not called properly, but passed through instead. This broke the buttons in at least the calculation setup tab, but probably also in other places.

- Fixes #1331 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
