### PR TITLE
Change exchange amount validator to use regex

### DIFF
--- a/activity_browser/layouts/pages/activity_details/exchanges_tab.py
+++ b/activity_browser/layouts/pages/activity_details/exchanges_tab.py
@@ -277,7 +277,7 @@ class ExchangeAmountDelegate(QtWidgets.QStyledItemDelegate):
         editor = QtWidgets.QLineEdit(parent)
         locale = QtCore.QLocale(QtCore.QLocale.English)
         locale.setNumberOptions(QtCore.QLocale.RejectGroupSeparator)
-        validator = QtGui.QDoubleValidator()
+        validator = QtGui.QRegularExpressionValidator(QtCore.QRegularExpression(r"^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$"), editor)
         validator.setLocale(locale)
         editor.setValidator(validator)
         return editor


### PR DESCRIPTION
Changes the exchange amount validator to use regex. This allows copy and pasting from e.g. excel. Something the standard QDoubleValidator does not allow.

- closes #625 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
