### PR TITLE
ci: derive beta package version from UTC date-time (PEP 440)

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta_report.yml
+++ b/.github/ISSUE_TEMPLATE/beta_report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: Version
       description: Please specify the version of the Activity Browser you are using.
-      placeholder: e.g. 3.0.0b940
+      placeholder: e.g. 3.0.0b202503221430 (from About / pip show)
   - type: dropdown
     id: distribution
     attributes:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,8 +71,8 @@ The Activity Browser project uses five GitHub Actions workflows to automate test
 **Purpose:** Publishes beta versions to PyPI (test and production) and Anaconda Cloud.
 
 ### Version Scheme
-- Beta version format: `3.0.0b<N>` where N is the commit count since commit `199b6c3`
-- Calculated dynamically: `git rev-list 199b6c3..HEAD --count`
+- Beta version format: `3.0.0b<YYYYMMDD><HHMM>` (UTC), e.g. `3.0.0b202503221430` = 2025-03-22 14:30 UTC
+- Set in CI: `date -u +%Y%m%d%H%M` (compact so the string is a valid [PEP 440](https://packaging.python.org/en/latest/specifications/version-specifiers/) pre-release)
 
 ### Steps
 1. Checkout with full git history (`fetch-depth: "0"`)

--- a/.github/workflows/python-package-deploy.yml
+++ b/.github/workflows/python-package-deploy.yml
@@ -20,8 +20,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: "0"
+    # PEP 440 beta: 3.0.0b + YYYYMMDDHHMM (UTC). Sortable; no hyphens (invalid in public versions).
     - name: Set version
-      run: echo "VERSION=3.0.0b$(git rev-list 199b6c3..HEAD --count)" >> $GITHUB_ENV
+      run: echo "VERSION=3.0.0b$(date -u +%Y%m%d%H%M)" >> $GITHUB_ENV
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Replace commit-count suffix after 199b6c3 with YYYYMMDDHHMM UTC so PyPI/conda beta builds are time-stamped and sortable.