### PR TITLE
Parameter robustness

### DIFF
--- a/.github/conda-envs/test.yml
+++ b/.github/conda-envs/test.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - pytest
-  - pytest-qt
+  - pytest-qt =4.4.0
   - pytest-mock
   - pytest-env

--- a/activity_browser/actions/exchange/exchange_formula_remove.py
+++ b/activity_browser/actions/exchange/exchange_formula_remove.py
@@ -18,6 +18,9 @@ class ExchangeFormulaRemove(ABAction):
     @exception_dialogs
     def run(exchanges: List[Any]):
         for exchange in exchanges:
+            if "formula" not in exchange:
+                return
+
             del exchange["formula"]
             exchange.save()
 

--- a/activity_browser/actions/exchange/exchange_formula_remove.py
+++ b/activity_browser/actions/exchange/exchange_formula_remove.py
@@ -1,5 +1,7 @@
 from typing import Any, List
 
+from bw2data.parameters import ParameterizedExchange
+
 from activity_browser.actions.base import ABAction, exception_dialogs
 from activity_browser.ui.icons import qicons
 
@@ -18,3 +20,5 @@ class ExchangeFormulaRemove(ABAction):
         for exchange in exchanges:
             del exchange["formula"]
             exchange.save()
+
+            ParameterizedExchange.delete().where(ParameterizedExchange.exchange == exchange._document.id).execute()

--- a/activity_browser/actions/exchange/exchange_modify.py
+++ b/activity_browser/actions/exchange/exchange_modify.py
@@ -6,6 +6,7 @@ from activity_browser.mod.bw2data.parameters import ActivityParameter
 from activity_browser.ui.icons import qicons
 
 from ..parameter.parameter_new_automatic import ParameterNewAutomatic
+from .exchange_formula_remove import ExchangeFormulaRemove
 
 
 class ExchangeModify(ABAction):
@@ -19,6 +20,11 @@ class ExchangeModify(ABAction):
     @classmethod
     @exception_dialogs
     def run(cls, exchange: Any, data: dict):
+        # remove the formula if it is an empty string
+        if "formula" in exchange and data.get("formula") == "":
+            del data["formula"]
+            ExchangeFormulaRemove.run([exchange])
+
         for key, value in data.items():
             exchange[key] = value
 

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -61,8 +61,14 @@ class BaseExchangeModel(EditablePandasModel):
     def create_row(self, exchange) -> dict:
         """Take the given Exchange object and extract a number of attributes."""
         try:
+            # fixing a broken exchange
+            if not isinstance(exchange.get("amount"), float):
+                log.warning(f"Fixing broken exchange amount for {exchange.get('type', '')} exchange from: {exchange.input}")
+                exchange["amount"] = 1.0  # Ensure amount is a float
+                exchange.save()
+
             row = {
-                "Amount": float(exchange.get("amount", 1)),
+                "Amount": exchange.get("amount"),
                 "Unit": exchange.input.get("unit", "Unknown"),
                 "exchange": exchange,
             }

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from logging import getLogger
 
 import pandas as pd
+import numpy as np
 from asteval import Interpreter
 from bw2data.parameters import (ActivityParameter, DatabaseParameter, Group,
                                 ProjectParameter)
@@ -62,9 +63,13 @@ class BaseExchangeModel(EditablePandasModel):
         """Take the given Exchange object and extract a number of attributes."""
         try:
             # fixing a broken exchange
-            if not isinstance(exchange.get("amount"), float):
+            if not isinstance(exchange.get("amount"), float) or pd.isna(exchange.get("amount")):
                 log.warning(f"Fixing broken exchange amount for {exchange.get('type', '')} exchange from: {exchange.input}")
-                exchange["amount"] = 1.0  # Ensure amount is a float
+                try:
+                    amount = float(exchange.get("amount")) if exchange.get("amount") is not np.nan else 1.0
+                except TypeError:
+                    amount = 1.0
+                exchange["amount"] = amount
                 exchange.save()
 
             row = {


### PR DESCRIPTION
Some quickfixes to make parameter usage a bit more robust. This PR does the following

- Make sure parameterized exchanges are properly deleted from the parameter database on use of the `ExchangeFormulaRemove` action.
- Make sure formulas are removed when an empty string is provided so formula's don't evaluate to `None`
- Make the AB able to open exchanges with an amount set to `None` in order for users to be able to fix their models.

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
