### PR TITLE
Fix encoding issues in logger.py

### DIFF
--- a/activity_browser/logger.py
+++ b/activity_browser/logger.py
@@ -43,7 +43,7 @@ class ABFileHandler(logging.Handler):
         log_file_location = self.filepath
 
         # create the logfile and write the headers
-        with open(self.filepath, "a") as log_file:
+        with open(self.filepath, "a", encoding='utf-8') as log_file:
             log_file.write(";".join(self.headers) + "\n")
 
     def emit(self, record: logging.LogRecord):
@@ -52,7 +52,7 @@ class ABFileHandler(logging.Handler):
         message = self.format(record)
 
         # append to the logfile
-        with open(self.filepath, "a") as log_file:
+        with open(self.filepath, "a", encoding='utf-8') as log_file:
             log_file.write(message)
 
             # if there's exception info, write the exception traceback to the file as well
@@ -136,7 +136,7 @@ class ABPycharmHandler(logging.Handler):
         message = self.format_log(record)
 
         # append to the logfile
-        with open(self.filepath, "a") as log_file:
+        with open(self.filepath, "a", encoding='utf-8') as log_file:
             log_file.write(message)
 
             # if there's exception info, write the exception traceback to the file as well


### PR DESCRIPTION
Make the logger use utf-8 encoding to solve issues linked to incompatible character sets.
Solves issues like `UnicodeEncodeError: 'charmap' codec can't encode character '\u0441' in position 186: character maps to <undefined>` for international users.

## Checklist

- [X] Keep pull requests small so they can be easily reviewed.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

---

No issue was open on the topic but this PR solves the following issue : 

``` python
Traceback (most recent call last):
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tab.py", line 60, in generate_setup
    new_tab = LCAResultsSubTab(data, self)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tabs.py", line 143, in __init__
    ef=ElementaryFlowContributionTab(self),
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tabs.py", line 1196, in __init__
    self.toggle_comparisons(self.switches.indexes.func)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tabs.py", line 1058, in toggle_comparisons
    self.update_tab()
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tabs.py", line 1133, in update_tab
    super().update_tab()
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tabs.py", line 388, in update_tab
    self.update_plot()
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tabs.py", line 1155, in update_plot
    super().update_plot(self.df, unit=self.unit)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\layouts\tabs\LCA_results_tabs.py", line 400, in update_plot
    self.plot.plot(*args, **kwargs)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\ui\figures.py", line 270, in plot
    self.canvas.draw()
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\backends\backend_agg.py", line 382, in draw
    self.figure.draw(self.renderer)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\artist.py", line 94, in draw_wrapper
    result = draw(artist, renderer, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\artist.py", line 71, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\figure.py", line 3257, in draw
    mimage._draw_list_compositing_images(
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\image.py", line 134, in _draw_list_compositing_images
    a.draw(renderer)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\artist.py", line 71, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\axes\_base.py", line 3210, in draw
    mimage._draw_list_compositing_images(
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\image.py", line 134, in _draw_list_compositing_images
    a.draw(renderer)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\artist.py", line 71, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\axis.py", line 1405, in draw
    tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\axis.py", line 1332, in _get_ticklabel_bboxes
    return ([tick.label1.get_window_extent(renderer)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\axis.py", line 1332, in <listcomp>
    return ([tick.label1.get_window_extent(renderer)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\text.py", line 969, in get_window_extent
    bbox, info, descent = self._get_layout(self._renderer)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\text.py", line 373, in _get_layout
    _, lp_h, lp_d = _get_text_metrics_with_cache(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\text.py", line 69, in _get_text_metrics_with_cache
    return _get_text_metrics_with_cache_impl(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\text.py", line 77, in _get_text_metrics_with_cache_impl
    return renderer_ref().get_text_width_height_descent(text, fontprop, ismath)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\backends\backend_agg.py", line 218, in get_text_width_height_descent
    font = self._prepare_font(prop)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\backends\backend_agg.py", line 252, in _prepare_font
    font = get_font(_fontManager._find_fonts_by_props(font_prop))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\font_manager.py", line 1441, in _find_fonts_by_props
    self.findfont(
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\font_manager.py", line 1352, in findfont
    ret = self._findfont_cached(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\matplotlib\font_manager.py", line 1483, in _findfont_cached
    _log.debug('findfont: score(%s) = %s', font, score)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\logging\__init__.py", line 1477, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\logging\__init__.py", line 1634, in _log
    self.handle(record)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\logging\__init__.py", line 1644, in handle
    self.callHandlers(record)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\logging\__init__.py", line 1706, in callHandlers
    hdlr.handle(record)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\logging\__init__.py", line 978, in handle
    self.emit(record)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\site-packages\activity_browser\logger.py", line 140, in emit
    log_file.write(message)
  File "\AppData\Local\miniconda3\envs\brightway\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u0441' in position 186: character maps to <undefined>
```
