### PR TITLE
update activity relink to only show relevant

### DIFF
--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -422,7 +422,7 @@ class DatabaseLinkingResultsDialog(QtWidgets.QDialog):
         for act, key in unlinked_exchanges.items():
             button = QtWidgets.QPushButton(act.as_dict()["name"])
             button.clicked.connect(
-                lambda: signals.unsafe_open_activity_tab.emit(act.key)
+                lambda: signals.safe_open_activity_tab.emit(act.key)
             )
             obj.exchangesUnlinked.addWidget(button)
         obj.updateGeometry()
@@ -574,7 +574,7 @@ class ActivityLinkingResultsDialog(QtWidgets.QDialog):
         for act, key in unlinked_exchanges.items():
             button = QtWidgets.QPushButton(act.as_dict()["name"])
             button.clicked.connect(
-                lambda: signals.unsafe_open_activity_tab.emit(act.key)
+                lambda: signals.safe_open_activity_tab.emit(act.key)
             )
             obj.exchangesUnlinked.addWidget(button)
         obj.updateGeometry()


### PR DESCRIPTION
Resolves #1167
Show only relevant databases for activity relink
Uses bw2data function as previously, but provides keyword arguments to the db.dependents() function.
Also avoids error of non-existing failed variable for opening relink dialogue for activities without exchanges.Lastly, updated relink dialogue to use safe_open_activity_tab signal (unsafe open is broken)

## Checklist<!--Remove items that do not apply.For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.-->
- [X] Keep pull requests small so they can be easily reviewed.
- [X] Update the documentation- For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).- For user documentation, please update the wiki in[`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [X] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.