### PR TITLE
Added export to .csv button to LCA results tabs

### DIFF
--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -176,7 +176,23 @@ class LCAResultsSubTab(QTabWidget):
                 self.tabs.sankey.new_sankey()
 
     @QtCore.Slot(name="lciaScenarioExport")
-    def generate_lcia_scenario_export(self):
+    def generate_lcia_scenario_csv(self):
+        """Create a dataframe of the impact category results for all reference flows,
+        impact categories and scenarios, then call the 'export to csv'
+        """
+        df = self.mlca.lca_scores_to_dataframe()
+        filepath, _ = QFileDialog.getSaveFileName(
+            parent=self,
+            caption="Choose location to save lca results",
+            filter="Comma Separated Values (*.csv);; All Files (*.*)",
+        )
+        if filepath:
+            if not filepath.endswith(".csv"):
+                filepath += ".csv"
+            df.to_csv(filepath)
+
+    @QtCore.Slot(name="lciaScenarioExport")
+    def generate_lcia_scenario_excel(self):
         """Create a dataframe of the impact category results for all reference flows,
         impact categories and scenarios, then call the 'export to excel'
         """
@@ -727,13 +743,23 @@ class LCAScoresTab(NewAnalysisTab):
             # Then add the additional label and export btn, plus new stretch.
             exp_layout = QHBoxLayout()
             exp_layout.addWidget(QLabel("Export all data"))
-            btn = QPushButton("Excel")
-            btn.setToolTip(
+
+            csv_btn = QPushButton(".csv")
+            csv_btn.setToolTip(
                 "Include all reference flows, impact categories and scenarios"
             )
             if self.parent:
-                btn.clicked.connect(self.parent.generate_lcia_scenario_export)
-            exp_layout.addWidget(btn)
+                csv_btn.clicked.connect(self.parent.generate_lcia_scenario_csv)
+
+            excel_btn = QPushButton("Excel")
+            excel_btn.setToolTip(
+                "Include all reference flows, impact categories and scenarios"
+            )
+            if self.parent:
+                excel_btn.clicked.connect(self.parent.generate_lcia_scenario_excel)
+
+            exp_layout.addWidget(csv_btn)
+            exp_layout.addWidget(excel_btn)
             layout.addWidget(vertical_line())
             layout.addLayout(exp_layout)
             layout.addSpacerItem(stretch)
@@ -793,13 +819,23 @@ class LCIAResultsTab(NewAnalysisTab):
             # Then add the additional label and export btn, plus new stretch.
             exp_layout = QHBoxLayout()
             exp_layout.addWidget(QLabel("Export all data"))
-            btn = QPushButton("Excel")
-            btn.setToolTip(
+
+            csv_btn = QPushButton(".csv")
+            csv_btn.setToolTip(
                 "Include all reference flows, impact categories and scenarios"
             )
             if self.parent:
-                btn.clicked.connect(self.parent.generate_lcia_scenario_export)
-            exp_layout.addWidget(btn)
+                csv_btn.clicked.connect(self.parent.generate_lcia_scenario_csv)
+
+            excel_btn = QPushButton("Excel")
+            excel_btn.setToolTip(
+                "Include all reference flows, impact categories and scenarios"
+            )
+            if self.parent:
+                excel_btn.clicked.connect(self.parent.generate_lcia_scenario_excel)
+
+            exp_layout.addWidget(csv_btn)
+            exp_layout.addWidget(excel_btn)
             layout.addWidget(vertical_line())
             layout.addLayout(exp_layout)
             layout.addSpacerItem(stretch)


### PR DESCRIPTION
In addition to the export to Excel button the LCA result tabs for scenarios now also display a .csv option for exporting.

![image](https://github.com/user-attachments/assets/b26df8c8-e3ad-4301-83aa-066d5b21900a)


## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
