### PR TITLE
Methods deletion simplification and fix

### DIFF
--- a/activity_browser/actions/method/method_delete.py
+++ b/activity_browser/actions/method/method_delete.py
@@ -24,25 +24,19 @@ class MethodDelete(ABAction):
     @staticmethod
     @exception_dialogs
     def run(methods: List[tuple], level: str):
-        # this action can handle only one selected method for now
-        selected_method = methods[0]
-
         # check whether we're dealing with a leaf or node. If it's a node, select all underlying methods for deletion
-        if level is not None and level != "leaf":
-            all_methods = [
-                bd.Method(method)
-                for method in bd.methods
-                if set(selected_method).issubset(method)
-            ]
+        all_methods = [bd.Method(method) for method in methods]
+
+        if len(all_methods) == 1:
+            warning_text = f"Are you sure you want to delete this method?\n\n{methods[0]}"
         else:
-            all_methods = [bd.Method(selected_method)]
+            warning_text = f"Are you sure you want to delete {len(all_methods)} methods?"
 
         # warn the user about the pending deletion
         warning = QtWidgets.QMessageBox.warning(
             application.main_window,
             "Deleting Method",
-            f"Are you sure you want to delete this method and possible underlying "
-            f"methods?\n\n{selected_method}",
+            warning_text,
             QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
             QtWidgets.QMessageBox.No,
         )

--- a/activity_browser/actions/method/method_delete.py
+++ b/activity_browser/actions/method/method_delete.py
@@ -23,7 +23,7 @@ class MethodDelete(ABAction):
 
     @staticmethod
     @exception_dialogs
-    def run(methods: List[tuple], level: str):
+    def run(methods: List[tuple]):
         # check whether we're dealing with a leaf or node. If it's a node, select all underlying methods for deletion
         all_methods = [bd.Method(method) for method in methods]
 

--- a/activity_browser/ui/tables/impact_categories.py
+++ b/activity_browser/ui/tables/impact_categories.py
@@ -202,7 +202,7 @@ class MethodsTree(ABDictTreeView):
             filter_on = ", ".join(tree_level[1]) + ", "
 
         methods = self.model.get_methods(filter_on)
-        return methods
+        return list(methods)
 
     def tree_level(self) -> tuple:
         """Return list of (tree level, content).

--- a/activity_browser/ui/tables/impact_categories.py
+++ b/activity_browser/ui/tables/impact_categories.py
@@ -33,9 +33,7 @@ class MethodsTable(ABFilterableDataFrameView):
         self.duplicate_method_action = actions.MethodDuplicate.get_QAction(
             self.selected_methods, None
         )
-        self.delete_method_action = actions.MethodDelete.get_QAction(
-            self.selected_methods, None
-        )
+        self.delete_method_action = actions.MethodDelete.get_QAction(self.selected_methods)
 
         self.connect_signals()
 
@@ -113,9 +111,7 @@ class MethodsTree(ABDictTreeView):
         self.duplicate_method_action = actions.MethodDuplicate.get_QAction(
             self.selected_methods, self.tree_level
         )
-        self.delete_method_action = actions.MethodDelete.get_QAction(
-            self.selected_methods, self.tree_level
-        )
+        self.delete_method_action = actions.MethodDelete.get_QAction(self.selected_methods)
 
         self._connect_signals()
 

--- a/tests/actions/test_method_actions.py
+++ b/tests/actions/test_method_actions.py
@@ -116,8 +116,8 @@ def test_cf_uncertainty_remove(ab_app):
 
 def test_method_delete(ab_app, monkeypatch):
     method = ("A_methods", "methods", "method_to_delete")
-    branch = ("A_methods", "methods_to_delete")
-    branched_method = ("A_methods", "methods_to_delete", "method_to_delete")
+    dual_method_1 = ("A_methods", "methods_to_delete", "method_to_delete_one")
+    dual_method_2 = ("A_methods", "methods_to_delete", "method_to_delete_two")
 
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
@@ -127,13 +127,15 @@ def test_method_delete(ab_app, monkeypatch):
 
     assert bd.projects.current == "default"
     assert method in bd.methods
-    assert branched_method in bd.methods
+    assert dual_method_1 in bd.methods
+    assert dual_method_2 in bd.methods
 
-    actions.MethodDelete.run([method], "leaf")
-    actions.MethodDelete.run([branch], "branch")
+    actions.MethodDelete.run([method])
+    actions.MethodDelete.run([dual_method_1, dual_method_2])
 
     assert method not in bd.methods
-    assert branched_method not in bd.methods
+    assert dual_method_1 not in bd.methods
+    assert dual_method_2 not in bd.methods
 
 
 def test_method_duplicate(ab_app, monkeypatch):


### PR DESCRIPTION
Fixes a bug when multiple methods are selected for deletion. Moves away from figuring out what to do with branches or nodes in the Action. Instead delegate such tasks to the model/view.

- Fixes #1361 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
