### PR TITLE
resolve faulty disable of `range` and `score` buttons

### DIFF
--- a/activity_browser/docs/wiki/LCA-Results.md
+++ b/activity_browser/docs/wiki/LCA-Results.md
@@ -150,8 +150,7 @@ For `Range`, this is the full _range_ of results, for example, if all your negat
 and all your positive results together have a score of 10, the _range_ is 12 (-2 * -1 + 10).
 For `Score`, this is the total score (sum) of the results, for example, if all your negative results together have a 
 score of -2 and all your positive results together have a score of 10, the _score_ is 8 (-2 + 10).
-The `Range` or `Score` setting are only used when 1) your Cut-off type is `Relative` 
-and 2) your results contain both positive and negative results.
+The `Range` or `Score` setting are only used when your results contain both positive and negative results.
 
 ### Positive and negative numbers in contribution results
 It can happen in LCA that you get both positive and negative numbers in your contribution results.

--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -1112,12 +1112,6 @@ class ContributionTab(NewAnalysisTab):
         QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         self.set_combobox_changes()
 
-        if self.cutoff_menu.limit_type == "percent":
-            self.total_menu.range.setEnabled(True)
-            self.total_menu.score.setEnabled(True)
-        else:
-            self.total_menu.range.setEnabled(False)
-            self.total_menu.score.setEnabled(False)
         super().update_tab()
         QApplication.restoreOverrideCursor()
 


### PR DESCRIPTION
This should not have been implemented
<!--
Thank you for your pull request. 
Please provide a description above and review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
