### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "numpy>=1.23.5,<2",
     "pandas>=2.2.1",
     "pint<=0.21",
+    "py7zr<=1.0.0rc1",
     "pyperclip",
     "pyside6",
     "pypardiso ; platform_system == 'Windows'",


### PR DESCRIPTION
Breaking change between py7zr==1.0.0rc1 and rc3 (the most recent, installed by default).

Problem:
ecoinvent_importer.py function read_archive_to_bytes attempts "archive.read(file_list)". This attribute was removed in rc2 of py7zr.

Workaround:
pin dependency to "py7zr<=1.0.0rc1"

<!--
Thank you for your pull request. 
Please provide a description above and review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
