### PR TITLE
Add cancel button to setup wizard

### DIFF
--- a/activity_browser/ui/wizards/project_setup_wizard.py
+++ b/activity_browser/ui/wizards/project_setup_wizard.py
@@ -28,6 +28,8 @@ class ProjectSetupWizard(QtWidgets.QWizard):
         self.setWizardStyle(self.ModernStyle)
         self.setOption(self.NoCancelButtonOnLastPage)
         self.setOption(self.NoBackButtonOnLastPage)
+        self.setOption(self.CancelButtonOnLeft)
+        self.setOption(self.NoCancelButton, False)
 
         # setting window options
         self.setWindowTitle("Project Setup")

--- a/activity_browser/ui/wizards/project_setup_wizard.py
+++ b/activity_browser/ui/wizards/project_setup_wizard.py
@@ -1,13 +1,8 @@
-import os
 import ecoinvent_interface as ei
-import bw2io as bi
 import requests
 from PySide2 import QtWidgets, QtCore
 
-from activity_browser import project_settings
-from activity_browser.bwutils.ecoinvent_biosphere_versions.ecospold2biosphereimporter import create_default_biosphere3
 from activity_browser.ui.threading import ABThread
-from activity_browser.mod import bw2data as bd
 from activity_browser.mod.bw2io import ab_bw2setup
 from activity_browser.mod.bw2io.ecoinvent import ab_import_ecoinvent_release
 from activity_browser.utils import sort_semantic_versions

--- a/activity_browser/ui/wizards/project_setup_wizard.py
+++ b/activity_browser/ui/wizards/project_setup_wizard.py
@@ -37,6 +37,7 @@ class ProjectSetupWizard(QtWidgets.QWizard):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.setWindowFlags(QtCore.Qt.Sheet)
         self.setWindowFlag(QtCore.Qt.WindowContextHelpButtonHint, False)
+        self.setWindowFlag(QtCore.Qt.WindowCloseButtonHint, False)
 
         # initializing and setting all pages
         self.setPage(self.choose_setup, ChooseSetupPage(self))
@@ -246,9 +247,6 @@ class InstallPage(QtWidgets.QWizardPage):
         self.setLayout(layout)
 
     def initializePage(self):
-        self.wizard().setWindowFlag(QtCore.Qt.WindowCloseButtonHint, False)
-        self.wizard().show()
-
         self.wizard().button(QtWidgets.QWizard.BackButton).hide()
 
         if self.wizard().type == "ecoinvent":

--- a/activity_browser/ui/wizards/project_setup_wizard.py
+++ b/activity_browser/ui/wizards/project_setup_wizard.py
@@ -28,7 +28,6 @@ class ProjectSetupWizard(QtWidgets.QWizard):
         self.setWizardStyle(self.ModernStyle)
         self.setOption(self.NoCancelButtonOnLastPage)
         self.setOption(self.NoBackButtonOnLastPage)
-        self.setOption(self.CancelButtonOnLeft)
         self.setOption(self.NoCancelButton, False)
 
         # setting window options


### PR DESCRIPTION
Adds cancel button to setup wizards, so MacOS users can cancel the setup wizard.

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
