### PR TITLE
Fixed broken database delete signalling

### DIFF
--- a/activity_browser/mod/bw2data/backends/base.py
+++ b/activity_browser/mod/bw2data/backends/base.py
@@ -33,13 +33,13 @@ class SQLiteBackend(SQLiteBackend):
     def delete(self, *args, **kwargs) -> None:
         # get all affected activities and exchanges that have QUpdater counterparts (i.e. have signals attached to them)
         acts = [
-            (Activity(ActivityDataset.get_by_id(qact.id)), qact)
+            (Activity(ActivityDataset.get_by_id(qact["id"])), qact)
             for qact in qactivity_list
             if qact["database"] == self.name
         ]
 
         excs = [
-            (Exchange(ExchangeDataset.get_by_id(qexc.id)), qexc)
+            (Exchange(ExchangeDataset.get_by_id(qexc["id"])), qexc)
             for qexc in qexchange_list
             if qexc["input_database"] == self.name
             or qexc["output_database"] == self.name


### PR DESCRIPTION
Broken database delete signalling causes databases not to be deleted from the SQL-database, only from the metadata.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
