### PR TITLE
Better connection error handling in Project Setup Wizard

### DIFF
--- a/activity_browser/ui/wizards/project_setup_wizard.py
+++ b/activity_browser/ui/wizards/project_setup_wizard.py
@@ -148,7 +148,6 @@ class EcoInventLoginPage(QtWidgets.QWizardPage):
             release = ei.EcoinventRelease(settings)
             release.list_versions()
 
-        # logon was unsuccesful
         except requests.exceptions.HTTPError as e:
             QtWidgets.QApplication.restoreOverrideCursor()
 
@@ -160,6 +159,16 @@ class EcoInventLoginPage(QtWidgets.QWizardPage):
             else:
                 self.message.setText("Unknown connection error, try again later.")
                 raise e
+
+        except requests.exceptions.ConnectionError:
+            QtWidgets.QApplication.restoreOverrideCursor()
+            self.message.setText("Cannot connect to the internet, please try again later.")
+            return False
+
+        except Exception as e:
+            # restore cursor on all exceptions
+            QtWidgets.QApplication.restoreOverrideCursor()
+            raise e
 
         # in case of success, set the settings for permanent use
         ei.permanent_setting("username", self.username.text())


### PR DESCRIPTION
Adds better exception handling in Project Setup Wizard in two ways:

1. Special handling for `requests.exceptions.ConnectionError`
2. All exceptions will restore the cursor

- closes #1408 

@marc-vdm no fix needed for `safe_link_fetch` as there's already general exception handling in place there.

<!--
Thank you for your pull request. 
Please provide a description above and review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
