### PR TITLE
Disable collapsible panels in activity details

### DIFF
--- a/activity_browser/layouts/tabs/activity.py
+++ b/activity_browser/layouts/tabs/activity.py
@@ -167,6 +167,7 @@ class ActivityTab(QtWidgets.QWidget):
             self.group_splitter.addWidget(group)
         if state := ab_settings.settings.get("activity_table_layout", None):
             self.group_splitter.restoreState(bytearray.fromhex(state))
+        self.group_splitter.setChildrenCollapsible(False)
 
         # Full layout
         layout = QtWidgets.QVBoxLayout()


### PR DESCRIPTION
It was possible for exchange tables in the activity details tab to collapse, meaning they would become totally hidden/invisible. Normally this could be fixed by the user reloading the tab in some way or another, but since the last update the state of the tables is saved, meaning they will stay hidden. This PR disables the collapsible table functionality, as it is covered by the check-box functionality anyways.

- Closes #1328 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
