### PR TITLE
MetaDataStore drops database when it's deleted from the project

### DIFF
--- a/activity_browser/bwutils/metadata.py
+++ b/activity_browser/bwutils/metadata.py
@@ -177,6 +177,7 @@ class MetaDataStore(object):
         removed_dbs = [db for db in self.databases if db not in bd.databases]
         for db in removed_dbs:
             self.dataframe.drop(self.dataframe[self.dataframe.database == db].index, inplace=True)
+            self.databases.remove(db)
 
     def get_existing_fields(self, field_list: list) -> list:
         """Return a list of fieldnames that exist in the current dataframe."""

--- a/activity_browser/bwutils/metadata.py
+++ b/activity_browser/bwutils/metadata.py
@@ -52,6 +52,7 @@ class MetaDataStore(object):
         self.databases = set()
 
         bd.projects.current_changed.connect(self.reset_metadata)
+        bd.databases.metadata_changed.connect(self.check_databases)
 
     def add_metadata(self, db_names_list: list) -> None:
         """Include data from the brightway databases.
@@ -171,6 +172,11 @@ class MetaDataStore(object):
         log.debug("Reset metadata.")
         self.dataframe = pd.DataFrame()
         self.databases = set()
+
+    def check_databases(self):
+        removed_dbs = [db for db in self.databases if db not in bd.databases]
+        for db in removed_dbs:
+            self.dataframe.drop(self.dataframe[self.dataframe.database == db].index, inplace=True)
 
     def get_existing_fields(self, field_list: list) -> list:
         """Return a list of fieldnames that exist in the current dataframe."""


### PR DESCRIPTION
The `MetaDataStore` will now check whether it's databases are still existing when a database is removed from the project.

- fixes #1419 


## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
