### PR TITLE
Fix Impact Category list view actions

### DIFF
--- a/activity_browser/ui/tables/impact_categories.py
+++ b/activity_browser/ui/tables/impact_categories.py
@@ -46,9 +46,9 @@ class MethodsTable(ABFilterableDataFrameView):
         self.model.updated.connect(self.update_proxy_model)
         methods.metadata_changed.connect(self.sync)
 
-    def selected_methods(self) -> Iterable:
-        """Returns a generator which yields the 'method' for each row."""
-        return (self.model.get_method(p) for p in self.selectedIndexes())
+    def selected_methods(self) -> list:
+        """Returns a list of all the currently selected methods."""
+        return [self.model.get_method(p) for p in self.selectedIndexes()]
 
     @Slot(name="syncTable")
     def sync(self, query=None) -> None:


### PR DESCRIPTION
This PR fixes an issue where context menu actions in the Impact Category List view failed because they were triggered with a generator instead of the expected list object.

- Closes #1361 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
