### PR TITLE
Fix parameter scenario import bug

### DIFF
--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -613,6 +613,10 @@ class ScenarioImportWidget(QtWidgets.QWidget):
                     log.info(
                         "Superstructure: Attempting to read as parameter scenario file."
                     )
+
+                    if not df["Group"].dtype == object:
+                        df["Group"] = df["Group"].astype(str)
+
                     include_default = True
                     if "default" not in df.columns:
                         query = QtWidgets.QMessageBox.question(


### PR DESCRIPTION
Fixes bug where parameter scenario files with only numerical group names are imported as the wrong dtype, which causes joins later in the process to fail.

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
