### PR TITLE
Added health checks to `ABSettings`

### DIFF
--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -72,6 +72,25 @@ class ABSettings(BaseSettings):
 
         super().__init__(ab_dir.user_data_dir, filename)
 
+        if not self.healthy():
+            log.warn("Settings health check failed, resetting")
+            self.restore_default_settings()
+
+    def healthy(self) -> bool:
+        """
+        Checks the settings file to see if it is healthy. Returns True if all checks pass, otherwise returns False.
+        """
+        healthy = True
+
+        # check for write access to the current bw dir
+        healthy = healthy and os.access(self.settings.get("current_bw_dir"), os.W_OK)
+
+        # check for write access to the custom bw dirs
+        access = [os.access(path, os.W_OK) for path in self.settings.get("custom_bw_dirs")]
+        healthy = healthy and False not in access
+
+        return healthy
+
     @staticmethod
     def update_old_settings(directory: str, filename: str) -> None:
         """Recycling code to enable backward compatibility: This function is only required for compatibility


### PR DESCRIPTION
Added general health checks to the `ABSettings`, which will reset the settings when the health is compromised.

Specifically right now the settings get reset when there is no write access to the project folders, but the functionality can be extended in the future to encompass more checks.

- Closes #1286 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
