### PR TITLE
Added warning dialogue to ActivityDelete action

### DIFF
--- a/activity_browser/actions/activity/activity_delete.py
+++ b/activity_browser/actions/activity/activity_delete.py
@@ -27,6 +27,19 @@ class ActivityDelete(ABAction):
         # retrieve activity objects from the controller using the provided keys
         activities = [bd.get_activity(key) for key in activity_keys]
 
+        # alert the user
+        choice = QtWidgets.QMessageBox.warning(
+            application.main_window,
+            "Deleting activity/activities",
+            f"Are you certain you want to delete {len(activities)} activity/activities?",
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+            QtWidgets.QMessageBox.No,
+        )
+
+        # return if the user cancels
+        if choice == QtWidgets.QMessageBox.No:
+            return
+
         # check for downstream processes
         if any(len(act.upstream()) > 0 for act in activities):
             # warning text

--- a/activity_browser/actions/activity/activity_delete.py
+++ b/activity_browser/actions/activity/activity_delete.py
@@ -27,11 +27,21 @@ class ActivityDelete(ABAction):
         # retrieve activity objects from the controller using the provided keys
         activities = [bd.get_activity(key) for key in activity_keys]
 
+        warning_text = f"Are you certain you want to delete {len(activities)} activity/activities?"
+
+        # check for downstream processes
+        if any(len(act.upstream()) > 0 for act in activities):
+            # warning text
+            warning_text += (
+                "\n\nOne or more activities have downstream processes. Deleting these activities will remove the "
+                "exchange from the downstream processes as well."
+            )
+
         # alert the user
         choice = QtWidgets.QMessageBox.warning(
             application.main_window,
             "Deleting activity/activities",
-            f"Are you certain you want to delete {len(activities)} activity/activities?",
+            warning_text,
             QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
             QtWidgets.QMessageBox.No,
         )
@@ -40,27 +50,7 @@ class ActivityDelete(ABAction):
         if choice == QtWidgets.QMessageBox.No:
             return
 
-        # check for downstream processes
-        if any(len(act.upstream()) > 0 for act in activities):
-            # warning text
-            text = (
-                "One or more activities have downstream processes. Deleting these activities will remove the "
-                "exchange from the downstream processes, this can't be undone.\n\nAre you sure you want to "
-                "continue?"
-            )
 
-            # alert the user
-            choice = QtWidgets.QMessageBox.warning(
-                application.main_window,
-                "Activity/Activities has/have downstream processes",
-                text,
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-                QtWidgets.QMessageBox.No,
-            )
-
-            # return if the user cancels
-            if choice == QtWidgets.QMessageBox.No:
-                return
 
         # use the activity controller to delete multiple activities
         for act in activities:


### PR DESCRIPTION
The ActivityDelete action now asks for a confirmation from the user.

- Closes #1207 


![Animation](https://github.com/user-attachments/assets/a44edb3d-9839-41e2-a655-dae91531b763)

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
