### PR TITLE
Make the dependent biosphere database visible in the CF table

### DIFF
--- a/activity_browser/ui/tables/impact_categories.py
+++ b/activity_browser/ui/tables/impact_categories.py
@@ -255,17 +255,17 @@ class MethodCharacterizationFactorsTable(ABFilterableDataFrameView):
         super().__init__(parent)
         self.model = MethodCharacterizationFactorsModel(parent=self)
         self.setVisible(False)
-        self.setItemDelegateForColumn(2, FloatDelegate(self))
-        self.setItemDelegateForColumn(4, UncertaintyDelegate(self))
-        self.setItemDelegateForColumn(6, FloatDelegate(self))
+        self.setItemDelegateForColumn(3, FloatDelegate(self))
+        self.setItemDelegateForColumn(5, UncertaintyDelegate(self))
         self.setItemDelegateForColumn(7, FloatDelegate(self))
         self.setItemDelegateForColumn(8, FloatDelegate(self))
         self.setItemDelegateForColumn(9, FloatDelegate(self))
         self.setItemDelegateForColumn(10, FloatDelegate(self))
+        self.setItemDelegateForColumn(11, FloatDelegate(self))
 
         self.model.updated.connect(self.update_proxy_model)
         self.model.updated.connect(self.set_filter_data)
-        self.model.updated.connect(lambda: self.setColumnHidden(5, True))
+        self.model.updated.connect(lambda: self.setColumnHidden(6, True))
 
         self.read_only = True
         self.setAcceptDrops(not self.read_only)

--- a/activity_browser/ui/tables/models/impact_categories.py
+++ b/activity_browser/ui/tables/models/impact_categories.py
@@ -295,8 +295,8 @@ class MethodsTreeModel(BaseTreeModel):
 
 
 class MethodCharacterizationFactorsModel(EditablePandasModel):
-    COLUMNS = ["name", "categories", "amount", "unit"]
-    HEADERS = ["Name", "Category", "Amount", "Unit", "Uncertainty"] + ["cf"]
+    COLUMNS = ["name", "categories", "database", "amount", "unit"]
+    HEADERS = ["Name", "Category", "Database", "Amount", "Unit", "Uncertainty"] + ["cf"]
     UNCERTAINTY = ["loc", "scale", "shape", "minimum", "maximum"]
 
     def __init__(self, parent=None):


### PR DESCRIPTION
Because the biosphere3 database isn't necessarily the only elementary flow database anymore, it is necessary to show what database the characterization factor in the CF table is from. This PR enables that functionality.

![image](https://github.com/user-attachments/assets/19e2df50-9015-4f65-a480-2a6dc5f1d92b)


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
