### PR TITLE
Ensuring the graph explorer updates with activity modifications

### DIFF
--- a/activity_browser/layouts/panels/right.py
+++ b/activity_browser/layouts/panels/right.py
@@ -83,7 +83,10 @@ class GraphExplorerTab(ABTab):
             log.info("adding graph tab")
             new_tab = GraphNavigatorWidget(self, key=key)
             self.tabs[key] = new_tab
-            self.addTab(new_tab, get_activity_name(bd.get_activity(key), str_length=30))
+            self.addTab(new_tab, new_tab.objectName())
+
+            new_tab.objectNameChanged.connect(lambda name: self.setTabText(self.indexOf(new_tab), name))
+
         else:
             tab = self.tabs[key]
             tab.new_graph(key)

--- a/activity_browser/ui/web/navigator.py
+++ b/activity_browser/ui/web/navigator.py
@@ -275,7 +275,7 @@ class Graph(BaseGraph):
         try:
             self.nodes = [get_activity(act.key) for act in self.nodes]
             self.edges = [Edge(document=ExchangeDataset.get_by_id(exc._document.id)) for exc in self.edges]
-        except ActivityDataset.DoesNotExist:
+        except (ActivityDataset.DoesNotExist, ExchangeDataset.DoesNotExist):
             try:
                 get_activity(self.central_activity.key)  # test whether the activity still exists
                 self.new_graph(self.central_activity.key)  # if so, create a new graph


### PR DESCRIPTION
The graph explorer did not update with changes to the underlying model, i.e.: when the activity name of product name changes the explorer did not update the displayed graph or tab text. This PR fixes that by connecting to the right signals and refreshing the cached dataset nodes accordingly.

- closes #1414 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
