### PR TITLE
FT contributions: fix multiple exchanges from same key

### DIFF
--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -1430,7 +1430,9 @@ class FirstTierContributionsTab(ContributionTab):
 
             amounts = [exch.amount * scale for exch in technosphere if
                        exch.input.key != exch.output.key]
-            demands = {keys[i]: amounts[i] for i, _ in enumerate(keys)}
+            demands = {}
+            for key, amount in zip(keys, amounts):
+                demands[key] = demands.get(key, 0) + amount
             return demands
 
         def get_scenario_demands() -> dict:
@@ -1452,7 +1454,10 @@ class FirstTierContributionsTab(ContributionTab):
                     amounts.append(_lca.technosphere_matrix[exch_idx, demand_idx] * scale)
 
             # write al non-zero exchanges to demand dict
-            demands = {keys[i]: amounts[i] for i, _ in enumerate(keys) if amounts[i] != 0}
+            demands = {}
+            for key, amount in zip(keys, amounts):
+                if amount != 0:
+                    demands[key] = demands.get(key, 0) + amount
             return demands
 
         # reuse LCA object from original calculation to skip 1 LCA


### PR DESCRIPTION

- fix #1585

problem was with multiple exchanges from same key, where only one would be counted. Now all exchanges to/from same key are summed correctly.
<!--
Thank you for your pull request. 
Please provide a description above and review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. 
For completed items, change [ ] to [x] or you can click the checkboxes once your pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation
  - For in-code documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
  - For user documentation, please update the wiki in 
    [`./activity_browser/docs/wiki`](https://github.com/LCA-ActivityBrowser/activity-browser/tree/main/activity_browser/docs/wiki)
- [ ] Update tests.
- [x] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

#### If you have write access (otherwise a maintainer will do this for you):
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [x] Add a milestone to the PR (and related issues, if any) for the intended release.
- [x] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
