### PR TITLE
Fix issues with project hash difference between BW Legacy and BW25

### DIFF
--- a/activity_browser/actions/project/project_delete.py
+++ b/activity_browser/actions/project/project_delete.py
@@ -1,8 +1,13 @@
+import shutil
+
 from qtpy import QtWidgets
+
+import bw2data as bd
+from bw2data.project import ProjectDataset
+from bw2data.utils import safe_filename
 
 from activity_browser import settings, application
 from activity_browser.actions.base import ABAction, exception_dialogs
-from activity_browser.mod import bw2data as bd
 from activity_browser.ui.icons import qicons
 
 
@@ -73,6 +78,18 @@ class ProjectDelete(ABAction):
         QtWidgets.QMessageBox.information(
             application.main_window, "Project(s) deleted", "Project(s) successfully deleted"
         )
+
+    @staticmethod
+    def delete_project(name: str, delete_dir: bool):
+
+        ds = ProjectDataset.get(ProjectDataset.name == name)
+
+        if delete_dir:
+            dir_path = bd.projects._base_data_dir / safe_filename(name, full=ds.full_hash)
+            assert dir_path.is_dir(), "Can't find project directory"
+            shutil.rmtree(dir_path)
+
+        ds.delete()
 
 
 class ProjectDeletionDialog(QtWidgets.QDialog):

--- a/activity_browser/actions/project/project_delete.py
+++ b/activity_browser/actions/project/project_delete.py
@@ -10,6 +10,8 @@ from activity_browser import settings, application
 from activity_browser.actions.base import ABAction, exception_dialogs
 from activity_browser.ui.icons import qicons
 
+from .project_switch import ProjectSwitch
+
 
 class ProjectDelete(ABAction):
     """
@@ -67,12 +69,10 @@ class ProjectDelete(ABAction):
 
         # try to delete the project, delete directory if user specified so
         if bd.projects.current in project_names:
-            bd.projects.set_current(settings.ab_settings.startup_project)
+            ProjectSwitch.run(settings.ab_settings.startup_project)
 
         for project in project_names:
-            bd.projects.delete_project(
-                project, delete_dialog.deletion_warning_checked()
-            )
+            ProjectDelete.delete_project(project, delete_dialog.deletion_warning_checked())
 
         # inform the user of successful deletion
         QtWidgets.QMessageBox.information(
@@ -89,7 +89,7 @@ class ProjectDelete(ABAction):
             assert dir_path.is_dir(), "Can't find project directory"
             shutil.rmtree(dir_path)
 
-        ds.delete()
+        ds.delete_instance()
 
 
 class ProjectDeletionDialog(QtWidgets.QDialog):

--- a/activity_browser/actions/project/project_export.py
+++ b/activity_browser/actions/project/project_export.py
@@ -5,8 +5,10 @@ from logging import getLogger
 
 from qtpy import QtWidgets, QtCore
 
+import bw2data as bd
+from bw2data.project import ProjectDataset
+
 from activity_browser import application
-from activity_browser.mod import bw2data as bd
 from activity_browser.actions.base import ABAction, exception_dialogs
 from activity_browser.ui.threading import ABThread
 
@@ -65,7 +67,9 @@ class ExportThread(ABThread):
     project_name: str
 
     def run_safely(self):
-        project_dir = os.path.join(bd.projects._base_data_dir, bd.utils.safe_filename(self.project_name))
+        ds = ProjectDataset.get(ProjectDataset.name == self.project_name)
+        project_folder_name = bd.utils.safe_filename(self.project_name, full=ds.full_hash)
+        project_dir = os.path.join(bd.projects._base_data_dir, project_folder_name)
 
         with open(os.path.join(project_dir, ".project-name.json"), "w") as f:
             json.dump({"name": self.project_name}, f)


### PR DESCRIPTION
Project folders have different hashes attached to them between BW legacy and BW25, this causes issues when deleting migrated projects. This PR fixes that.

- fixes #1515

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Add a milestone to the PR (and related issues, if any) for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
