### PR TITLE
Added Open Impact Category to Calculation Setup screen

### DIFF
--- a/activity_browser/actions/__init__.py
+++ b/activity_browser/actions/__init__.py
@@ -30,6 +30,7 @@ from .exchange.exchange_copy_sdf import ExchangeCopySDF
 
 from .method.method_duplicate import MethodDuplicate
 from .method.method_delete import MethodDelete
+from .method.method_open import MethodOpen
 
 from .method.cf_uncertainty_modify import CFUncertaintyModify
 from .method.cf_amount_modify import CFAmountModify

--- a/activity_browser/actions/method/method_open.py
+++ b/activity_browser/actions/method/method_open.py
@@ -1,0 +1,26 @@
+from typing import List
+
+from PySide2 import QtWidgets, QtCore
+
+from activity_browser import signals
+from activity_browser.actions.base import ABAction, exception_dialogs
+from activity_browser.ui.icons import qicons
+
+
+class MethodOpen(ABAction):
+    """
+    ABAction to open one or more supplied methods in a method tab by employing signals.
+
+    TODO: move away from using signals like this. Probably add a method to the MainWindow to add a panel instead.
+    """
+
+    icon = qicons.right
+    text = "Open Impact Category"
+
+    @staticmethod
+    @exception_dialogs
+    def run(method_names: List[tuple]):
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
+        for method_name in method_names:
+            signals.method_selected.emit(method_name)
+        QtWidgets.QApplication.restoreOverrideCursor()

--- a/activity_browser/ui/tables/LCA_setup.py
+++ b/activity_browser/ui/tables/LCA_setup.py
@@ -1,7 +1,7 @@
 from PySide2 import QtWidgets
 from PySide2.QtCore import Qt, Slot
 
-from activity_browser import log, signals
+from activity_browser import log, signals, actions
 from activity_browser.mod.bw2data import calculation_setups
 
 from ..icons import qicons
@@ -174,6 +174,8 @@ class CSMethodsTable(CSGenericTable):
             "Hold CTRL and click to select multiple rows to open or delete them."
         )
 
+        self.open_method_action = actions.MethodOpen.get_QAction(self.selected_methods)
+
     def to_python(self):
         return self.model.methods
 
@@ -195,11 +197,14 @@ class CSMethodsTable(CSGenericTable):
         if self.indexAt(event.pos()).row() == -1:
             return
         menu = QtWidgets.QMenu()
+
+        menu.addAction(self.open_method_action)
         menu.addAction(
             qicons.delete,
-            "Remove row",
+            "Remove rows",
             lambda: self.model.delete_rows(self.selectedIndexes()),
         )
+
         menu.exec_(event.globalPos())
 
     def dragEnterEvent(self, event):
@@ -224,6 +229,9 @@ class CSMethodsTable(CSGenericTable):
                 and from_index != to_index
             ):
                 self.model.relocateRow(from_index, to_index)
+
+    def selected_methods(self):
+        return [self.model.get_method(p) for p in self.selectedIndexes() if p.column() == 0]
 
 
 class ScenarioImportTable(ABDataFrameView):

--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterable, List, Union
 
 import numpy as np
 import pandas as pd
@@ -191,6 +191,13 @@ class CSMethodsModel(CSGenericModel):
             if self._dataframe is None
             else self._dataframe.loc[:, "method"].to_list()
         )
+
+    def get_method(self, proxy: Union[QModelIndex, int]) -> tuple:
+        """
+        Return the method coupled to a model index
+        """
+        idx = self.proxy_to_source(proxy)
+        return self._dataframe["method"][idx.row()]
 
     def load(self, cs_name: str = None) -> None:
         """


### PR DESCRIPTION
Added ABAction to open method(s) and added the option to open methods directly from the calculation setup screen.

- Closes #1208 

![Animation](https://github.com/user-attachments/assets/8dcf2e1f-70ff-41d6-9528-6a0ce0b0ddd8)

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
