### PR TITLE
Results won't close on CS and Parameter changes anymore

### DIFF
--- a/activity_browser/layouts/tabs/LCA_results_tab.py
+++ b/activity_browser/layouts/tabs/LCA_results_tab.py
@@ -35,7 +35,6 @@ class LCAResultsTab(ABTab):
         signals.lca_calculation.connect(self.generate_setup)
         self.tabCloseRequested.connect(self.close_tab)
         bd.projects.current_changed.connect(self.close_all)
-        bd.parameters.parameters_changed.connect(self.close_all)
 
     @Slot(str, name="removeSetup")
     def remove_setup(self, name: str):

--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -164,8 +164,6 @@ class LCAResultsSubTab(QTabWidget):
         self.currentChanged.connect(self.generate_content_on_click)
         QApplication.restoreOverrideCursor()
 
-        calculation_setups.metadata_changed.connect(self.check_cs)
-
     def setup_tabs(self):
         """Have all of the tabs pull in their required data and add them."""
         self._update_tabs()
@@ -234,10 +232,6 @@ class LCAResultsSubTab(QTabWidget):
             if not filepath.endswith(".xlsx"):
                 filepath += ".xlsx"
             df.to_excel(filepath)
-
-    def check_cs(self):
-        if self.cs != calculation_setups.get(self.cs_name, None):
-            self.deleteLater()
 
 
 class NewAnalysisTab(BaseRightTab):


### PR DESCRIPTION
Results used to close when their connected calculation setup changed, or when any parameter was updated. This is changed with this PR, keeping result tabs open in these cases.

- closes #1418 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
