### PR TITLE
Fix activity tab name update bug

### DIFF
--- a/activity_browser/layouts/tabs/activity.py
+++ b/activity_browser/layouts/tabs/activity.py
@@ -54,7 +54,7 @@ class ActivitiesTab(ABTab):
             )
             new_tab.destroyed.connect(signals.hide_when_empty.emit)
             new_tab.objectNameChanged.connect(
-                lambda name: self.setTabText(tab_index, name)
+                lambda name: self.setTabText(self.indexOf(new_tab), name)
             )
 
         self.select_tab(self.tabs[key])


### PR DESCRIPTION
Fixes bug where the wrong activity tab name is updated when the activity tabs have been dragged around.

- closes #1411 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
