### PR TITLE
Better plugin logging

### DIFF
--- a/activity_browser/controllers/plugin.py
+++ b/activity_browser/controllers/plugin.py
@@ -16,27 +16,30 @@ class PluginController(QObject):
         self.connect_signals()
         # Shortcut to ab_settings plugins list
         self.plugins = ab_settings.plugins
-        self.load_plugins()
+        self.import_plugins()
 
     def connect_signals(self):
         bd.projects.current_changed.connect(self.reload_plugins)
-        signals.plugin_selected.connect(self.add_plugin)
+        signals.plugin_selected.connect(self.load_plugin)
 
-    def load_plugins(self):
+    def import_plugins(self):
+        """Import plugins from python environment."""
         names = self.discover_plugins()
         for name in names:
-            plugin = self.load_plugin(name)
+            plugin = self.import_plugin(name)
             if plugin:
                self.plugins[name] = plugin
 
     def discover_plugins(self):
+        """Discover available plugins in python environment."""
         plugins = []
         for module in iter_modules():
             if module.name.startswith("ab_plugin"):
                 plugins.append(module.name)
         return plugins
 
-    def load_plugin(self, name):
+    def import_plugin(self, name):
+        """Import plugin from python environment."""
         try:
             log.info("Importing plugin {}".format(name))
             plugin_lib = importlib.import_module(name)
@@ -48,14 +51,15 @@ class PluginController(QObject):
                       f"\n{e}")
             return None
 
-    def add_plugin(self, name, select: bool = True):
-        """add or reload tabs of the given plugin"""
+    def load_plugin(self, name, select: bool = True):
+        """Load or unload the Plugin, depending on select."""
         if select:
+            # load the plugin
             plugin = self.plugins[name]
             try:
                 plugin.load()
             except Exception as e:
-                log.warning(f"Loading of plugin '{name}' failed. "
+                log.error(f"Loading of plugin '{name}' failed. "
                             "If this keeps happening contact the plugin developers and let them know of this error:"
                             f"\n{e}")
                 return
@@ -68,11 +72,12 @@ class PluginController(QObject):
             log.info(f"Loaded tab '{name}'")
             return
 
+        # not select, remove the plugin
         log.info(f"Removing plugin '{name}'")
-        # Apply plugin remove() function
-        self.plugins[name].remove()
-        # Close plugin tabs
-        self.close_plugin_tabs(self.plugins[name])
+
+        self.close_plugin_tabs(self.plugins[name])  # close tabs in AB
+        self.plugins[name].close()  # call close of the plugin
+        self.plugins[name].remove()  # call remove of the plugin
 
     def close_plugin_tabs(self, plugin):
         for panel in (
@@ -82,19 +87,20 @@ class PluginController(QObject):
             panel.close_tab_by_tab_name(plugin.infos["name"])
 
     def reload_plugins(self):
-        """close all plugins tabs then import all plugins tabs"""
+        """close all plugins then reload all plugins."""
         plugins_list = [name for name in self.plugins.keys()]  # copy plugins list
         for name in plugins_list:
-            self.close_plugin_tabs(self.plugins[name])
+            self.close_plugin_tabs(self.plugins[name])  # close tabs in AB
+            self.plugins[name].close()  # call close of the plugin
         for name in project_settings.get_plugins_list():
             if name in self.plugins:
-                self.add_plugin(name)
+                self.load_plugin(name)
             else:
                 log.warning(f"Reloading of plugin '{name}' was skipped due to a previous error. "
                             "To reload this plugin, restart Activity Browser")
 
     def close(self):
-        """close all plugins"""
+        """Close all plugins, called when AB closes."""
         for plugin in self.plugins.values():
             plugin.close()
 

--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -204,8 +204,11 @@ class ProjectSettings(BaseSettings):
             self.write_settings()
 
     def connect_signals(self):
-        """Reload the project settings whenever a project switch occurs."""
+
+        # Reload the project settings whenever a project switch occurs.
         bd.projects.current_changed.connect(self.reset_for_project_selection)
+
+        # save new plugin for this project
         signals.plugin_selected.connect(self.add_plugin)
 
     @classmethod


### PR DESCRIPTION
AB now better communicates what is going on when loading plugins

\+ refactor of `load` to `import` (as we imported from the python env with this function) and `add` to `load` (as we called the `plugin.load()` function in the plugin)

\+ More consistent closing and removing of plugins when needed
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
