### PR TITLE
fix wrong logic for `range` CA total

### DIFF
--- a/activity_browser/bwutils/multilca.py
+++ b/activity_browser/bwutils/multilca.py
@@ -394,20 +394,24 @@ class Contributions(object):
             ),
         }
 
-    def normalize(self, contribution_array: np.ndarray) -> np.ndarray:
-        """Normalise the contribution array.
+    def normalize(self, contribution_array: np.ndarray, total_range:bool=True) -> np.ndarray:
+        """Normalize the contribution array based on range or score
 
         Parameters
         ----------
         contribution_array : A 2-dimensional contribution array
+        total_range : A bool, True for normalization based on range, False for score
 
         Returns
         -------
         2-dimensional array of same shape, with scores normalized.
 
         """
-        scores = abs(contribution_array.sum(axis=1, keepdims=True))
-        return contribution_array / scores
+        if total_range:  # total is based on the range
+            total = abs(abs(contribution_array).sum(axis=1, keepdims=True))
+        else:  # total is based on the score
+            total = abs(contribution_array.sum(axis=1, keepdims=True))
+        return contribution_array / total
 
     def _build_dict(
         self,
@@ -850,7 +854,7 @@ class Contributions(object):
 
         # Normalise if required
         if normalize:
-            contributions = self.normalize(contributions)
+            contributions = self.normalize(contributions, total_range)
 
         top_cont_dict = self._build_dict(
             contributions, index, rev_index, limit, limit_type, total_range
@@ -906,7 +910,7 @@ class Contributions(object):
 
         # Normalise if required
         if normalize:
-            contributions = self.normalize(contributions)
+            contributions = self.normalize(contributions, total_range)
 
         top_cont_dict = self._build_dict(
             contributions, index, rev_index, limit, limit_type, total_range

--- a/activity_browser/docs/wiki/LCA-Results.md
+++ b/activity_browser/docs/wiki/LCA-Results.md
@@ -98,14 +98,16 @@ The total impact is still 1.6.
 In this section we generalize a little bit for the different contribution approaches,
 we call the _from_ part of the contributions (the EFs or activities or FT above) _entities_.
 
-There are several ways Activity Browser manipulates your results by default.
+There are several ways Activity Browser manipulates your results by default:
 - The results are **sorted** so that the row with the largest (absolute) average values are shown first.
 - A `cut-off` of 5% is applied, this only shows results that contribute at least 5% to the total range of results, 
-  all other entities are grouped into a `Rest (+)` or `Rest (-)` groups.
-- The contributions are _normalized_ to the impact of that reference flow, meaning they are show as a percentage, 
-  counting up to 100% for every item you compare.
+  all other entities are grouped into the `Rest (+)` and `Rest (-)` groups for positive and negative 
+  contributions respectively.
+- The contributions are _normalized_ to the [range of results](#range-and-score) of that reference flow, 
+  meaning contributions are shown as a percentage contribution of the range, counting up to 100%.
 
-These actions are taken to show you the most relevant results.
+These defaults exist to show you the most relevant results in most cases, but you may often want to make this more 
+specific for your analysis. 
 
 You can manually manipulate the contribution results in the menu shown below, which we will explain bit by bit 
 in the next sections.
@@ -113,11 +115,12 @@ in the next sections.
 
 #### Cut-off
 You can manually change the `Cut-off type` of the results in two ways, `Relative` or `Top #`.
-The `Relative` mode shows contributions _from_ entities of _x_% or higher.
-The `Top #` mode shows contributions from the _x_ entities that contribute the most (as absolute).
+- The `Relative` mode shows contributions _from_ entities of _x_% or higher.
+- The `Top #` mode shows contributions from the _x_ entities that contribute the most (as absolute).
+
 You can adjust the `Cut-off level` to change how many results you see.
 
-All results that don't make the cut-off will be grouped into the `Rest (+)` and `Rest (-)` groups.
+All contributions that are below the cut-off will be grouped into the `Rest (+)` and `Rest (-)` groups.
 The Rest groups are only present when there are positive or negative numbers remaining for the respective rest groups. 
 
 #### Compare
@@ -131,33 +134,37 @@ The compare mode defines what is shown in the figure.
 
 #### Aggregation
 The `Aggregate by` menu can be used to _group_ results based on field names.
-As an example, EF contributions can be grouped on the name, 
-for example to group all flows with the same name.
-Another example for process contributions can be grouped based on their reference product name.
+As an example, EF contributions can be grouped on the name to group all flows with the same name 
+(which would for example group all EFs with the name _carbon dioxide_ together).
+As another example, process contributions can be grouped based on their reference product name
+(which would for example group all processes with the product name _electricity, high voltage_ together).
 
 #### Plot and Table
 By default, Activity Browser shows a plot and a table. 
-You can disable one of them if you want to focus on one of them.
+You can disable one of them if you want to focus on the other.
 
 #### Relative and Absolute
 You can choose between `Relative` and `Absolute` results.
 The `Relative` results will sum to 100% (the total score), the `Absolute` results will sum to the impact score.
 
 #### Range and Score
-If the Cut-off type is `Relative`, you can choose between `Range` and `Score`.
-This determines what you use as the _total_ to which the relative contributions are counted. 
-For `Range`, this is the full _range_ of results, for example, if all your negative results together have a score of -2
-and all your positive results together have a score of 10, the _range_ is 12 (-2 * -1 + 10).
-For `Score`, this is the total score (sum) of the results, for example, if all your negative results together have a 
-score of -2 and all your positive results together have a score of 10, the _score_ is 8 (-2 + 10).
-The `Range` or `Score` setting are only used when your results contain both positive and negative results.
+The `Range`/`Score` determines what you use as the _total_ to which the contributions are counted. 
+- For `Range`, this is the full _range_ of results
+  - For example, if all your negative results together have a score of -2 and all your positive results together have a 
+    score of 10, the _range_ is 12 (-2 * -1 + 10).
+- For `Score`, this is the total score (sum) of the results
+  - For example, if all your negative results together have a score of -2 and all your positive results together have a 
+    score of 10, the _score_ is 8 (-2 + 10).
+
+The `Range` or `Score` setting are only relevant when your results contain both positive and negative contributions.
 
 ### Positive and negative numbers in contribution results
 It can happen in LCA that you get both positive and negative numbers in your contribution results.
-Some of these reasons could be negative characterization factors, flows with negative numbers or using substitution flows.
+Some reasons for this could be negative characterization factors, flows with negative numbers or using 
+substitution flows.
 
 When there are both positive and negative numbers in the result, Activity Browser will show a marker to indicate 
-where the total score is, and show positive and negative contributions to the impact separately.
+where the total _score_ is, and show positive and negative contributions to the impact separately.
 
 Below is a simple example (with unrealistic values) to demonstrate this:
 


### PR DESCRIPTION
Affects:
Results with `relative`, `range` results with negative contributions
- Resolves: #1429 


Results were normalized in a wrong way, representing the result wrongly.

<!--
Thank you for your pull request. 
Please provide a description above and review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
