### PR TITLE
Hide uncertainty on CF table load

### DIFF
--- a/activity_browser/layouts/tabs/impact_categories.py
+++ b/activity_browser/layouts/tabs/impact_categories.py
@@ -39,6 +39,7 @@ class MethodCharacterizationFactorsTab(QtWidgets.QWidget):
 
         self.method = bd.Method(method_tuple)
         self.cf_table.model.load(self.method)
+        self.cf_table.hide_uncertain()
         self.cf_table.show()
         self.panel.select_tab(self)
 


### PR DESCRIPTION
Fixes bug where CF table shows uncertainty even though "Hide uncertainty columns" is checked.

- fixes #1415 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] ~~Request a review from another developer.~~ - Small and quick, will close myself
