### PR TITLE
Show non-found CS aspects in tables for deletion

### DIFF
--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -147,7 +147,7 @@ class CSActivityModel(CSGenericModel):
                 f"Could not load key '{key}' in Calculation Setup '{self.current_cs}'"
             )
 
-            return {"key": key, "Amount": amount, "Activity": "NOT FOUND", "Database": key[0]}
+            return {"key": key, "Amount": amount, "Activity": f"NOT FOUND: {key}", "Database": key[0]}
 
     @Slot(name="deleteRows")
     def delete_rows(self, proxies: list) -> None:
@@ -271,7 +271,7 @@ class CSMethodsModel(CSGenericModel):
                 f"Could not load key '{method_tuple}' in Calculation Setup '{self.current_cs}'"
             )
 
-            return {"Name": "NOT FOUND", "Unit": "Unknown", "# CFs": 0, "method": method_tuple}
+            return {"Name": f"NOT FOUND: {method_tuple}", "Unit": "Unknown", "# CFs": 0, "method": method_tuple}
 
     @Slot(list, name="deleteRows")
     def delete_rows(self, proxies: list) -> None:

--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -3,9 +3,10 @@ from logging import getLogger
 
 import numpy as np
 import pandas as pd
+from PySide2 import QtWidgets
 from PySide2.QtCore import QModelIndex, Qt, Slot
 
-from activity_browser import signals
+from activity_browser import signals, application
 from activity_browser.bwutils import commontasks as bc
 from activity_browser.mod import bw2data as bd
 from activity_browser.mod.bw2data.backends import ActivityDataset
@@ -124,7 +125,7 @@ class CSActivityModel(CSGenericModel):
             columns=self.HEADERS,
         )
         # Drop rows where the fu key was invalid in some way.
-        self._dataframe = df.dropna().reset_index(drop=True)
+        self._dataframe = df
         self.key_col = self._dataframe.columns.get_loc("key")
         self.updated.emit()
 
@@ -145,7 +146,8 @@ class CSActivityModel(CSGenericModel):
             log.error(
                 f"Could not load key '{key}' in Calculation Setup '{self.current_cs}'"
             )
-            return {}
+
+            return {"key": key, "Amount": amount, "Activity": "NOT FOUND", "Database": key[0]}
 
     @Slot(name="deleteRows")
     def delete_rows(self, proxies: list) -> None:
@@ -155,9 +157,12 @@ class CSActivityModel(CSGenericModel):
 
         # we can disconnect from the deleted activities
         for key in [self._dataframe.at[row, "key"] for row in rows]:
-            activity = bd.get_activity(key)
-            activity.changed.disconnect(self.sync)
-            del self._activities[activity.key]
+            try:
+                activity = bd.get_activity(key)
+                activity.changed.disconnect(self.sync)
+                del self._activities[activity.key]
+            except ActivityDataset.DoesNotExist:
+                pass
 
         self._dataframe = self._dataframe.drop(rows).reset_index(drop=True)
         self.updated.emit()
@@ -230,7 +235,6 @@ class CSMethodsModel(CSGenericModel):
         method_tuples = [
             mthd
             for mthd in bd.calculation_setups[self.current_cs].get("ia", [])
-            if mthd in bd.methods
         ]
 
         # build rows for all the collected methods and store in our dataframe
@@ -244,23 +248,30 @@ class CSMethodsModel(CSGenericModel):
         """
         Build a single row for the methods table and connect the table to the method we're building the row for.
         """
-        # gather data using the given method_tuple
-        method_metadata = bd.methods[method_tuple]
-        method = bd.Method(method_tuple)
+        try:
+            # gather data using the given method_tuple
+            method_metadata = bd.methods[method_tuple]
+            method = bd.Method(method_tuple)
 
-        # construct a row dictionary
-        row = {
-            "Name": ", ".join(method_tuple),
-            "Unit": method_metadata.get("unit", "Unknown"),
-            "# CFs": method_metadata.get("num_cfs", 0),
-            "method": method_tuple,
-        }
+            # construct a row dictionary
+            row = {
+                "Name": ", ".join(method_tuple),
+                "Unit": method_metadata.get("unit", "Unknown"),
+                "# CFs": method_metadata.get("num_cfs", 0),
+                "method": method_tuple,
+            }
 
-        # if the method changes we need to sync
-        method.changed.connect(self.sync, Qt.UniqueConnection)
-        self._methods[method.name] = method
+            # if the method changes we need to sync
+            method.changed.connect(self.sync, Qt.UniqueConnection)
+            self._methods[method.name] = method
 
-        return row
+            return row
+        except KeyError:
+            log.error(
+                f"Could not load key '{method_tuple}' in Calculation Setup '{self.current_cs}'"
+            )
+
+            return {"Name": "NOT FOUND", "Unit": "Unknown", "# CFs": 0, "method": method_tuple}
 
     @Slot(list, name="deleteRows")
     def delete_rows(self, proxies: list) -> None:
@@ -270,6 +281,9 @@ class CSMethodsModel(CSGenericModel):
 
         # we can disconnect from the deleted methods
         for method_tuple in [self._dataframe.at[row, "method"] for row in rows]:
+            if method_tuple not in bd.methods:
+                continue
+
             method = bd.Method(method_tuple)
             method.changed.disconnect(self.sync)
             del self._methods[method.name]


### PR DESCRIPTION
Activities and Methods that are deleted are not automatically deleted from calculations setups. With this PR we show these missing Activities and Methods in their respective CS tables so they can be deleted manually.

![image](https://github.com/user-attachments/assets/55e157b1-fe85-459f-b174-4cd3e7178823)


- closes #1238 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
