### PR TITLE
Quick-fix for already extracted ecoinvent releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report for AB.
-labels: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -35,9 +35,10 @@ body:
       options:
         - Windows 10
         - Windows 11
-        - MacOS
+        - MacOS (Apple Silicon)
+        - MacOS (Intel)        
         - Linux/Other (please specify above)
-      default: 0
+      default: 1
   - type: textarea
     id: conda-env
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: File a feature request for AB.
-labels: ["feature"]
+type: Feature
 body:
   - type: markdown
     attributes:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@
 
 # Activity Browser
 
+
+> [!TIP]
+> **Activity Browser** now has an open beta for Version 3🚀.
+>
+> The beta supports many new features such as Multi-functionality and uses Brightway 2.5 under the hood.
+> Help us by making Activity Browser even better by using and providing feedback on Activity Browser.
+>
+> Learn more about the beta
+> [here](https://lca-activitybrowser.github.io/activity-browser/beta.html).
+
 <img src="https://user-images.githubusercontent.com/33026150/54299977-47a9f680-45bc-11e9-81c6-b99462f84d0b.png" width=100%/>
 
 The **Activity Browser (AB) is an open source software for Life Cycle Assessment (LCA)** that builds on [Brightway2](https://brightway.dev).

--- a/activity_browser/actions/database/database_import_from_ecoinvent.py
+++ b/activity_browser/actions/database/database_import_from_ecoinvent.py
@@ -1,4 +1,5 @@
 import re
+import os
 from logging import getLogger
 from copy import deepcopy
 
@@ -223,7 +224,7 @@ class EiWizard(widgets.ABWizard):
                     fix_version=False
                 )
                 path = str(path)
-                if not path.endswith(".7z"):
+                if not path.endswith(".7z") and os.path.exists(path + ".7z"):
                     path = path + ".7z"
                 self.download_ready.emit(path)
 

--- a/activity_browser/docs/wiki/_Footer.md
+++ b/activity_browser/docs/wiki/_Footer.md
@@ -2,3 +2,12 @@ Activity Browser is a __community project__, we rely on __you__ for it to be awe
 
 | <picture><img alt="Activity Browser logo" src="./assets/activitybrowser.png" width="25"></picture> | ❓ Need help?<br/>[💬 Ask the community](https://github.com/LCA-ActivityBrowser/activity-browser/discussions?discussions_q=) | 💡 Ideas to improve?<br/>[💭 Request a feature](https://github.com/LCA-ActivityBrowser/activity-browser/issues/new?assignees=&labels=feature&projects=&template=feature_request.yml) | 🔥 Something Broken?<br/>[🪲 Start a bug report](https://github.com/LCA-ActivityBrowser/activity-browser/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) | ⚙️ Want to help out? <br/>[🛠️ Learn how to contribute](https://github.com/LCA-ActivityBrowser/activity-browser/blob/main/CONTRIBUTING.md) |
 |----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+
+> [!TIP]
+> **Activity Browser** now has an open beta for Version 3🚀.
+>
+> The beta supports many new features such as Multi-functionality and uses Brightway 2.5 under the hood.
+> Help us by making Activity Browser even better by using and providing feedback on Activity Browser.
+>
+> Learn more about the beta
+> [here](https://lca-activitybrowser.github.io/activity-browser/beta.html).


### PR DESCRIPTION
Fixes issue where the ecoinvent importer fails when `ecoinvent_interface` has already downloaded and extracted the release before, which deletes the .7z file by default.

This is a quick fix and will need revisiting so we can move some of this logic to both `bw2io` and `ecoinvent_interface` so they support local ecoinvent files as well.

- fixes #1528 

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [x] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
